### PR TITLE
Fix CI: remove pnpm version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Remove `version: 10` from pnpm/action-setup in CI workflow
- `packageManager` in package.json already specifies `pnpm@10.32.1`
- Having both causes pnpm/action-setup@v4 to error

Merge this first, then rebase/re-run CI on other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)