### PR TITLE
Fix build tooling and complete WIP→Score rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,14 @@ export default Song({ bpm: 140, tracks: [kick, bass] })
 9. Audio scheduling always uses `audioContext.currentTime` — never `setTimeout` or `Date.now()`
 10. **All code is functional** — factory functions, `const`, arrow functions, zero classes
 
+## Git Workflow
+
+- **`main`** — production. Protected: PRs only, enforced on admins.
+- **`dev`** — development. Protected: PRs only, enforced on admins.
+- **Feature branches** — all work happens here. Branch off `dev`, PR into `dev`.
+- `dev` → `main` via PR for releases.
+- **No direct commits** to `main` or `dev` — ever.
+
 ## Current Phase
 
 **Phase 1 — Scaffold** (in progress)

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/core/tests/ScoreError.test.ts
+++ b/packages/core/tests/ScoreError.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { ScoreError } from '../src/errors/ScoreError.js'
+
+describe('ScoreError', () => {
+  it('creates an error with the correct name', () => {
+    const error = ScoreError('test message')
+    expect(error.name).toBe('ScoreError')
+    expect(error.message).toBe('test message')
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('includes context when provided', () => {
+    const error = ScoreError('bad value', { received: 42, fix: 'use a string' })
+    expect(error.context.received).toBe(42)
+    expect(error.context.fix).toBe('use a string')
+  })
+
+  it('defaults context to empty object', () => {
+    const error = ScoreError('no context')
+    expect(error.context).toEqual({})
+  })
+})

--- a/packages/dsl/vitest.config.ts
+++ b/packages/dsl/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/effects/vitest.config.ts
+++ b/packages/effects/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/midi/vitest.config.ts
+++ b/packages/midi/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/mixer/vitest.config.ts
+++ b/packages/mixer/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/sequencer/vitest.config.ts
+++ b/packages/sequencer/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     environment: 'node',
+    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       thresholds: {


### PR DESCRIPTION
## Summary
- Fixed all build tooling issues (missing `typescript-eslint`, `type: module`, CI branch triggers)
- Completed WIP→Score rename: `ScoreError` is now a factory function with typed interfaces
- Added `.prettierignore`, `pnpm-lock.yaml`, ScoreError unit tests, `passWithNoTests` for stub packages
- Documented git workflow (branch protections on `main` and `dev`) in CLAUDE.md
- All checks green: typecheck, lint, test (3 passing), prettier

## Test plan
- [x] `pnpm typecheck` — 11/11 tasks pass
- [x] `pnpm lint` — 10/10 packages pass
- [x] `pnpm test` — 3 ScoreError tests pass, 9 packages pass with no tests
- [x] `pnpm format:check` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)