### PR TITLE
Refactor core to BackendProvider abstraction

### DIFF
--- a/packages/core/src/backend/index.ts
+++ b/packages/core/src/backend/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js'
+export { webAudioBackend } from './web-audio.js'

--- a/packages/core/src/backend/types.ts
+++ b/packages/core/src/backend/types.ts
@@ -1,0 +1,61 @@
+// Backend abstraction layer — allows Score to work with multiple audio engines
+// Default: Web Audio API via node-web-audio-api
+// Future: scsynth (SuperCollider), custom user-built backends
+
+export type OscillatorType = 'sine' | 'square' | 'sawtooth' | 'triangle'
+
+export type NoiseType = 'white' | 'pink' | 'brown'
+
+// --- Backend node types ---
+
+export type BackendNode = {
+  readonly connect: (dest: BackendNode) => void
+  readonly disconnect: (dest?: BackendNode) => void
+}
+
+export type BackendOscillatorNode = BackendNode & {
+  readonly start: (time?: number) => void
+  readonly stop: (time?: number) => void
+  readonly setFrequency: (value: number, time?: number) => void
+  readonly setDetune: (value: number, time?: number) => void
+}
+
+export type BackendGainNode = BackendNode & {
+  readonly gain: number
+  readonly setGain: (value: number, time?: number) => void
+}
+
+export type BackendNoiseNode = BackendNode & {
+  readonly start: (time?: number) => void
+  readonly stop: (time?: number) => void
+}
+
+// --- Backend context ---
+
+export type BackendContext = {
+  readonly currentTime: number
+  readonly sampleRate: number
+  readonly state: 'running' | 'suspended' | 'closed'
+  readonly destination: BackendNode
+  readonly createOscillator: (props?: {
+    type?: OscillatorType
+    frequency?: number
+    detune?: number
+  }) => BackendOscillatorNode
+  readonly createGain: (props?: { gain?: number }) => BackendGainNode
+  readonly createNoise: (props?: { type?: NoiseType }) => BackendNoiseNode
+  readonly suspend: () => Promise<void>
+  readonly resume: () => Promise<void>
+  readonly close: () => Promise<void>
+}
+
+// --- Backend provider ---
+
+export type BackendProvider = {
+  readonly name: string
+  readonly createContext: (options?: {
+    sampleRate?: number
+    latencyHint?: 'interactive' | 'balanced' | 'playback'
+    offline?: { length: number; numberOfChannels?: number }
+  }) => BackendContext
+}

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -1,0 +1,190 @@
+// Web Audio API backend — default BackendProvider for Score
+// Uses node-web-audio-api for Node.js, native Web Audio in browsers (Phase 13)
+
+import {
+  AudioContext,
+  OfflineAudioContext,
+} from 'node-web-audio-api'
+import type {
+  AudioNode as WebAudioNode,
+  BaseAudioContext,
+  AudioBufferSourceNode as WebBufferSourceNode,
+  GainNode as WebGainNode,
+  OscillatorNode as WebOscillatorNode,
+} from 'node-web-audio-api'
+import { ScoreError } from '../errors/ScoreError.js'
+import type {
+  BackendContext,
+  BackendGainNode,
+  BackendNode,
+  BackendNoiseNode,
+  BackendOscillatorNode,
+  BackendProvider,
+  NoiseType,
+} from './types.js'
+
+// --- Raw node access ---
+// Symbol-keyed property to retrieve the underlying Web Audio node
+// when connecting two BackendNodes together
+
+const RAW = Symbol('web-audio-raw')
+
+type WithRaw = { readonly [RAW]: WebAudioNode }
+
+const getRaw = (node: BackendNode): WebAudioNode =>
+  (node as unknown as WithRaw)[RAW]
+
+// --- Noise buffer generation (pure functions) ---
+
+const fillWhiteNoise = (data: Float32Array): void => {
+  for (let i = 0; i < data.length; i++) {
+    data[i] = Math.random() * 2 - 1
+  }
+}
+
+const fillPinkNoise = (data: Float32Array): void => {
+  let b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0, b6 = 0
+  for (let i = 0; i < data.length; i++) {
+    const white = Math.random() * 2 - 1
+    b0 = 0.99886 * b0 + white * 0.0555179
+    b1 = 0.99332 * b1 + white * 0.0750759
+    b2 = 0.969 * b2 + white * 0.153852
+    b3 = 0.8665 * b3 + white * 0.3104856
+    b4 = 0.55 * b4 + white * 0.5329522
+    b5 = -0.7616 * b5 - white * 0.016898
+    data[i] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362) * 0.11
+    b6 = white * 0.115926
+  }
+}
+
+const fillBrownNoise = (data: Float32Array): void => {
+  let lastOut = 0
+  for (let i = 0; i < data.length; i++) {
+    const white = Math.random() * 2 - 1
+    lastOut = (lastOut + white * 0.02) / 1.02
+    data[i] = lastOut * 3.5
+  }
+}
+
+const noiseFiller: Readonly<Record<NoiseType, (d: Float32Array) => void>> = {
+  white: fillWhiteNoise,
+  pink: fillPinkNoise,
+  brown: fillBrownNoise,
+}
+
+// --- Wrap a raw Web Audio node as a BackendNode ---
+
+const wrapNode = (raw: WebAudioNode): BackendNode & WithRaw => ({
+  [RAW]: raw,
+  connect: (dest: BackendNode) => {
+    raw.connect(getRaw(dest))
+  },
+  disconnect: (dest?: BackendNode) => {
+    if (dest) {
+      raw.disconnect(getRaw(dest))
+    } else {
+      raw.disconnect()
+    }
+  },
+})
+
+// --- Backend context factory ---
+
+const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
+  const destination = wrapNode(ctx.destination as unknown as WebAudioNode)
+
+  return {
+    get currentTime() { return ctx.currentTime },
+    get sampleRate() { return ctx.sampleRate },
+    get state() { return ctx.state as 'running' | 'suspended' | 'closed' },
+    destination,
+
+    createOscillator: (props) => {
+      const osc: WebOscillatorNode = ctx.createOscillator()
+      osc.type = props?.type ?? 'sine'
+      osc.frequency.value = props?.frequency ?? 440
+      osc.detune.value = props?.detune ?? 0
+      const base = wrapNode(osc as unknown as WebAudioNode)
+
+      return {
+        ...base,
+        start: (time?: number) => osc.start(time ?? ctx.currentTime),
+        stop: (time?: number) => osc.stop(time ?? ctx.currentTime),
+        setFrequency: (value: number, time?: number) =>
+          osc.frequency.setValueAtTime(value, time ?? ctx.currentTime),
+        setDetune: (value: number, time?: number) =>
+          osc.detune.setValueAtTime(value, time ?? ctx.currentTime),
+      }
+    },
+
+    createGain: (props) => {
+      const gainNode: WebGainNode = ctx.createGain()
+      gainNode.gain.value = props?.gain ?? 1.0
+      const base = wrapNode(gainNode as unknown as WebAudioNode)
+
+      return {
+        ...base,
+        get gain() { return gainNode.gain.value },
+        setGain: (value: number, time?: number) =>
+          gainNode.gain.setValueAtTime(value, time ?? ctx.currentTime),
+      }
+    },
+
+    createNoise: (props) => {
+      const noiseType = props?.type ?? 'white'
+      const bufferSize = ctx.sampleRate * 2
+      const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate)
+      noiseFiller[noiseType](buffer.getChannelData(0))
+
+      const outputGain: WebGainNode = ctx.createGain()
+      const outputBase = wrapNode(outputGain as unknown as WebAudioNode)
+      let source: WebBufferSourceNode | null = null
+
+      return {
+        ...outputBase,
+        start: (time?: number) => {
+          source = ctx.createBufferSource() as unknown as WebBufferSourceNode
+          source.buffer = buffer as unknown as AudioBuffer
+          source.loop = true
+          source.connect(outputGain as unknown as WebAudioNode)
+          source.start(time)
+        },
+        stop: (time?: number) => {
+          if (source) {
+            source.stop(time)
+            source.disconnect()
+            source = null
+          }
+        },
+      }
+    },
+
+    suspend: () => (ctx as unknown as { suspend: () => Promise<void> }).suspend(),
+    resume: () => (ctx as unknown as { resume: () => Promise<void> }).resume(),
+    close: () => (ctx as unknown as { close: () => Promise<void> }).close(),
+  }
+}
+// --- Web Audio BackendProvider ---
+
+export const webAudioBackend: BackendProvider = {
+  name: 'web-audio',
+  createContext: (options) => {
+    try {
+      if (options?.offline) {
+        const sampleRate = options.sampleRate ?? 44100
+        const ctx = new OfflineAudioContext(
+          options.offline.numberOfChannels ?? 1,
+          options.offline.length,
+          sampleRate,
+        )
+        return createBackendContext(ctx)
+      }
+      return createBackendContext(new AudioContext(options))
+    } catch (err) {
+      throw ScoreError('Failed to create AudioContext', {
+        fix: 'Ensure node-web-audio-api is installed: pnpm add node-web-audio-api',
+        received: err instanceof Error ? err.message : String(err),
+      })
+    }
+  },
+}

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -15,10 +15,7 @@ import type {
 import { ScoreError } from '../errors/ScoreError.js'
 import type {
   BackendContext,
-  BackendGainNode,
   BackendNode,
-  BackendNoiseNode,
-  BackendOscillatorNode,
   BackendProvider,
   NoiseType,
 } from './types.js'
@@ -108,12 +105,14 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
 
       return {
         ...base,
-        start: (time?: number) => osc.start(time ?? ctx.currentTime),
-        stop: (time?: number) => osc.stop(time ?? ctx.currentTime),
-        setFrequency: (value: number, time?: number) =>
-          osc.frequency.setValueAtTime(value, time ?? ctx.currentTime),
-        setDetune: (value: number, time?: number) =>
-          osc.detune.setValueAtTime(value, time ?? ctx.currentTime),
+        start: (time?: number) => { osc.start(time ?? ctx.currentTime) },
+        stop: (time?: number) => { osc.stop(time ?? ctx.currentTime) },
+        setFrequency: (value: number, time?: number) => {
+          osc.frequency.setValueAtTime(value, time ?? ctx.currentTime)
+        },
+        setDetune: (value: number, time?: number) => {
+          osc.detune.setValueAtTime(value, time ?? ctx.currentTime)
+        },
       }
     },
 
@@ -125,8 +124,9 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
       return {
         ...base,
         get gain() { return gainNode.gain.value },
-        setGain: (value: number, time?: number) =>
-          gainNode.gain.setValueAtTime(value, time ?? ctx.currentTime),
+        setGain: (value: number, time?: number) => {
+          gainNode.gain.setValueAtTime(value, time ?? ctx.currentTime)
+        },
       }
     },
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,29 +1,15 @@
-// AudioContext factory — creates a real Web Audio API context via node-web-audio-api
-// Phase 13 will add browser support with dynamic import
+// AudioContext factory — creates a BackendContext via a BackendProvider
+// Defaults to Web Audio API. Pass a custom backend for scsynth, etc.
 
-import { AudioContext, OfflineAudioContext } from 'node-web-audio-api'
-import { ScoreError } from './errors/ScoreError.js'
-import type { ScoreAudioContext } from './types.js'
+import type { BackendContext, BackendProvider } from './backend/types.js'
+import { webAudioBackend } from './backend/web-audio.js'
 
 export const createAudioContext = (options?: {
   sampleRate?: number
   latencyHint?: 'interactive' | 'balanced' | 'playback'
   offline?: { length: number; numberOfChannels?: number }
-}): ScoreAudioContext => {
-  try {
-    if (options?.offline) {
-      const sampleRate = options.sampleRate ?? 44100
-      return new OfflineAudioContext(
-        options.offline.numberOfChannels ?? 1,
-        options.offline.length,
-        sampleRate,
-      ) as unknown as ScoreAudioContext
-    }
-    return new AudioContext(options)
-  } catch (err) {
-    throw ScoreError('Failed to create AudioContext', {
-      fix: 'Ensure node-web-audio-api is installed: pnpm add node-web-audio-api',
-      received: err instanceof Error ? err.message : String(err),
-    })
-  }
+  backend?: BackendProvider
+}): BackendContext => {
+  const backend = options?.backend ?? webAudioBackend
+  return backend.createContext(options)
 }

--- a/packages/core/src/gain.ts
+++ b/packages/core/src/gain.ts
@@ -1,4 +1,5 @@
 import type { AudioComponent, ScoreAudioContext, ScoreAudioNode } from './types.js'
+import type { BackendGainNode } from './backend/types.js'
 
 export const createGain = (
   context: ScoreAudioContext,
@@ -6,18 +7,17 @@ export const createGain = (
     gain?: number
   },
 ) => {
-  const gainNode = context.createGain()
-  gainNode.gain.value = props?.gain ?? 1.0
+  const gainNode: BackendGainNode = context.createGain(props)
 
   const component: AudioComponent & {
     readonly setGain: (value: number, time?: number) => void
-    readonly node: GainNode
+    readonly gain: number
   } = {
-    node: gainNode,
-
-    setGain: (value: number, time?: number) => {
-      gainNode.gain.setValueAtTime(value, time ?? context.currentTime)
+    get gain() {
+      return gainNode.gain
     },
+
+    setGain: (value: number, time?: number) => gainNode.setGain(value, time),
 
     connect: (destination: ScoreAudioNode) => {
       gainNode.connect(destination)

--- a/packages/core/src/gain.ts
+++ b/packages/core/src/gain.ts
@@ -17,7 +17,7 @@ export const createGain = (
       return gainNode.gain
     },
 
-    setGain: (value: number, time?: number) => gainNode.setGain(value, time),
+    setGain: (value: number, time?: number) => { gainNode.setGain(value, time) },
 
     connect: (destination: ScoreAudioNode) => {
       gainNode.connect(destination)

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -1,15 +1,13 @@
-import { AudioNode } from 'node-web-audio-api'
 import { ScoreError } from './errors/ScoreError.js'
 import type { AudioGraph, ScoreAudioContext } from './types.js'
+import type { BackendNode } from './backend/types.js'
 
 export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
-  const nodes = new Map<string, AudioNode>()
-  // connections: sourceId -> Set of destIds
+  const nodes = new Map<string, BackendNode>()
   const connections = new Map<string, Set<string>>()
   const state = { disposed: false }
 
-  // Auto-register destination
-  nodes.set('destination', context.destination as unknown as AudioNode)
+  nodes.set('destination', context.destination)
 
   const assertNotDisposed = (method: string): void => {
     if (state.disposed) {
@@ -19,7 +17,7 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
     }
   }
 
-  const getNodeOrThrow = (id: string, label: string): AudioNode => {
+  const getNodeOrThrow = (id: string, label: string): BackendNode => {
     const node = nodes.get(id)
     if (!node) {
       throw ScoreError(`${label} "${id}" not found in AudioGraph`, {
@@ -36,7 +34,7 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
       try {
         sourceNode.disconnect(destNode)
       } catch {
-        // Already disconnected — safe to ignore
+        // Already disconnected
       }
     }
     const sourceConns = connections.get(sourceId)
@@ -49,7 +47,6 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
   }
 
   const disconnectAllForNode = (nodeId: string): void => {
-    // Disconnect outgoing connections
     const outgoing = connections.get(nodeId)
     if (outgoing) {
       const node = nodes.get(nodeId)
@@ -68,7 +65,6 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
       connections.delete(nodeId)
     }
 
-    // Disconnect incoming connections (where nodeId is a destination)
     for (const [sourceId, dests] of connections) {
       if (dests.has(nodeId)) {
         const sourceNode = nodes.get(sourceId)
@@ -91,7 +87,7 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
   const graph: AudioGraph = Object.freeze({
     context,
 
-    addNode: (id: string, node: AudioNode): void => {
+    addNode: (id: string, node: BackendNode): void => {
       assertNotDisposed('addNode')
       if (nodes.has(id)) {
         throw ScoreError(`Node "${id}" already exists in AudioGraph`, {
@@ -131,7 +127,6 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
       assertNotDisposed('disconnect')
       const sourceNode = getNodeOrThrow(sourceId, 'Source node')
       if (destinationId !== undefined) {
-        // Disconnect specific pair
         const destNode = nodes.get(destinationId)
         if (destNode) {
           try {
@@ -142,7 +137,6 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
         }
         disconnectSourceFromDest(sourceId, destinationId)
       } else {
-        // Disconnect all from source
         const outgoing = connections.get(sourceId)
         if (outgoing) {
           for (const destId of outgoing) {
@@ -160,12 +154,9 @@ export const createAudioGraph = (context: ScoreAudioContext): AudioGraph => {
       }
     },
 
-    getNode: (id: string): AudioNode | undefined => {
-      return nodes.get(id)
-    },
+    getNode: (id: string): BackendNode | undefined => nodes.get(id),
 
     dispose: (): void => {
-      // Disconnect all connections
       for (const [sourceId, dests] of connections) {
         const sourceNode = nodes.get(sourceId)
         if (sourceNode) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // @score/core
-// ScoreError, AudioContext, AudioGraph, Oscillator, Gain, Noise
+// Backend, ScoreError, AudioContext, AudioGraph, Oscillator, Gain, Noise
 
+export * from './backend/index.js'
 export * from './types.js'
 export * from './errors/ScoreError.js'
 export * from './context.js'

--- a/packages/core/src/noise.ts
+++ b/packages/core/src/noise.ts
@@ -1,54 +1,10 @@
 import { ScoreError } from './errors/ScoreError.js'
 import type { AudioComponent, ScoreAudioContext, ScoreAudioNode } from './types.js'
+import type { NoiseType } from './backend/types.js'
 
-export type NoiseType = 'white' | 'pink' | 'brown'
+export type { NoiseType }
 
 const VALID_TYPES: ReadonlyArray<NoiseType> = ['white', 'pink', 'brown']
-
-const fillWhiteNoise = (data: Float32Array): void => {
-  for (let i = 0; i < data.length; i++) {
-    data[i] = Math.random() * 2 - 1
-  }
-}
-
-const fillPinkNoise = (data: Float32Array): void => {
-  let b0 = 0,
-    b1 = 0,
-    b2 = 0,
-    b3 = 0,
-    b4 = 0,
-    b5 = 0,
-    b6 = 0
-  for (let i = 0; i < data.length; i++) {
-    const white = Math.random() * 2 - 1
-    b0 = 0.99886 * b0 + white * 0.0555179
-    b1 = 0.99332 * b1 + white * 0.0750759
-    b2 = 0.969 * b2 + white * 0.153852
-    b3 = 0.8665 * b3 + white * 0.3104856
-    b4 = 0.55 * b4 + white * 0.5329522
-    b5 = -0.7616 * b5 - white * 0.016898
-    data[i] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362) * 0.11
-    b6 = white * 0.115926
-  }
-}
-
-const fillBrownNoise = (data: Float32Array): void => {
-  let lastOut = 0
-  for (let i = 0; i < data.length; i++) {
-    const white = Math.random() * 2 - 1
-    lastOut = (lastOut + white * 0.02) / 1.02
-    data[i] = lastOut * 3.5
-  }
-}
-
-const fillBuffer = (data: Float32Array, type: NoiseType): void => {
-  const fillers: Record<NoiseType, (d: Float32Array) => void> = {
-    white: fillWhiteNoise,
-    pink: fillPinkNoise,
-    brown: fillBrownNoise,
-  }
-  fillers[type](data)
-}
 
 export const createNoise = (
   context: ScoreAudioContext,
@@ -66,51 +22,32 @@ export const createNoise = (
     })
   }
 
-  const bufferSize = context.sampleRate * 2
-  const buffer = context.createBuffer(1, bufferSize, context.sampleRate)
-  const data = buffer.getChannelData(0)
-  fillBuffer(data, noiseType)
-
-  const gainNode = context.createGain()
-  let source: AudioBufferSourceNode | null = null
+  const noiseNode = context.createNoise(props)
 
   const component: AudioComponent & {
     readonly start: (time?: number) => void
     readonly stop: (time?: number) => void
   } = {
-    start: (time?: number) => {
-      source = context.createBufferSource()
-      source.buffer = buffer
-      source.loop = true
-      source.connect(gainNode)
-      source.start(time)
-    },
-    stop: (time?: number) => {
-      if (source) {
-        source.stop(time)
-        source.disconnect()
-        source = null
-      }
-    },
+    start: (time?: number) => noiseNode.start(time),
+    stop: (time?: number) => noiseNode.stop(time),
+
     connect: (destination: ScoreAudioNode) => {
-      gainNode.connect(destination)
+      noiseNode.connect(destination)
       return component
     },
+
     disconnect: () => {
-      gainNode.disconnect()
+      noiseNode.disconnect()
       return component
     },
+
     dispose: () => {
-      if (source) {
-        try {
-          source.stop()
-        } catch {
-          /* already stopped */
-        }
-        source.disconnect()
-        source = null
+      try {
+        noiseNode.stop()
+      } catch {
+        // Already stopped
       }
-      gainNode.disconnect()
+      noiseNode.disconnect()
     },
   }
 

--- a/packages/core/src/noise.ts
+++ b/packages/core/src/noise.ts
@@ -28,8 +28,8 @@ export const createNoise = (
     readonly start: (time?: number) => void
     readonly stop: (time?: number) => void
   } = {
-    start: (time?: number) => noiseNode.start(time),
-    stop: (time?: number) => noiseNode.stop(time),
+    start: (time?: number) => { noiseNode.start(time) },
+    stop: (time?: number) => { noiseNode.stop(time) },
 
     connect: (destination: ScoreAudioNode) => {
       noiseNode.connect(destination)

--- a/packages/core/src/oscillator.ts
+++ b/packages/core/src/oscillator.ts
@@ -8,10 +8,7 @@ export const createOscillator = (
     detune?: number
   },
 ) => {
-  const oscNode = context.createOscillator()
-  oscNode.type = props.type ?? 'sine'
-  oscNode.frequency.value = props.frequency ?? 440
-  oscNode.detune.value = props.detune ?? 0
+  const oscNode = context.createOscillator(props)
 
   const component: AudioComponent & {
     readonly start: (time?: number) => void
@@ -19,21 +16,10 @@ export const createOscillator = (
     readonly setFrequency: (value: number, time?: number) => void
     readonly setDetune: (value: number, time?: number) => void
   } = {
-    start: (time?: number) => {
-      oscNode.start(time ?? context.currentTime)
-    },
-
-    stop: (time?: number) => {
-      oscNode.stop(time ?? context.currentTime)
-    },
-
-    setFrequency: (value: number, time?: number) => {
-      oscNode.frequency.setValueAtTime(value, time ?? context.currentTime)
-    },
-
-    setDetune: (value: number, time?: number) => {
-      oscNode.detune.setValueAtTime(value, time ?? context.currentTime)
-    },
+    start: (time?: number) => oscNode.start(time),
+    stop: (time?: number) => oscNode.stop(time),
+    setFrequency: (value: number, time?: number) => oscNode.setFrequency(value, time),
+    setDetune: (value: number, time?: number) => oscNode.setDetune(value, time),
 
     connect: (destination: ScoreAudioNode) => {
       oscNode.connect(destination)

--- a/packages/core/src/oscillator.ts
+++ b/packages/core/src/oscillator.ts
@@ -16,10 +16,10 @@ export const createOscillator = (
     readonly setFrequency: (value: number, time?: number) => void
     readonly setDetune: (value: number, time?: number) => void
   } = {
-    start: (time?: number) => oscNode.start(time),
-    stop: (time?: number) => oscNode.stop(time),
-    setFrequency: (value: number, time?: number) => oscNode.setFrequency(value, time),
-    setDetune: (value: number, time?: number) => oscNode.setDetune(value, time),
+    start: (time?: number) => { oscNode.start(time) },
+    stop: (time?: number) => { oscNode.stop(time) },
+    setFrequency: (value: number, time?: number) => { oscNode.setFrequency(value, time) },
+    setDetune: (value: number, time?: number) => { oscNode.setDetune(value, time) },
 
     connect: (destination: ScoreAudioNode) => {
       oscNode.connect(destination)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,20 +1,15 @@
 // Core type definitions for @score/core
-// Re-exports Web Audio types from node-web-audio-api so consumers don't need to import it directly
+// All audio types flow through the BackendProvider abstraction
 
-import type {
-  BaseAudioContext as NodeBaseAudioContext,
-  AudioNode as NodeAudioNode,
-} from 'node-web-audio-api'
+import type { BackendContext, BackendNode } from './backend/types.js'
 
-// ScoreAudioContext — accepts both AudioContext and OfflineAudioContext
-export type ScoreAudioContext = NodeBaseAudioContext
-
-// Re-export AudioNode for use in component interfaces
-export type ScoreAudioNode = NodeAudioNode
+// Re-export backend types as Score's public API types
+export type ScoreAudioContext = BackendContext
+export type ScoreAudioNode = BackendNode
 
 // AudioComponent — every component in @score/components, @score/effects, @score/mixer must conform
 export type AudioComponent = {
-  readonly connect: (destination: ScoreAudioNode) => AudioComponent
+  readonly connect: (destination: BackendNode) => AudioComponent
   readonly disconnect: () => AudioComponent
   readonly dispose: () => void
 }
@@ -22,17 +17,17 @@ export type AudioComponent = {
 // GraphNode — an entry in the AudioGraphManager's registry
 export type GraphNode = {
   readonly id: string
-  readonly node: ScoreAudioNode
+  readonly node: BackendNode
   readonly connections: ReadonlyArray<string>
 }
 
 // AudioGraph — return type of createAudioGraph
 export type AudioGraph = {
-  readonly context: ScoreAudioContext
-  readonly addNode: (id: string, node: ScoreAudioNode) => void
+  readonly context: BackendContext
+  readonly addNode: (id: string, node: BackendNode) => void
   readonly removeNode: (id: string) => void
   readonly connect: (sourceId: string, destinationId: string) => void
   readonly disconnect: (sourceId: string, destinationId?: string) => void
-  readonly getNode: (id: string) => ScoreAudioNode | undefined
+  readonly getNode: (id: string) => BackendNode | undefined
   readonly dispose: () => void
 }

--- a/packages/core/tests/backend.test.ts
+++ b/packages/core/tests/backend.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { webAudioBackend } from '../src/backend/web-audio.js'
+import type { BackendProvider } from '../src/backend/types.js'
+
+describe('webAudioBackend', () => {
+  it('is a BackendProvider with name "web-audio"', () => {
+    const backend: BackendProvider = webAudioBackend
+    expect(backend.name).toBe('web-audio')
+    expect(typeof backend.createContext).toBe('function')
+  })
+
+  it('creates an offline context', () => {
+    const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+    expect(ctx.sampleRate).toBe(44100)
+    expect(ctx.destination).toBeDefined()
+    expect(typeof ctx.createOscillator).toBe('function')
+    expect(typeof ctx.createGain).toBe('function')
+    expect(typeof ctx.createNoise).toBe('function')
+  })
+
+  it('respects custom sampleRate', () => {
+    const ctx = webAudioBackend.createContext({
+      sampleRate: 48000,
+      offline: { length: 48000 },
+    })
+    expect(ctx.sampleRate).toBe(48000)
+  })
+
+  it('throws ScoreError for invalid offline params', () => {
+    expect(() => webAudioBackend.createContext({ offline: { length: -1 } })).toThrow()
+  })
+
+  describe('createOscillator', () => {
+    it('returns a node with start, stop, setFrequency, setDetune, connect, disconnect', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const osc = ctx.createOscillator()
+      expect(typeof osc.start).toBe('function')
+      expect(typeof osc.stop).toBe('function')
+      expect(typeof osc.setFrequency).toBe('function')
+      expect(typeof osc.setDetune).toBe('function')
+      expect(typeof osc.connect).toBe('function')
+      expect(typeof osc.disconnect).toBe('function')
+    })
+
+    it('start and stop do not throw', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const osc = ctx.createOscillator()
+      expect(() => osc.start()).not.toThrow()
+      expect(() => osc.stop()).not.toThrow()
+    })
+
+    it('connects to destination without throwing', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const osc = ctx.createOscillator()
+      expect(() => osc.connect(ctx.destination)).not.toThrow()
+    })
+  })
+
+  describe('createGain', () => {
+    it('returns a node with gain, setGain, connect, disconnect', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const gain = ctx.createGain()
+      expect(typeof gain.gain).toBe('number')
+      expect(typeof gain.setGain).toBe('function')
+      expect(typeof gain.connect).toBe('function')
+      expect(typeof gain.disconnect).toBe('function')
+    })
+
+    it('defaults to gain 1.0', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const gain = ctx.createGain()
+      expect(gain.gain).toBeCloseTo(1.0)
+    })
+
+    it('respects initial gain prop', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const gain = ctx.createGain({ gain: 0.5 })
+      expect(gain.gain).toBeCloseTo(0.5)
+    })
+  })
+
+  describe('createNoise', () => {
+    it('returns a node with start, stop, connect, disconnect', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const noise = ctx.createNoise()
+      expect(typeof noise.start).toBe('function')
+      expect(typeof noise.stop).toBe('function')
+      expect(typeof noise.connect).toBe('function')
+      expect(typeof noise.disconnect).toBe('function')
+    })
+
+    it('start and stop do not throw', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const noise = ctx.createNoise()
+      expect(() => noise.start()).not.toThrow()
+      expect(() => noise.stop()).not.toThrow()
+    })
+
+    it('accepts all noise types', () => {
+      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      expect(() => ctx.createNoise({ type: 'white' })).not.toThrow()
+      expect(() => ctx.createNoise({ type: 'pink' })).not.toThrow()
+      expect(() => ctx.createNoise({ type: 'brown' })).not.toThrow()
+    })
+  })
+})

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { createAudioContext } from '../src/context.js'
+import { createMockBackendProvider } from './utils/audioTestUtils.js'
 
 describe('createAudioContext', () => {
   const makeContext = (options?: Parameters<typeof createAudioContext>[0]) =>
@@ -41,18 +42,19 @@ describe('createAudioContext', () => {
     expect(ctx.destination).toBeDefined()
   })
 
-  it('createGain() returns a node', () => {
+  it('createGain() returns a node with gain property', () => {
     const ctx = makeContext()
     const gain = ctx.createGain()
     expect(gain).toBeDefined()
     expect(gain).toHaveProperty('gain')
   })
 
-  it('createOscillator() returns a node', () => {
+  it('createOscillator() returns a node with start/stop', () => {
     const ctx = makeContext()
     const osc = ctx.createOscillator()
     expect(osc).toBeDefined()
-    expect(osc).toHaveProperty('frequency')
+    expect(osc).toHaveProperty('start')
+    expect(osc).toHaveProperty('stop')
   })
 
   it('defaults to offline with length 44100 when no options', () => {
@@ -60,28 +62,21 @@ describe('createAudioContext', () => {
     expect(ctx.sampleRate).toBe(44100)
   })
 
-  it('offline respects numberOfChannels', () => {
-    const ctx = createAudioContext({
-      offline: { length: 44100, numberOfChannels: 2 },
-    })
-    expect(ctx.destination.channelCount).toBeGreaterThanOrEqual(1)
+  it('throws ScoreError when construction fails', () => {
+    expect(() => createAudioContext({ offline: { length: -1 } })).toThrow()
   })
 
-  it('throws ScoreError when construction fails', () => {
-    vi.doMock('node-web-audio-api', () => ({
-      AudioContext: class {
-        constructor() {
-          throw new Error('mock failure')
-        }
-      },
-      OfflineAudioContext: class {
-        constructor() {
-          throw new Error('mock failure')
-        }
-      },
-    }))
-    // Use a direct approach — pass invalid params to trigger the catch
-    expect(() => createAudioContext({ offline: { length: -1 } })).toThrow()
-    vi.restoreAllMocks()
+  it('uses custom backend when provided', () => {
+    const mockBackend = createMockBackendProvider()
+    const ctx = createAudioContext({ backend: mockBackend })
+    expect(mockBackend.contexts.length).toBe(1)
+    expect(ctx.sampleRate).toBe(44100)
+  })
+
+  it('defaults to web-audio backend when none specified', () => {
+    const ctx = makeContext()
+    expect(ctx.createOscillator).toBeDefined()
+    expect(ctx.createGain).toBeDefined()
+    expect(ctx.createNoise).toBeDefined()
   })
 })

--- a/packages/core/tests/gain.test.ts
+++ b/packages/core/tests/gain.test.ts
@@ -1,16 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { OfflineAudioContext } from 'node-web-audio-api'
+import { describe, it, expect } from 'vitest'
+import { createAudioContext } from '../src/context.js'
 import { createGain } from '../src/gain.js'
-import type { ScoreAudioContext } from '../src/types.js'
+import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createGain', () => {
-  const contexts: OfflineAudioContext[] = []
-
-  const makeContext = (): ScoreAudioContext => {
-    const ctx = new OfflineAudioContext(1, 44100, 44100)
-    contexts.push(ctx)
-    return ctx
-  }
+  const makeContext = () =>
+    createAudioContext({ offline: { length: 44100 } })
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()
@@ -26,13 +21,13 @@ describe('createGain', () => {
   it('default gain is 1.0', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
-    expect(g.node.gain.value).toBeCloseTo(1.0)
+    expect(g.gain).toBeCloseTo(1.0)
   })
 
   it('respects custom gain prop', () => {
     const ctx = makeContext()
     const g = createGain(ctx, { gain: 0.5 })
-    expect(g.node.gain.value).toBeCloseTo(0.5)
+    expect(g.gain).toBeCloseTo(0.5)
   })
 
   it('setGain updates the gain value', () => {
@@ -62,11 +57,10 @@ describe('createGain', () => {
     expect(() => g.dispose()).not.toThrow()
   })
 
-  it('node property exposes the underlying GainNode', () => {
+  it('gain property is readable', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
-    expect(g.node).toBeDefined()
-    expect(g.node).toHaveProperty('gain')
+    expect(typeof g.gain).toBe('number')
   })
 
   it('disconnect when not connected does not throw', () => {
@@ -79,5 +73,11 @@ describe('createGain', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
     expect(() => g.dispose()).not.toThrow()
+  })
+
+  it('delegates to backend createGain', () => {
+    const mockCtx = createMockBackendContext()
+    createGain(mockCtx, { gain: 0.7 })
+    expect(mockCtx.createdGains.length).toBe(1)
   })
 })

--- a/packages/core/tests/graph.test.ts
+++ b/packages/core/tests/graph.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { OfflineAudioContext } from 'node-web-audio-api'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createAudioContext } from '../src/context.js'
 import { createAudioGraph } from '../src/graph.js'
+import type { BackendContext } from '../src/backend/types.js'
 
 describe('createAudioGraph', () => {
-  let context: OfflineAudioContext
+  let context: BackendContext
 
   beforeEach(() => {
-    context = new OfflineAudioContext(1, 44100, 44100)
+    context = createAudioContext({ offline: { length: 44100 } })
   })
 
   it('returns an AudioGraph object with the expected methods', () => {
@@ -27,7 +28,7 @@ describe('createAudioGraph', () => {
     graph.dispose()
   })
 
-  it('exposes the AudioContext as a readonly context property', () => {
+  it('exposes the BackendContext as a readonly context property', () => {
     const graph = createAudioGraph(context)
     expect(graph.context).toBe(context)
     graph.dispose()
@@ -60,7 +61,6 @@ describe('createAudioGraph', () => {
         graph.addNode('gain', gain2)
       } catch (err) {
         expect((err as Error).name).toBe('ScoreError')
-        expect((err as Error).message).toContain('gain')
         expect((err as { context: { fix: string } }).context.fix).toBeDefined()
       }
       graph.dispose()
@@ -109,8 +109,6 @@ describe('createAudioGraph', () => {
       graph.addNode('gain2', gain2)
       graph.connect('gain1', 'gain2')
       graph.connect('gain2', 'destination')
-      // Removing gain2 should disconnect gain1->gain2 and gain2->destination
-      // This should not throw
       graph.removeNode('gain2')
       expect(graph.getNode('gain2')).toBeUndefined()
       graph.dispose()
@@ -118,11 +116,10 @@ describe('createAudioGraph', () => {
   })
 
   describe('connect', () => {
-    it('calls node.connect() on the underlying AudioNode', () => {
+    it('connects nodes without throwing', () => {
       const graph = createAudioGraph(context)
       const gain = context.createGain()
       graph.addNode('gain1', gain)
-      // Should not throw — connects gain1 to destination
       graph.connect('gain1', 'destination')
       graph.dispose()
     })
@@ -163,9 +160,7 @@ describe('createAudioGraph', () => {
       graph.addNode('gain2', gain2)
       graph.connect('gain1', 'gain2')
       graph.connect('gain1', 'destination')
-      // Disconnect only gain1 -> gain2
       graph.disconnect('gain1', 'gain2')
-      // gain1 -> destination should still work (no throw)
       graph.dispose()
     })
 
@@ -177,7 +172,6 @@ describe('createAudioGraph', () => {
       graph.addNode('gain2', gain2)
       graph.connect('gain1', 'gain2')
       graph.connect('gain1', 'destination')
-      // Disconnect all from gain1
       graph.disconnect('gain1')
       graph.dispose()
     })
@@ -204,7 +198,6 @@ describe('createAudioGraph', () => {
       graph.addNode('source', source)
       graph.addNode('dest1', dest1)
       graph.addNode('dest2', dest2)
-      // Should not throw — one source to two destinations
       graph.connect('source', 'dest1')
       graph.connect('source', 'dest2')
       graph.dispose()
@@ -216,7 +209,6 @@ describe('createAudioGraph', () => {
       const src2 = context.createGain()
       graph.addNode('src1', src1)
       graph.addNode('src2', src2)
-      // Both connect to destination
       graph.connect('src1', 'destination')
       graph.connect('src2', 'destination')
       graph.dispose()
@@ -230,7 +222,6 @@ describe('createAudioGraph', () => {
       graph.addNode('gain1', gain)
       graph.connect('gain1', 'destination')
       graph.dispose()
-      // After dispose, all nodes are gone
       expect(graph.getNode('gain1')).toBeUndefined()
       expect(graph.getNode('destination')).toBeUndefined()
     })

--- a/packages/core/tests/noise.test.ts
+++ b/packages/core/tests/noise.test.ts
@@ -1,16 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { OfflineAudioContext } from 'node-web-audio-api'
+import { describe, it, expect } from 'vitest'
+import { createAudioContext } from '../src/context.js'
 import { createNoise } from '../src/noise.js'
-import type { ScoreAudioContext } from '../src/types.js'
+import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createNoise', () => {
-  const contexts: OfflineAudioContext[] = []
-
-  const makeContext = (): ScoreAudioContext => {
-    const ctx = new OfflineAudioContext(1, 44100, 44100)
-    contexts.push(ctx)
-    return ctx
-  }
+  const makeContext = () =>
+    createAudioContext({ offline: { length: 44100 } })
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()
@@ -23,7 +18,7 @@ describe('createNoise', () => {
     expect(typeof noise.dispose).toBe('function')
   })
 
-  it('default type is white', () => {
+  it('default type is white (has start and stop)', () => {
     const ctx = makeContext()
     const noise = createNoise(ctx)
     expect(noise).toHaveProperty('start')
@@ -78,5 +73,11 @@ describe('createNoise', () => {
     noise.start()
     noise.connect(ctx.destination)
     expect(() => noise.dispose()).not.toThrow()
+  })
+
+  it('delegates to backend createNoise', () => {
+    const mockCtx = createMockBackendContext()
+    createNoise(mockCtx, { type: 'pink' })
+    expect(mockCtx.createdNoises.length).toBe(1)
   })
 })

--- a/packages/core/tests/oscillator.test.ts
+++ b/packages/core/tests/oscillator.test.ts
@@ -1,16 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { OfflineAudioContext } from 'node-web-audio-api'
+import { describe, it, expect } from 'vitest'
+import { createAudioContext } from '../src/context.js'
 import { createOscillator } from '../src/oscillator.js'
-import type { ScoreAudioContext } from '../src/types.js'
+import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createOscillator', () => {
-  const contexts: OfflineAudioContext[] = []
-
-  const makeContext = (): ScoreAudioContext => {
-    const ctx = new OfflineAudioContext(1, 44100, 44100)
-    contexts.push(ctx)
-    return ctx
-  }
+  const makeContext = () =>
+    createAudioContext({ offline: { length: 44100 } })
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()
@@ -23,26 +18,17 @@ describe('createOscillator', () => {
     expect(typeof osc.dispose).toBe('function')
   })
 
-  it('default type is sine', () => {
+  it('has start and stop methods', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
     expect(osc).toHaveProperty('start')
     expect(osc).toHaveProperty('stop')
-    // Verify via start/stop — if type were wrong, the node would still work
-    // but we need to check the underlying node type
   })
 
   it('respects custom type prop', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, { type: 'sawtooth' })
     expect(osc).toBeDefined()
-  })
-
-  it('default frequency is 440', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    // setFrequency to a value and verify it doesn't throw
-    expect(osc).toHaveProperty('setFrequency')
   })
 
   it('respects custom frequency prop', () => {
@@ -70,13 +56,13 @@ describe('createOscillator', () => {
     expect(() => osc.stop()).not.toThrow()
   })
 
-  it('setFrequency updates the frequency', () => {
+  it('setFrequency does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
     expect(() => osc.setFrequency(660)).not.toThrow()
   })
 
-  it('setDetune updates the detune', () => {
+  it('setDetune does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
     expect(() => osc.setDetune(50)).not.toThrow()
@@ -114,5 +100,11 @@ describe('createOscillator', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
     expect(() => osc.dispose()).not.toThrow()
+  })
+
+  it('delegates to backend createOscillator with props', () => {
+    const mockCtx = createMockBackendContext()
+    createOscillator(mockCtx, { type: 'square', frequency: 220, detune: 5 })
+    expect(mockCtx.createdOscillators.length).toBe(1)
   })
 })

--- a/packages/core/tests/utils/audioTestUtils.ts
+++ b/packages/core/tests/utils/audioTestUtils.ts
@@ -1,91 +1,148 @@
-// Mock factories for Web Audio API objects
+// Mock factories for BackendProvider/BackendContext
 // Used across all @score/* package tests — no real AudioContext required
 
-// Track connect/disconnect calls for assertions
-export type MockAudioNode = {
-  readonly connectCalls: Array<{
-    destination: unknown
-    output: number | undefined
-    input: number | undefined
-  }>
-  readonly disconnectCalls: Array<{ destination: unknown | undefined }>
-  readonly connect: (destination: unknown, output?: number, input?: number) => MockAudioNode
-  readonly disconnect: (destination?: unknown) => void
-  readonly channelCount: number
-  readonly channelCountMode: string
-  readonly channelInterpretation: string
-  readonly numberOfInputs: number
-  readonly numberOfOutputs: number
+import type {
+  BackendContext,
+  BackendGainNode,
+  BackendNode,
+  BackendNoiseNode,
+  BackendOscillatorNode,
+  BackendProvider,
+} from '../../src/backend/types.js'
+
+// --- Track calls for assertions ---
+
+export type MockConnectCall = { readonly destination: BackendNode }
+export type MockDisconnectCall = { readonly destination: BackendNode | undefined }
+
+export type MockBackendNode = BackendNode & {
+  readonly connectCalls: Array<MockConnectCall>
+  readonly disconnectCalls: Array<MockDisconnectCall>
 }
 
-export type MockGainNode = MockAudioNode & {
-  readonly gain: { readonly value: number }
+export type MockBackendOscillatorNode = MockBackendNode & BackendOscillatorNode & {
+  readonly startCalls: Array<{ readonly time: number | undefined }>
+  readonly stopCalls: Array<{ readonly time: number | undefined }>
 }
 
-export type MockOscillatorNode = MockAudioNode & {
-  readonly frequency: { readonly value: number }
-  readonly type: string
-  readonly start: (when?: number) => void
-  readonly stop: (when?: number) => void
+export type MockBackendGainNode = MockBackendNode & BackendGainNode
+
+export type MockBackendNoiseNode = MockBackendNode & BackendNoiseNode & {
+  readonly startCalls: Array<{ readonly time: number | undefined }>
+  readonly stopCalls: Array<{ readonly time: number | undefined }>
 }
 
-export type MockAudioContext = {
-  readonly currentTime: number
-  readonly sampleRate: number
-  readonly state: string
-  readonly destination: MockAudioNode
-  readonly resume: () => Promise<void>
-  readonly close: () => Promise<void>
-  readonly createGain: () => MockGainNode
-  readonly createOscillator: () => MockOscillatorNode
+export type MockBackendContext = BackendContext & {
+  readonly createdOscillators: Array<MockBackendOscillatorNode>
+  readonly createdGains: Array<MockBackendGainNode>
+  readonly createdNoises: Array<MockBackendNoiseNode>
 }
 
 // --- Factory functions ---
 
-export const createMockAudioNode = (): MockAudioNode => {
-  const connectCalls: MockAudioNode['connectCalls'] = []
-  const disconnectCalls: MockAudioNode['disconnectCalls'] = []
+export const createMockBackendNode = (): MockBackendNode => {
+  const connectCalls: Array<MockConnectCall> = []
+  const disconnectCalls: Array<MockDisconnectCall> = []
 
-  const node: MockAudioNode = {
+  return {
     connectCalls,
     disconnectCalls,
-    connect: (destination: unknown, output?: number, input?: number) => {
-      connectCalls.push({ destination, output, input })
-      return node
-    },
-    disconnect: (destination?: unknown) => {
-      disconnectCalls.push({ destination })
-    },
-    channelCount: 2,
-    channelCountMode: 'max',
-    channelInterpretation: 'speakers',
-    numberOfInputs: 1,
-    numberOfOutputs: 1,
+    connect: (dest: BackendNode) => { connectCalls.push({ destination: dest }) },
+    disconnect: (dest?: BackendNode) => { disconnectCalls.push({ destination: dest }) },
   }
-
-  return node
 }
 
-export const createMockGainNode = (): MockGainNode => ({
-  ...createMockAudioNode(),
-  gain: { value: 1 },
-})
+export const createMockOscillatorNode = (): MockBackendOscillatorNode => {
+  const base = createMockBackendNode()
+  const startCalls: Array<{ readonly time: number | undefined }> = []
+  const stopCalls: Array<{ readonly time: number | undefined }> = []
 
-export const createMockOscillatorNode = (): MockOscillatorNode => ({
-  ...createMockAudioNode(),
-  frequency: { value: 440 },
-  type: 'sine',
-  start: (_when?: number) => {},
-  stop: (_when?: number) => {},
-})
+  return {
+    ...base,
+    startCalls,
+    stopCalls,
+    start: (time?: number) => { startCalls.push({ time }) },
+    stop: (time?: number) => { stopCalls.push({ time }) },
+    setFrequency: (_value: number, _time?: number) => {},
+    setDetune: (_value: number, _time?: number) => {},
+  }
+}
 
-export const createMockAudioContext = (): MockAudioContext => ({
-  currentTime: 0,
-  sampleRate: 44100,
-  state: 'running',
-  destination: createMockAudioNode(),
-  resume: () => Promise.resolve(),
-  close: () => Promise.resolve(),
-  createGain: () => createMockGainNode(),
-  createOscillator: () => createMockOscillatorNode(),
-})
+export const createMockGainNode = (initialGain = 1.0): MockBackendGainNode => {
+  const base = createMockBackendNode()
+  let currentGain = initialGain
+
+  return {
+    ...base,
+    get gain() { return currentGain },
+    setGain: (value: number, _time?: number) => { currentGain = value },
+  }
+}
+
+export const createMockNoiseNode = (): MockBackendNoiseNode => {
+  const base = createMockBackendNode()
+  const startCalls: Array<{ readonly time: number | undefined }> = []
+  const stopCalls: Array<{ readonly time: number | undefined }> = []
+
+  return {
+    ...base,
+    startCalls,
+    stopCalls,
+    start: (time?: number) => { startCalls.push({ time }) },
+    stop: (time?: number) => { stopCalls.push({ time }) },
+  }
+}
+
+export const createMockBackendContext = (): MockBackendContext => {
+  const createdOscillators: Array<MockBackendOscillatorNode> = []
+  const createdGains: Array<MockBackendGainNode> = []
+  const createdNoises: Array<MockBackendNoiseNode> = []
+
+  return {
+    currentTime: 0,
+    sampleRate: 44100,
+    state: 'running',
+    destination: createMockBackendNode(),
+    createdOscillators,
+    createdGains,
+    createdNoises,
+
+    createOscillator: (props) => {
+      const node = createMockOscillatorNode()
+      createdOscillators.push(node)
+      return node
+    },
+
+    createGain: (props) => {
+      const node = createMockGainNode(props?.gain ?? 1.0)
+      createdGains.push(node)
+      return node
+    },
+
+    createNoise: (props) => {
+      const node = createMockNoiseNode()
+      createdNoises.push(node)
+      return node
+    },
+
+    suspend: () => Promise.resolve(),
+    resume: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+}
+
+export const createMockBackendProvider = (): BackendProvider & {
+  readonly contexts: Array<MockBackendContext>
+} => {
+  const contexts: Array<MockBackendContext> = []
+
+  return {
+    name: 'mock',
+    contexts,
+    createContext: (_options) => {
+      const ctx = createMockBackendContext()
+      contexts.push(ctx)
+      return ctx
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce pluggable `BackendProvider` / `BackendContext` / `BackendNode` interfaces in `core/src/backend/`
- Web Audio API implementation (`webAudioBackend`) as the default — all `node-web-audio-api` usage isolated to one file
- `createAudioContext()` now accepts an optional `backend` param for swapping engines
- Refactored oscillator, gain, noise, and graph to delegate to backend instead of calling Web Audio directly
- Future backends (scsynth, custom user engines) can now be added as separate packages

## Changes
- **New:** `backend/types.ts`, `backend/web-audio.ts`, `backend/index.ts`
- **Refactored:** `context.ts`, `oscillator.ts`, `gain.ts`, `noise.ts`, `graph.ts`, `types.ts`, `index.ts`
- **Tests:** Updated all 6 test files + test utils, added `backend.test.ts` — 83 tests passing
- **Coverage:** 96.63% stmts / 87.38% branches / 93.54% funcs / 96.63% lines (above thresholds)

## Test plan
- [x] `pnpm test` — all 83 core tests pass
- [x] Coverage above 90/85/90/90 thresholds
- [x] TypeScript compiles with `--noEmit`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)