### PR TITLE
Phase 4: Sampler, test infrastructure, and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ coverage
 samples/**/*
 !samples/**/.gitkeep
 !samples/README.md
+
+# Sounds are user-provided — never committed
+sounds/**/*
+!sounds/**/.gitkeep
+!sounds/README.md

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -16,12 +16,18 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,js,json,md}\""
+    "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.ts": "eslint --fix"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "turbo": "^2.0.0",
     "typescript": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.ts": "eslint --fix"
+    "*.ts": [
+      "eslint --fix",
+      "bash -c 'pnpm typecheck'"
+    ]
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^2.0.0",
     "vitest": "^2.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src",
+    "lint": "eslint src tests",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/core/src/backend/types.ts
+++ b/packages/core/src/backend/types.ts
@@ -30,6 +30,23 @@ export type BackendNoiseNode = BackendNode & {
   readonly stop: (time?: number) => void
 }
 
+// Decoded audio buffer — holds sample data
+export type BackendBuffer = {
+  readonly duration: number
+  readonly length: number
+  readonly sampleRate: number
+  readonly numberOfChannels: number
+}
+
+// Buffer source — plays a BackendBuffer (one-shot or looped)
+export type BackendBufferSourceNode = BackendNode & {
+  readonly start: (time?: number, offset?: number, duration?: number) => void
+  readonly stop: (time?: number) => void
+  readonly loop: boolean
+  readonly setLoop: (loop: boolean) => void
+  readonly setPlaybackRate: (rate: number, time?: number) => void
+}
+
 // --- Backend context ---
 
 export type BackendContext = {
@@ -44,6 +61,11 @@ export type BackendContext = {
   }) => BackendOscillatorNode
   readonly createGain: (props?: { gain?: number }) => BackendGainNode
   readonly createNoise: (props?: { type?: NoiseType }) => BackendNoiseNode
+  readonly decodeAudio: (data: ArrayBuffer) => Promise<BackendBuffer>
+  readonly createBufferSource: (buffer: BackendBuffer, props?: {
+    loop?: boolean
+    playbackRate?: number
+  }) => BackendBufferSourceNode
   readonly suspend: () => Promise<void>
   readonly resume: () => Promise<void>
   readonly close: () => Promise<void>

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -14,6 +14,7 @@ import type {
 } from 'node-web-audio-api'
 import { ScoreError } from '../errors/ScoreError.js'
 import type {
+  BackendBuffer,
   BackendContext,
   BackendNode,
   BackendProvider,
@@ -25,11 +26,16 @@ import type {
 // when connecting two BackendNodes together
 
 const RAW = Symbol('web-audio-raw')
+const BUFFER = Symbol('web-audio-buffer')
 
 type WithRaw = { readonly [RAW]: WebAudioNode }
+type WithBuffer = { readonly [BUFFER]: AudioBuffer }
 
 const getRaw = (node: BackendNode): WebAudioNode =>
   (node as unknown as WithRaw)[RAW]
+
+const getRawBuffer = (buf: BackendBuffer): AudioBuffer =>
+  (buf as unknown as WithBuffer)[BUFFER]
 
 // --- Noise buffer generation (pure functions) ---
 
@@ -143,6 +149,11 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
       return {
         ...outputBase,
         start: (time?: number) => {
+          // Clean up previous source to prevent memory leak
+          if (source) {
+            try { source.stop() } catch { /* already stopped */ }
+            try { source.disconnect() } catch { /* already disconnected */ }
+          }
           source = ctx.createBufferSource() as unknown as WebBufferSourceNode
           source.buffer = buffer as unknown as AudioBuffer
           source.loop = true
@@ -155,6 +166,55 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
             source.disconnect()
             source = null
           }
+        },
+      }
+    },
+
+    decodeAudio: async (data: ArrayBuffer): Promise<BackendBuffer> => {
+      try {
+        const audioBuffer = await (ctx as unknown as { decodeAudioData: (d: ArrayBuffer) => Promise<AudioBuffer> })
+          .decodeAudioData(data)
+        return {
+          [BUFFER]: audioBuffer,
+          duration: audioBuffer.duration,
+          length: audioBuffer.length,
+          sampleRate: audioBuffer.sampleRate,
+          numberOfChannels: audioBuffer.numberOfChannels,
+        } as unknown as BackendBuffer
+      } catch (err) {
+        throw ScoreError('Failed to decode audio data', {
+          fix: 'Ensure the file is a valid audio format (WAV, MP3, OGG, FLAC)',
+          received: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+
+    createBufferSource: (buffer: BackendBuffer, props) => {
+      const rawBuffer = getRawBuffer(buffer)
+      const source = ctx.createBufferSource() as unknown as WebBufferSourceNode
+      source.buffer = rawBuffer as unknown as AudioBuffer
+      source.loop = props?.loop ?? false
+      if (props?.playbackRate !== undefined) {
+        source.playbackRate.value = props.playbackRate
+      }
+      const base = wrapNode(source as unknown as WebAudioNode)
+      let loopState = props?.loop ?? false
+
+      return {
+        ...base,
+        get loop() { return loopState },
+        setLoop: (loop: boolean) => {
+          loopState = loop
+          source.loop = loop
+        },
+        setPlaybackRate: (rate: number, time?: number) => {
+          source.playbackRate.setValueAtTime(rate, time ?? ctx.currentTime)
+        },
+        start: (time?: number, offset?: number, duration?: number) => {
+          source.start(time, offset, duration)
+        },
+        stop: (time?: number) => {
+          source.stop(time)
         },
       }
     },

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -221,7 +221,12 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
 
     suspend: () => (ctx as unknown as { suspend: () => Promise<void> }).suspend(),
     resume: () => (ctx as unknown as { resume: () => Promise<void> }).resume(),
-    close: () => (ctx as unknown as { close: () => Promise<void> }).close(),
+    close: () => {
+      const maybeCloseable = ctx as unknown as { close?: () => Promise<void> }
+      return typeof maybeCloseable.close === 'function'
+        ? maybeCloseable.close()
+        : Promise.resolve()
+    },
   }
 }
 // --- Web Audio BackendProvider ---

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // @score/core
-// Backend, ScoreError, AudioContext, AudioGraph, Oscillator, Gain, Noise
+// Backend, ScoreError, AudioContext, AudioGraph, Oscillator, Gain, Noise, Sample
 
 export * from './backend/index.js'
 export * from './types.js'
@@ -9,3 +9,4 @@ export * from './graph.js'
 export * from './oscillator.js'
 export * from './gain.js'
 export * from './noise.js'
+export * from './sample.js'

--- a/packages/core/src/sample.ts
+++ b/packages/core/src/sample.ts
@@ -1,0 +1,120 @@
+import { ScoreError } from './errors/ScoreError.js'
+import type { AudioComponent, ScoreAudioContext, ScoreAudioNode } from './types.js'
+import type { BackendBuffer, BackendBufferSourceNode } from './backend/types.js'
+
+// --- Sample decoding ---
+// Accepts raw audio data (ArrayBuffer) and decodes via the backend.
+// File reading is intentionally NOT here — it belongs in @score/cli or user code.
+// This keeps core backend-agnostic (works in Node, browser, scsynth).
+
+export const decodeSample = async (
+  context: ScoreAudioContext,
+  data: ArrayBuffer,
+): Promise<BackendBuffer> => {
+  if (data.byteLength === 0) {
+    throw ScoreError('Cannot decode empty audio data', {
+      fix: 'Provide a non-empty ArrayBuffer containing valid audio data (WAV, MP3, OGG, FLAC)',
+    })
+  }
+  return context.decodeAudio(data)
+}
+
+// --- Sample player ---
+// Wraps a decoded BackendBuffer as an AudioComponent.
+// Each start() creates a fresh buffer source (Web Audio one-shot pattern).
+// Gain is managed internally for volume control.
+
+export const createSamplePlayer = (
+  context: ScoreAudioContext,
+  buffer: BackendBuffer,
+  props?: {
+    loop?: boolean
+    playbackRate?: number
+    gain?: number
+  },
+) => {
+  const gainNode = context.createGain({ gain: props?.gain ?? 1.0 })
+  let activeSource: BackendBufferSourceNode | null = null
+
+  const component: AudioComponent & {
+    readonly start: (time?: number, offset?: number, duration?: number) => void
+    readonly stop: (time?: number) => void
+    readonly setPlaybackRate: (rate: number, time?: number) => void
+    readonly setGain: (value: number, time?: number) => void
+    readonly buffer: BackendBuffer
+  } = {
+    buffer,
+
+    start: (time?: number, offset?: number, duration?: number) => {
+      // Clean up previous source to prevent memory leak (Web Audio sources are one-shot)
+      if (activeSource) {
+        try { activeSource.stop() } catch { /* already stopped */ }
+        try { activeSource.disconnect() } catch { /* already disconnected */ }
+      }
+      activeSource = context.createBufferSource(buffer, {
+        loop: props?.loop ?? false,
+        playbackRate: props?.playbackRate ?? 1.0,
+      })
+      activeSource.connect(gainNode)
+      activeSource.start(time, offset, duration)
+    },
+
+    stop: (time?: number) => {
+      if (activeSource) {
+        try {
+          activeSource.stop(time)
+        } catch {
+          // Already stopped
+        }
+        activeSource = null
+      }
+    },
+
+    setPlaybackRate: (rate: number, time?: number) => {
+      if (activeSource) {
+        activeSource.setPlaybackRate(rate, time)
+      }
+    },
+
+    setGain: (value: number, time?: number) => {
+      gainNode.setGain(value, time)
+    },
+
+    connect: (destination: ScoreAudioNode) => {
+      gainNode.connect(destination)
+      return component
+    },
+
+    disconnect: () => {
+      try {
+        gainNode.disconnect()
+      } catch {
+        // Already disconnected
+      }
+      return component
+    },
+
+    dispose: () => {
+      if (activeSource) {
+        try {
+          activeSource.stop()
+        } catch {
+          // Already stopped
+        }
+        try {
+          activeSource.disconnect()
+        } catch {
+          // Already disconnected
+        }
+        activeSource = null
+      }
+      try {
+        gainNode.disconnect()
+      } catch {
+        // Already disconnected
+      }
+    },
+  }
+
+  return component
+}

--- a/packages/core/tests/backend.test.ts
+++ b/packages/core/tests/backend.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, afterAll } from 'vitest'
 import { webAudioBackend } from '../src/backend/web-audio.js'
-import type { BackendContext, BackendProvider } from '../src/backend/types.js'
+import type { BackendContext } from '../src/backend/types.js'
+import { runBackendContractTests } from './utils/backendContract.js'
 
-describe('webAudioBackend', () => {
+// --- Contract tests (any BackendProvider must pass these) ---
+runBackendContractTests(webAudioBackend)
+
+// --- Web Audio-specific tests ---
+describe('webAudioBackend (implementation-specific)', () => {
   const contexts: BackendContext[] = []
 
   const track = <T extends BackendContext>(ctx: T): T => {
@@ -14,104 +19,14 @@ describe('webAudioBackend', () => {
     await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
   })
 
-  it('is a BackendProvider with name "web-audio"', () => {
-    const backend: BackendProvider = webAudioBackend
-    expect(backend.name).toBe('web-audio')
-    expect(typeof backend.createContext).toBe('function')
-  })
-
-  it('creates an offline context', () => {
-    const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-    expect(ctx.sampleRate).toBe(44100)
-    expect(ctx.destination).toBeDefined()
-    expect(typeof ctx.createOscillator).toBe('function')
-    expect(typeof ctx.createGain).toBe('function')
-    expect(typeof ctx.createNoise).toBe('function')
-  })
-
-  it('respects custom sampleRate', () => {
-    const ctx = track(webAudioBackend.createContext({
-      sampleRate: 48000,
-      offline: { length: 48000 },
-    }))
-    expect(ctx.sampleRate).toBe(48000)
-  })
-
   it('throws ScoreError for invalid offline params', () => {
     expect(() => webAudioBackend.createContext({ offline: { length: -1 } })).toThrow()
   })
 
-  describe('createOscillator', () => {
-    it('returns a node with start, stop, setFrequency, setDetune, connect, disconnect', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const osc = ctx.createOscillator()
-      expect(typeof osc.start).toBe('function')
-      expect(typeof osc.stop).toBe('function')
-      expect(typeof osc.setFrequency).toBe('function')
-      expect(typeof osc.setDetune).toBe('function')
-      expect(typeof osc.connect).toBe('function')
-      expect(typeof osc.disconnect).toBe('function')
-    })
-
-    it('start and stop do not throw', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const osc = ctx.createOscillator()
-      expect(() => { osc.start(); }).not.toThrow()
-      expect(() => { osc.stop(); }).not.toThrow()
-    })
-
-    it('connects to destination without throwing', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const osc = ctx.createOscillator()
-      expect(() => { osc.connect(ctx.destination); }).not.toThrow()
-    })
-  })
-
-  describe('createGain', () => {
-    it('returns a node with gain, setGain, connect, disconnect', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const gain = ctx.createGain()
-      expect(typeof gain.gain).toBe('number')
-      expect(typeof gain.setGain).toBe('function')
-      expect(typeof gain.connect).toBe('function')
-      expect(typeof gain.disconnect).toBe('function')
-    })
-
-    it('defaults to gain 1.0', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const gain = ctx.createGain()
-      expect(gain.gain).toBeCloseTo(1.0)
-    })
-
-    it('respects initial gain prop', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const gain = ctx.createGain({ gain: 0.5 })
-      expect(gain.gain).toBeCloseTo(0.5)
-    })
-  })
-
-  describe('createNoise', () => {
-    it('returns a node with start, stop, connect, disconnect', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const noise = ctx.createNoise()
-      expect(typeof noise.start).toBe('function')
-      expect(typeof noise.stop).toBe('function')
-      expect(typeof noise.connect).toBe('function')
-      expect(typeof noise.disconnect).toBe('function')
-    })
-
-    it('start and stop do not throw', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      const noise = ctx.createNoise()
-      expect(() => { noise.start(); }).not.toThrow()
-      expect(() => { noise.stop(); }).not.toThrow()
-    })
-
-    it('accepts all noise types', () => {
-      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
-      expect(() => ctx.createNoise({ type: 'white' })).not.toThrow()
-      expect(() => ctx.createNoise({ type: 'pink' })).not.toThrow()
-      expect(() => ctx.createNoise({ type: 'brown' })).not.toThrow()
-    })
+  it('accepts all noise types without error', () => {
+    const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
+    expect(() => ctx.createNoise({ type: 'white' })).not.toThrow()
+    expect(() => ctx.createNoise({ type: 'pink' })).not.toThrow()
+    expect(() => ctx.createNoise({ type: 'brown' })).not.toThrow()
   })
 })

--- a/packages/core/tests/backend.test.ts
+++ b/packages/core/tests/backend.test.ts
@@ -45,14 +45,14 @@ describe('webAudioBackend', () => {
     it('start and stop do not throw', () => {
       const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
       const osc = ctx.createOscillator()
-      expect(() => osc.start()).not.toThrow()
-      expect(() => osc.stop()).not.toThrow()
+      expect(() => { osc.start(); }).not.toThrow()
+      expect(() => { osc.stop(); }).not.toThrow()
     })
 
     it('connects to destination without throwing', () => {
       const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
       const osc = ctx.createOscillator()
-      expect(() => osc.connect(ctx.destination)).not.toThrow()
+      expect(() => { osc.connect(ctx.destination); }).not.toThrow()
     })
   })
 
@@ -92,8 +92,8 @@ describe('webAudioBackend', () => {
     it('start and stop do not throw', () => {
       const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
       const noise = ctx.createNoise()
-      expect(() => noise.start()).not.toThrow()
-      expect(() => noise.stop()).not.toThrow()
+      expect(() => { noise.start(); }).not.toThrow()
+      expect(() => { noise.stop(); }).not.toThrow()
     })
 
     it('accepts all noise types', () => {

--- a/packages/core/tests/backend.test.ts
+++ b/packages/core/tests/backend.test.ts
@@ -1,30 +1,22 @@
 import { describe, it, expect, afterAll } from 'vitest'
+import { useHarness } from './utils/harness.js'
 import { webAudioBackend } from '../src/backend/web-audio.js'
-import type { BackendContext } from '../src/backend/types.js'
 import { runBackendContractTests } from './utils/backendContract.js'
 
 // --- Contract tests (any BackendProvider must pass these) ---
 runBackendContractTests(webAudioBackend)
 
 // --- Web Audio-specific tests ---
+const h = useHarness()
+afterAll(() => h.cleanup())
+
 describe('webAudioBackend (implementation-specific)', () => {
-  const contexts: BackendContext[] = []
-
-  const track = <T extends BackendContext>(ctx: T): T => {
-    contexts.push(ctx)
-    return ctx
-  }
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
   it('throws ScoreError for invalid offline params', () => {
     expect(() => webAudioBackend.createContext({ offline: { length: -1 } })).toThrow()
   })
 
-  it('accepts all noise types without error', () => {
-    const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
+  it('accepts all noise types', () => {
+    const ctx = h.context()
     expect(() => ctx.createNoise({ type: 'white' })).not.toThrow()
     expect(() => ctx.createNoise({ type: 'pink' })).not.toThrow()
     expect(() => ctx.createNoise({ type: 'brown' })).not.toThrow()

--- a/packages/core/tests/backend.test.ts
+++ b/packages/core/tests/backend.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { webAudioBackend } from '../src/backend/web-audio.js'
-import type { BackendProvider } from '../src/backend/types.js'
+import type { BackendContext, BackendProvider } from '../src/backend/types.js'
 
 describe('webAudioBackend', () => {
+  const contexts: BackendContext[] = []
+
+  const track = <T extends BackendContext>(ctx: T): T => {
+    contexts.push(ctx)
+    return ctx
+  }
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
   it('is a BackendProvider with name "web-audio"', () => {
     const backend: BackendProvider = webAudioBackend
     expect(backend.name).toBe('web-audio')
@@ -10,7 +21,7 @@ describe('webAudioBackend', () => {
   })
 
   it('creates an offline context', () => {
-    const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+    const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
     expect(ctx.sampleRate).toBe(44100)
     expect(ctx.destination).toBeDefined()
     expect(typeof ctx.createOscillator).toBe('function')
@@ -19,10 +30,10 @@ describe('webAudioBackend', () => {
   })
 
   it('respects custom sampleRate', () => {
-    const ctx = webAudioBackend.createContext({
+    const ctx = track(webAudioBackend.createContext({
       sampleRate: 48000,
       offline: { length: 48000 },
-    })
+    }))
     expect(ctx.sampleRate).toBe(48000)
   })
 
@@ -32,7 +43,7 @@ describe('webAudioBackend', () => {
 
   describe('createOscillator', () => {
     it('returns a node with start, stop, setFrequency, setDetune, connect, disconnect', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const osc = ctx.createOscillator()
       expect(typeof osc.start).toBe('function')
       expect(typeof osc.stop).toBe('function')
@@ -43,14 +54,14 @@ describe('webAudioBackend', () => {
     })
 
     it('start and stop do not throw', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const osc = ctx.createOscillator()
       expect(() => { osc.start(); }).not.toThrow()
       expect(() => { osc.stop(); }).not.toThrow()
     })
 
     it('connects to destination without throwing', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const osc = ctx.createOscillator()
       expect(() => { osc.connect(ctx.destination); }).not.toThrow()
     })
@@ -58,7 +69,7 @@ describe('webAudioBackend', () => {
 
   describe('createGain', () => {
     it('returns a node with gain, setGain, connect, disconnect', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const gain = ctx.createGain()
       expect(typeof gain.gain).toBe('number')
       expect(typeof gain.setGain).toBe('function')
@@ -67,13 +78,13 @@ describe('webAudioBackend', () => {
     })
 
     it('defaults to gain 1.0', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const gain = ctx.createGain()
       expect(gain.gain).toBeCloseTo(1.0)
     })
 
     it('respects initial gain prop', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const gain = ctx.createGain({ gain: 0.5 })
       expect(gain.gain).toBeCloseTo(0.5)
     })
@@ -81,7 +92,7 @@ describe('webAudioBackend', () => {
 
   describe('createNoise', () => {
     it('returns a node with start, stop, connect, disconnect', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const noise = ctx.createNoise()
       expect(typeof noise.start).toBe('function')
       expect(typeof noise.stop).toBe('function')
@@ -90,14 +101,14 @@ describe('webAudioBackend', () => {
     })
 
     it('start and stop do not throw', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       const noise = ctx.createNoise()
       expect(() => { noise.start(); }).not.toThrow()
       expect(() => { noise.stop(); }).not.toThrow()
     })
 
     it('accepts all noise types', () => {
-      const ctx = webAudioBackend.createContext({ offline: { length: 44100 } })
+      const ctx = track(webAudioBackend.createContext({ offline: { length: 44100 } }))
       expect(() => ctx.createNoise({ type: 'white' })).not.toThrow()
       expect(() => ctx.createNoise({ type: 'pink' })).not.toThrow()
       expect(() => ctx.createNoise({ type: 'brown' })).not.toThrow()

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
+import type { BackendContext } from '../src/backend/types.js'
 import { createMockBackendProvider } from './utils/audioTestUtils.js'
 
 describe('createAudioContext', () => {
-  const makeContext = (options?: Parameters<typeof createAudioContext>[0]) =>
-    createAudioContext({ offline: { length: 44100 }, ...options })
+  const contexts: BackendContext[] = []
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
+  const makeContext = (options?: Parameters<typeof createAudioContext>[0]) => {
+    const ctx = createAudioContext({ offline: { length: 44100 }, ...options })
+    contexts.push(ctx)
+    return ctx
+  }
 
   it('returns an object with currentTime, sampleRate, state, and destination', () => {
     const ctx = makeContext()
@@ -58,7 +68,7 @@ describe('createAudioContext', () => {
   })
 
   it('defaults to offline with length 44100 when no options', () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const ctx = makeContext()
     expect(ctx.sampleRate).toBe(44100)
   })
 

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,23 +1,13 @@
 import { describe, it, expect, afterAll } from 'vitest'
+import { useHarness } from './utils/harness.js'
 import { createAudioContext } from '../src/context.js'
-import type { BackendContext } from '../src/backend/types.js'
-import { createMockBackendProvider } from './utils/audioTestUtils.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('createAudioContext', () => {
-  const contexts: BackendContext[] = []
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  const makeContext = (options?: Parameters<typeof createAudioContext>[0]) => {
-    const ctx = createAudioContext({ offline: { length: 44100 }, ...options })
-    contexts.push(ctx)
-    return ctx
-  }
-
   it('returns an object with currentTime, sampleRate, state, and destination', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     expect(ctx).toHaveProperty('currentTime')
     expect(ctx).toHaveProperty('sampleRate')
     expect(ctx).toHaveProperty('state')
@@ -25,50 +15,45 @@ describe('createAudioContext', () => {
   })
 
   it('respects custom sampleRate option', () => {
-    const ctx = makeContext({ sampleRate: 48000 })
+    const ctx = h.context({ sampleRate: 48000 })
     expect(ctx.sampleRate).toBe(48000)
   })
 
   it('has a valid state string', () => {
-    const ctx = makeContext()
-    expect(typeof ctx.state).toBe('string')
+    const ctx = h.context()
     expect(['suspended', 'running', 'closed']).toContain(ctx.state)
   })
 
   it('currentTime is a number >= 0', () => {
-    const ctx = makeContext()
-    expect(typeof ctx.currentTime).toBe('number')
+    const ctx = h.context()
     expect(ctx.currentTime).toBeGreaterThanOrEqual(0)
   })
 
   it('sampleRate is a positive number', () => {
-    const ctx = makeContext()
-    expect(typeof ctx.sampleRate).toBe('number')
+    const ctx = h.context()
     expect(ctx.sampleRate).toBeGreaterThan(0)
   })
 
   it('destination exists', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     expect(ctx.destination).toBeDefined()
   })
 
   it('createGain() returns a node with gain property', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const gain = ctx.createGain()
-    expect(gain).toBeDefined()
     expect(gain).toHaveProperty('gain')
   })
 
   it('createOscillator() returns a node with start/stop', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const osc = ctx.createOscillator()
-    expect(osc).toBeDefined()
     expect(osc).toHaveProperty('start')
     expect(osc).toHaveProperty('stop')
   })
 
-  it('defaults to offline with length 44100 when no options', () => {
-    const ctx = makeContext()
+  it('defaults to sampleRate 44100', () => {
+    const ctx = h.context()
     expect(ctx.sampleRate).toBe(44100)
   })
 
@@ -77,16 +62,18 @@ describe('createAudioContext', () => {
   })
 
   it('uses custom backend when provided', () => {
-    const mockBackend = createMockBackendProvider()
+    const mockBackend = h.mockProvider()
     const ctx = createAudioContext({ backend: mockBackend })
     expect(mockBackend.contexts.length).toBe(1)
     expect(ctx.sampleRate).toBe(44100)
   })
 
-  it('defaults to web-audio backend when none specified', () => {
-    const ctx = makeContext()
+  it('backend context has all factory methods', () => {
+    const ctx = h.context()
     expect(ctx.createOscillator).toBeDefined()
     expect(ctx.createGain).toBeDefined()
     expect(ctx.createNoise).toBeDefined()
+    expect(ctx.decodeAudio).toBeDefined()
+    expect(ctx.createBufferSource).toBeDefined()
   })
 })

--- a/packages/core/tests/errorPropagation.test.ts
+++ b/packages/core/tests/errorPropagation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import type { BackendContext } from '../src/backend/types.js'
+import { webAudioBackend } from '../src/backend/web-audio.js'
+import { createAudioContext } from '../src/context.js'
+import { createNoise } from '../src/noise.js'
+import { decodeSample } from '../src/sample.js'
+import { createAudioGraph } from '../src/graph.js'
+import type { ScoreErrorInstance } from '../src/errors/ScoreError.js'
+
+// Verify all errors surface as ScoreError with context.fix
+
+const isScoreError = (err: unknown): err is ScoreErrorInstance =>
+  err instanceof Error && err.name === 'ScoreError' && 'context' in err
+
+const expectScoreError = (err: unknown): void => {
+  expect(isScoreError(err)).toBe(true)
+  if (isScoreError(err)) {
+    expect(err.context.fix).toBeDefined()
+    expect(typeof err.context.fix).toBe('string')
+  }
+}
+
+describe('Error propagation — all errors are ScoreError with fix', () => {
+  const contexts: BackendContext[] = []
+  const makeCtx = (): BackendContext => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    contexts.push(ctx)
+    return ctx
+  }
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
+  // --- Backend errors ---
+
+  it('webAudioBackend.createContext with invalid params throws ScoreError', () => {
+    try {
+      webAudioBackend.createContext({ offline: { length: -1 } })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+
+  it('createAudioContext with invalid params throws ScoreError', () => {
+    try {
+      createAudioContext({ offline: { length: -1 } })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+
+  // --- Noise validation ---
+
+  it('createNoise with invalid type throws ScoreError', () => {
+    const ctx = makeCtx()
+    try {
+      createNoise(ctx, { type: 'invalid' as never })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+
+  // --- Sample decode errors ---
+
+  it('decodeSample with empty data throws ScoreError', async () => {
+    const ctx = makeCtx()
+    try {
+      await decodeSample(ctx, new ArrayBuffer(0))
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+
+  it('decodeSample with corrupt data throws ScoreError', async () => {
+    const ctx = makeCtx()
+    const garbage = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer
+    try {
+      await decodeSample(ctx, garbage)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+
+  // --- Graph errors ---
+
+  it('graph.addNode with duplicate id throws ScoreError', () => {
+    const ctx = makeCtx()
+    const graph = createAudioGraph(ctx)
+    const gain1 = ctx.createGain()
+    const gain2 = ctx.createGain()
+    graph.addNode('g', gain1)
+    try {
+      graph.addNode('g', gain2)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+    graph.dispose()
+  })
+
+  it('graph.removeNode with unknown id throws ScoreError', () => {
+    const ctx = makeCtx()
+    const graph = createAudioGraph(ctx)
+    try {
+      graph.removeNode('nonexistent')
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+    graph.dispose()
+  })
+
+  it('graph.removeNode("destination") throws ScoreError', () => {
+    const ctx = makeCtx()
+    const graph = createAudioGraph(ctx)
+    try {
+      graph.removeNode('destination')
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+    graph.dispose()
+  })
+
+  it('graph.connect with unknown source throws ScoreError', () => {
+    const ctx = makeCtx()
+    const graph = createAudioGraph(ctx)
+    try {
+      graph.connect('unknown', 'destination')
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+    graph.dispose()
+  })
+
+  it('graph methods after dispose throw ScoreError', () => {
+    const ctx = makeCtx()
+    const graph = createAudioGraph(ctx)
+    graph.dispose()
+    const gain = ctx.createGain()
+
+    try {
+      graph.addNode('g', gain)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+
+    try {
+      graph.connect('destination', 'destination')
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expectScoreError(err)
+    }
+  })
+})

--- a/packages/core/tests/errorPropagation.test.ts
+++ b/packages/core/tests/errorPropagation.test.ts
@@ -1,163 +1,115 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import type { BackendContext } from '../src/backend/types.js'
+import { useHarness } from './utils/harness.js'
 import { webAudioBackend } from '../src/backend/web-audio.js'
 import { createAudioContext } from '../src/context.js'
 import { createNoise } from '../src/noise.js'
 import { decodeSample } from '../src/sample.js'
 import { createAudioGraph } from '../src/graph.js'
-import type { ScoreErrorInstance } from '../src/errors/ScoreError.js'
 
-// Verify all errors surface as ScoreError with context.fix
-
-const isScoreError = (err: unknown): err is ScoreErrorInstance =>
-  err instanceof Error && err.name === 'ScoreError' && 'context' in err
-
-const expectScoreError = (err: unknown): void => {
-  expect(isScoreError(err)).toBe(true)
-  if (isScoreError(err)) {
-    expect(err.context.fix).toBeDefined()
-    expect(typeof err.context.fix).toBe('string')
-  }
-}
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('Error propagation — all errors are ScoreError with fix', () => {
-  const contexts: BackendContext[] = []
-  const makeCtx = (): BackendContext => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
-    contexts.push(ctx)
-    return ctx
-  }
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  // --- Backend errors ---
-
-  it('webAudioBackend.createContext with invalid params throws ScoreError', () => {
+  it('webAudioBackend.createContext with invalid params', () => {
     try {
       webAudioBackend.createContext({ offline: { length: -1 } })
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 
-  it('createAudioContext with invalid params throws ScoreError', () => {
+  it('createAudioContext with invalid params', () => {
     try {
       createAudioContext({ offline: { length: -1 } })
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 
-  // --- Noise validation ---
-
-  it('createNoise with invalid type throws ScoreError', () => {
-    const ctx = makeCtx()
+  it('createNoise with invalid type', () => {
     try {
-      createNoise(ctx, { type: 'invalid' as never })
+      createNoise(h.context(), { type: 'invalid' as never })
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 
-  // --- Sample decode errors ---
-
-  it('decodeSample with empty data throws ScoreError', async () => {
-    const ctx = makeCtx()
+  it('decodeSample with empty data', async () => {
     try {
-      await decodeSample(ctx, new ArrayBuffer(0))
+      await decodeSample(h.context(), new ArrayBuffer(0))
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 
-  it('decodeSample with corrupt data throws ScoreError', async () => {
-    const ctx = makeCtx()
-    const garbage = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer
+  it('decodeSample with corrupt data', async () => {
     try {
-      await decodeSample(ctx, garbage)
+      await decodeSample(h.context(), new Uint8Array([0, 1, 2, 3, 4, 5]).buffer)
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 
-  // --- Graph errors ---
-
-  it('graph.addNode with duplicate id throws ScoreError', () => {
-    const ctx = makeCtx()
+  it('graph.addNode with duplicate id', () => {
+    const ctx = h.context()
     const graph = createAudioGraph(ctx)
-    const gain1 = ctx.createGain()
-    const gain2 = ctx.createGain()
-    graph.addNode('g', gain1)
+    graph.addNode('g', ctx.createGain())
     try {
-      graph.addNode('g', gain2)
+      graph.addNode('g', ctx.createGain())
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
     graph.dispose()
   })
 
-  it('graph.removeNode with unknown id throws ScoreError', () => {
-    const ctx = makeCtx()
-    const graph = createAudioGraph(ctx)
+  it('graph.removeNode with unknown id', () => {
+    const graph = createAudioGraph(h.context())
     try {
       graph.removeNode('nonexistent')
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
     graph.dispose()
   })
 
-  it('graph.removeNode("destination") throws ScoreError', () => {
-    const ctx = makeCtx()
-    const graph = createAudioGraph(ctx)
+  it('graph.removeNode("destination")', () => {
+    const graph = createAudioGraph(h.context())
     try {
       graph.removeNode('destination')
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
     graph.dispose()
   })
 
-  it('graph.connect with unknown source throws ScoreError', () => {
-    const ctx = makeCtx()
-    const graph = createAudioGraph(ctx)
+  it('graph.connect with unknown source', () => {
+    const graph = createAudioGraph(h.context())
     try {
       graph.connect('unknown', 'destination')
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
     graph.dispose()
   })
 
-  it('graph methods after dispose throw ScoreError', () => {
-    const ctx = makeCtx()
+  it('graph methods after dispose', () => {
+    const ctx = h.context()
     const graph = createAudioGraph(ctx)
     graph.dispose()
-    const gain = ctx.createGain()
-
     try {
-      graph.addNode('g', gain)
+      graph.addNode('g', ctx.createGain())
       expect.unreachable('should have thrown')
     } catch (err) {
-      expectScoreError(err)
-    }
-
-    try {
-      graph.connect('destination', 'destination')
-      expect.unreachable('should have thrown')
-    } catch (err) {
-      expectScoreError(err)
+      h.expectScoreError(err)
     }
   })
 })

--- a/packages/core/tests/gain.test.ts
+++ b/packages/core/tests/gain.test.ts
@@ -1,93 +1,65 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { createAudioContext } from '../src/context.js'
+import { useHarness } from './utils/harness.js'
 import { createGain } from '../src/gain.js'
-import type { BackendContext } from '../src/backend/types.js'
-import { createMockBackendContext } from './utils/audioTestUtils.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('createGain', () => {
-  const contexts: BackendContext[] = []
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  const makeContext = () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
-    contexts.push(ctx)
-    return ctx
-  }
-
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(g).toHaveProperty('connect')
-    expect(g).toHaveProperty('disconnect')
-    expect(g).toHaveProperty('dispose')
+    const g = createGain(h.context())
     expect(typeof g.connect).toBe('function')
     expect(typeof g.disconnect).toBe('function')
     expect(typeof g.dispose).toBe('function')
   })
 
   it('default gain is 1.0', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(g.gain).toBeCloseTo(1.0)
+    expect(createGain(h.context()).gain).toBeCloseTo(1.0)
   })
 
   it('respects custom gain prop', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx, { gain: 0.5 })
-    expect(g.gain).toBeCloseTo(0.5)
+    expect(createGain(h.context(), { gain: 0.5 }).gain).toBeCloseTo(0.5)
   })
 
-  it('setGain updates the gain value', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(() => { g.setGain(0.75); }).not.toThrow()
+  it('setGain does not throw', () => {
+    expect(() => { createGain(h.context()).setGain(0.75) }).not.toThrow()
   })
 
-  it('connect and disconnect work without throwing', () => {
-    const ctx = makeContext()
+  it('connect and disconnect work', () => {
+    const ctx = h.context()
     const g = createGain(ctx)
-    expect(() => g.connect(ctx.destination)).not.toThrow()
-    expect(() => g.disconnect()).not.toThrow()
+    expect(() => { g.connect(ctx.destination) }).not.toThrow()
+    expect(() => { g.disconnect() }).not.toThrow()
   })
 
   it('connect returns self for chaining', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const g = createGain(ctx)
-    const result = g.connect(ctx.destination)
-    expect(result).toBe(g)
+    expect(g.connect(ctx.destination)).toBe(g)
   })
 
   it('dispose cleans up without throwing', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const g = createGain(ctx)
     g.connect(ctx.destination)
-    expect(() => { g.dispose(); }).not.toThrow()
+    expect(() => { g.dispose() }).not.toThrow()
   })
 
-  it('gain property is readable', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(typeof g.gain).toBe('number')
+  it('gain property is a readable number', () => {
+    expect(typeof createGain(h.context()).gain).toBe('number')
   })
 
   it('disconnect when not connected does not throw', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(() => g.disconnect()).not.toThrow()
+    expect(() => { createGain(h.context()).disconnect() }).not.toThrow()
   })
 
   it('dispose when not connected does not throw', () => {
-    const ctx = makeContext()
-    const g = createGain(ctx)
-    expect(() => { g.dispose(); }).not.toThrow()
+    expect(() => { createGain(h.context()).dispose() }).not.toThrow()
   })
 
   it('delegates to backend createGain', () => {
-    const mockCtx = createMockBackendContext()
-    createGain(mockCtx, { gain: 0.7 })
-    expect(mockCtx.createdGains.length).toBe(1)
+    const mock = h.mockContext()
+    createGain(mock, { gain: 0.7 })
+    expect(mock.createdGains.length).toBe(1)
   })
 })

--- a/packages/core/tests/gain.test.ts
+++ b/packages/core/tests/gain.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
 import { createGain } from '../src/gain.js'
+import type { BackendContext } from '../src/backend/types.js'
 import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createGain', () => {
-  const makeContext = () =>
-    createAudioContext({ offline: { length: 44100 } })
+  const contexts: BackendContext[] = []
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
+  const makeContext = () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    contexts.push(ctx)
+    return ctx
+  }
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()

--- a/packages/core/tests/gain.test.ts
+++ b/packages/core/tests/gain.test.ts
@@ -33,7 +33,7 @@ describe('createGain', () => {
   it('setGain updates the gain value', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
-    expect(() => g.setGain(0.75)).not.toThrow()
+    expect(() => { g.setGain(0.75); }).not.toThrow()
   })
 
   it('connect and disconnect work without throwing', () => {
@@ -54,7 +54,7 @@ describe('createGain', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
     g.connect(ctx.destination)
-    expect(() => g.dispose()).not.toThrow()
+    expect(() => { g.dispose(); }).not.toThrow()
   })
 
   it('gain property is readable', () => {
@@ -72,7 +72,7 @@ describe('createGain', () => {
   it('dispose when not connected does not throw', () => {
     const ctx = makeContext()
     const g = createGain(ctx)
-    expect(() => g.dispose()).not.toThrow()
+    expect(() => { g.dispose(); }).not.toThrow()
   })
 
   it('delegates to backend createGain', () => {

--- a/packages/core/tests/graph.test.ts
+++ b/packages/core/tests/graph.test.ts
@@ -1,13 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
 import { createAudioGraph } from '../src/graph.js'
 import type { BackendContext } from '../src/backend/types.js'
 
 describe('createAudioGraph', () => {
+  const contexts: BackendContext[] = []
   let context: BackendContext
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
 
   beforeEach(() => {
     context = createAudioContext({ offline: { length: 44100 } })
+    contexts.push(context)
   })
 
   it('returns an AudioGraph object with the expected methods', () => {

--- a/packages/core/tests/graph.test.ts
+++ b/packages/core/tests/graph.test.ts
@@ -56,7 +56,7 @@ describe('createAudioGraph', () => {
       const gain1 = context.createGain()
       const gain2 = context.createGain()
       graph.addNode('gain', gain1)
-      expect(() => graph.addNode('gain', gain2)).toThrow()
+      expect(() => { graph.addNode('gain', gain2); }).toThrow()
       try {
         graph.addNode('gain', gain2)
       } catch (err) {
@@ -79,7 +79,7 @@ describe('createAudioGraph', () => {
 
     it('throws ScoreError when removing an unknown id', () => {
       const graph = createAudioGraph(context)
-      expect(() => graph.removeNode('nonexistent')).toThrow()
+      expect(() => { graph.removeNode('nonexistent'); }).toThrow()
       try {
         graph.removeNode('nonexistent')
       } catch (err) {
@@ -91,7 +91,7 @@ describe('createAudioGraph', () => {
 
     it('throws ScoreError when trying to remove "destination"', () => {
       const graph = createAudioGraph(context)
-      expect(() => graph.removeNode('destination')).toThrow()
+      expect(() => { graph.removeNode('destination'); }).toThrow()
       try {
         graph.removeNode('destination')
       } catch (err) {
@@ -126,7 +126,7 @@ describe('createAudioGraph', () => {
 
     it('throws ScoreError when sourceId is unknown', () => {
       const graph = createAudioGraph(context)
-      expect(() => graph.connect('unknown', 'destination')).toThrow()
+      expect(() => { graph.connect('unknown', 'destination'); }).toThrow()
       try {
         graph.connect('unknown', 'destination')
       } catch (err) {
@@ -140,7 +140,7 @@ describe('createAudioGraph', () => {
       const graph = createAudioGraph(context)
       const gain = context.createGain()
       graph.addNode('gain1', gain)
-      expect(() => graph.connect('gain1', 'unknown')).toThrow()
+      expect(() => { graph.connect('gain1', 'unknown'); }).toThrow()
       try {
         graph.connect('gain1', 'unknown')
       } catch (err) {
@@ -178,7 +178,7 @@ describe('createAudioGraph', () => {
 
     it('throws ScoreError when sourceId is unknown', () => {
       const graph = createAudioGraph(context)
-      expect(() => graph.disconnect('unknown')).toThrow()
+      expect(() => { graph.disconnect('unknown'); }).toThrow()
       try {
         graph.disconnect('unknown')
       } catch (err) {
@@ -239,7 +239,7 @@ describe('createAudioGraph', () => {
       const graph = createAudioGraph(context)
       graph.dispose()
       const gain = context.createGain()
-      expect(() => graph.addNode('gain1', gain)).toThrow()
+      expect(() => { graph.addNode('gain1', gain); }).toThrow()
       try {
         graph.addNode('gain1', gain)
       } catch (err) {
@@ -251,7 +251,7 @@ describe('createAudioGraph', () => {
     it('connect throws ScoreError after dispose', () => {
       const graph = createAudioGraph(context)
       graph.dispose()
-      expect(() => graph.connect('destination', 'destination')).toThrow()
+      expect(() => { graph.connect('destination', 'destination'); }).toThrow()
       try {
         graph.connect('destination', 'destination')
       } catch (err) {

--- a/packages/core/tests/graph.test.ts
+++ b/packages/core/tests/graph.test.ts
@@ -1,30 +1,13 @@
-import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { createAudioContext } from '../src/context.js'
+import { describe, it, expect, afterAll } from 'vitest'
+import { useHarness } from './utils/harness.js'
 import { createAudioGraph } from '../src/graph.js'
-import type { BackendContext } from '../src/backend/types.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('createAudioGraph', () => {
-  const contexts: BackendContext[] = []
-  let context: BackendContext
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  beforeEach(() => {
-    context = createAudioContext({ offline: { length: 44100 } })
-    contexts.push(context)
-  })
-
-  it('returns an AudioGraph object with the expected methods', () => {
-    const graph = createAudioGraph(context)
-    expect(graph).toHaveProperty('context')
-    expect(graph).toHaveProperty('addNode')
-    expect(graph).toHaveProperty('removeNode')
-    expect(graph).toHaveProperty('connect')
-    expect(graph).toHaveProperty('disconnect')
-    expect(graph).toHaveProperty('getNode')
-    expect(graph).toHaveProperty('dispose')
+  it('returns an AudioGraph with expected methods', () => {
+    const graph = createAudioGraph(h.context())
     expect(typeof graph.addNode).toBe('function')
     expect(typeof graph.removeNode).toBe('function')
     expect(typeof graph.connect).toBe('function')
@@ -34,85 +17,81 @@ describe('createAudioGraph', () => {
     graph.dispose()
   })
 
-  it('exposes the BackendContext as a readonly context property', () => {
-    const graph = createAudioGraph(context)
-    expect(graph.context).toBe(context)
+  it('exposes the BackendContext as context property', () => {
+    const ctx = h.context()
+    const graph = createAudioGraph(ctx)
+    expect(graph.context).toBe(ctx)
     graph.dispose()
   })
 
-  it('auto-registers "destination" node from context.destination', () => {
-    const graph = createAudioGraph(context)
-    const dest = graph.getNode('destination')
-    expect(dest).toBeDefined()
-    expect(dest).toBe(context.destination)
+  it('auto-registers "destination" node', () => {
+    const ctx = h.context()
+    const graph = createAudioGraph(ctx)
+    expect(graph.getNode('destination')).toBe(ctx.destination)
     graph.dispose()
   })
 
   describe('addNode', () => {
     it('registers a node retrievable via getNode', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      const gain = ctx.createGain()
       graph.addNode('gain1', gain)
       expect(graph.getNode('gain1')).toBe(gain)
       graph.dispose()
     })
 
-    it('throws ScoreError when adding a duplicate id', () => {
-      const graph = createAudioGraph(context)
-      const gain1 = context.createGain()
-      const gain2 = context.createGain()
-      graph.addNode('gain', gain1)
-      expect(() => { graph.addNode('gain', gain2); }).toThrow()
+    it('throws ScoreError for duplicate id', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain', ctx.createGain())
       try {
-        graph.addNode('gain', gain2)
+        graph.addNode('gain', ctx.createGain())
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
   })
 
   describe('removeNode', () => {
-    it('removes the node so getNode returns undefined', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
-      graph.addNode('gain1', gain)
+    it('removes the node', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
       graph.removeNode('gain1')
       expect(graph.getNode('gain1')).toBeUndefined()
       graph.dispose()
     })
 
-    it('throws ScoreError when removing an unknown id', () => {
-      const graph = createAudioGraph(context)
-      expect(() => { graph.removeNode('nonexistent'); }).toThrow()
+    it('throws ScoreError for unknown id', () => {
+      const graph = createAudioGraph(h.context())
       try {
         graph.removeNode('nonexistent')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
 
-    it('throws ScoreError when trying to remove "destination"', () => {
-      const graph = createAudioGraph(context)
-      expect(() => { graph.removeNode('destination'); }).toThrow()
+    it('throws ScoreError for "destination"', () => {
+      const graph = createAudioGraph(h.context())
       try {
         graph.removeNode('destination')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
 
     it('disconnects all connections involving the removed node', () => {
-      const graph = createAudioGraph(context)
-      const gain1 = context.createGain()
-      const gain2 = context.createGain()
-      graph.addNode('gain1', gain1)
-      graph.addNode('gain2', gain2)
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
+      graph.addNode('gain2', ctx.createGain())
       graph.connect('gain1', 'gain2')
       graph.connect('gain2', 'destination')
       graph.removeNode('gain2')
@@ -123,146 +102,127 @@ describe('createAudioGraph', () => {
 
   describe('connect', () => {
     it('connects nodes without throwing', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
-      graph.addNode('gain1', gain)
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
       graph.connect('gain1', 'destination')
       graph.dispose()
     })
 
-    it('throws ScoreError when sourceId is unknown', () => {
-      const graph = createAudioGraph(context)
-      expect(() => { graph.connect('unknown', 'destination'); }).toThrow()
+    it('throws ScoreError for unknown source', () => {
+      const graph = createAudioGraph(h.context())
       try {
         graph.connect('unknown', 'destination')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
 
-    it('throws ScoreError when destId is unknown', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
-      graph.addNode('gain1', gain)
-      expect(() => { graph.connect('gain1', 'unknown'); }).toThrow()
+    it('throws ScoreError for unknown destination', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
       try {
         graph.connect('gain1', 'unknown')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
   })
 
   describe('disconnect', () => {
-    it('disconnects a specific source-destination pair', () => {
-      const graph = createAudioGraph(context)
-      const gain1 = context.createGain()
-      const gain2 = context.createGain()
-      graph.addNode('gain1', gain1)
-      graph.addNode('gain2', gain2)
+    it('disconnects a specific pair', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
+      graph.addNode('gain2', ctx.createGain())
       graph.connect('gain1', 'gain2')
       graph.connect('gain1', 'destination')
       graph.disconnect('gain1', 'gain2')
       graph.dispose()
     })
 
-    it('disconnects all connections from source when destId is omitted', () => {
-      const graph = createAudioGraph(context)
-      const gain1 = context.createGain()
-      const gain2 = context.createGain()
-      graph.addNode('gain1', gain1)
-      graph.addNode('gain2', gain2)
+    it('disconnects all from source when destId omitted', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
+      graph.addNode('gain2', ctx.createGain())
       graph.connect('gain1', 'gain2')
       graph.connect('gain1', 'destination')
       graph.disconnect('gain1')
       graph.dispose()
     })
 
-    it('throws ScoreError when sourceId is unknown', () => {
-      const graph = createAudioGraph(context)
-      expect(() => { graph.disconnect('unknown'); }).toThrow()
+    it('throws ScoreError for unknown source', () => {
+      const graph = createAudioGraph(h.context())
       try {
         graph.disconnect('unknown')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
       graph.dispose()
     })
   })
 
   describe('fan-out and fan-in', () => {
-    it('supports fan-out: one source connects to multiple destinations', () => {
-      const graph = createAudioGraph(context)
-      const source = context.createGain()
-      const dest1 = context.createGain()
-      const dest2 = context.createGain()
-      graph.addNode('source', source)
-      graph.addNode('dest1', dest1)
-      graph.addNode('dest2', dest2)
-      graph.connect('source', 'dest1')
-      graph.connect('source', 'dest2')
+    it('one source to multiple destinations', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('src', ctx.createGain())
+      graph.addNode('d1', ctx.createGain())
+      graph.addNode('d2', ctx.createGain())
+      graph.connect('src', 'd1')
+      graph.connect('src', 'd2')
       graph.dispose()
     })
 
-    it('supports fan-in: multiple sources connect to one destination', () => {
-      const graph = createAudioGraph(context)
-      const src1 = context.createGain()
-      const src2 = context.createGain()
-      graph.addNode('src1', src1)
-      graph.addNode('src2', src2)
-      graph.connect('src1', 'destination')
-      graph.connect('src2', 'destination')
+    it('multiple sources to one destination', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('s1', ctx.createGain())
+      graph.addNode('s2', ctx.createGain())
+      graph.connect('s1', 'destination')
+      graph.connect('s2', 'destination')
       graph.dispose()
     })
   })
 
   describe('dispose', () => {
-    it('disconnects everything and clears the registry', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
-      graph.addNode('gain1', gain)
+    it('clears all nodes', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
+      graph.addNode('gain1', ctx.createGain())
       graph.connect('gain1', 'destination')
       graph.dispose()
       expect(graph.getNode('gain1')).toBeUndefined()
       expect(graph.getNode('destination')).toBeUndefined()
     })
 
-    it('getNode returns undefined for all nodes after dispose', () => {
-      const graph = createAudioGraph(context)
-      const gain = context.createGain()
-      graph.addNode('gain1', gain)
+    it('addNode throws after dispose', () => {
+      const ctx = h.context()
+      const graph = createAudioGraph(ctx)
       graph.dispose()
-      expect(graph.getNode('gain1')).toBeUndefined()
-      expect(graph.getNode('destination')).toBeUndefined()
-    })
-
-    it('addNode throws ScoreError after dispose', () => {
-      const graph = createAudioGraph(context)
-      graph.dispose()
-      const gain = context.createGain()
-      expect(() => { graph.addNode('gain1', gain); }).toThrow()
       try {
-        graph.addNode('gain1', gain)
+        graph.addNode('g', ctx.createGain())
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
     })
 
-    it('connect throws ScoreError after dispose', () => {
-      const graph = createAudioGraph(context)
+    it('connect throws after dispose', () => {
+      const graph = createAudioGraph(h.context())
       graph.dispose()
-      expect(() => { graph.connect('destination', 'destination'); }).toThrow()
       try {
         graph.connect('destination', 'destination')
+        expect.unreachable('should have thrown')
       } catch (err) {
-        expect((err as Error).name).toBe('ScoreError')
-        expect((err as { context: { fix: string } }).context.fix).toBeDefined()
+        h.expectScoreError(err)
       }
     })
   })

--- a/packages/core/tests/noise.test.ts
+++ b/packages/core/tests/noise.test.ts
@@ -1,93 +1,70 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { createAudioContext } from '../src/context.js'
+import { useHarness } from './utils/harness.js'
 import { createNoise } from '../src/noise.js'
-import type { BackendContext } from '../src/backend/types.js'
-import { createMockBackendContext } from './utils/audioTestUtils.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('createNoise', () => {
-  const contexts: BackendContext[] = []
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  const makeContext = () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
-    contexts.push(ctx)
-    return ctx
-  }
-
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
-    const ctx = makeContext()
-    const noise = createNoise(ctx)
-    expect(noise).toHaveProperty('connect')
-    expect(noise).toHaveProperty('disconnect')
-    expect(noise).toHaveProperty('dispose')
+    const noise = createNoise(h.context())
     expect(typeof noise.connect).toBe('function')
     expect(typeof noise.disconnect).toBe('function')
     expect(typeof noise.dispose).toBe('function')
   })
 
-  it('default type is white (has start and stop)', () => {
-    const ctx = makeContext()
-    const noise = createNoise(ctx)
-    expect(noise).toHaveProperty('start')
-    expect(noise).toHaveProperty('stop')
+  it('has start and stop methods', () => {
+    const noise = createNoise(h.context())
+    expect(typeof noise.start).toBe('function')
+    expect(typeof noise.stop).toBe('function')
   })
 
-  it('accepts pink noise type without error', () => {
-    const ctx = makeContext()
-    expect(() => createNoise(ctx, { type: 'pink' })).not.toThrow()
+  it('accepts pink noise type', () => {
+    expect(() => createNoise(h.context(), { type: 'pink' })).not.toThrow()
   })
 
-  it('accepts brown noise type without error', () => {
-    const ctx = makeContext()
-    expect(() => createNoise(ctx, { type: 'brown' })).not.toThrow()
+  it('accepts brown noise type', () => {
+    expect(() => createNoise(h.context(), { type: 'brown' })).not.toThrow()
   })
 
   it('invalid type throws ScoreError', () => {
-    const ctx = makeContext()
-    expect(() => createNoise(ctx, { type: 'invalid' as never })).toThrow('Invalid noise type')
+    expect(() => createNoise(h.context(), { type: 'invalid' as never })).toThrow('Invalid noise type')
   })
 
   it('start() does not throw', () => {
-    const ctx = makeContext()
-    const noise = createNoise(ctx)
-    expect(() => { noise.start(); }).not.toThrow()
+    expect(() => { createNoise(h.context()).start() }).not.toThrow()
   })
 
   it('stop() after start does not throw', () => {
-    const ctx = makeContext()
-    const noise = createNoise(ctx)
+    const noise = createNoise(h.context())
     noise.start()
-    expect(() => { noise.stop(); }).not.toThrow()
+    expect(() => { noise.stop() }).not.toThrow()
   })
 
-  it('connect and disconnect work without throwing', () => {
-    const ctx = makeContext()
+  it('connect and disconnect work', () => {
+    const ctx = h.context()
     const noise = createNoise(ctx)
-    expect(() => noise.connect(ctx.destination)).not.toThrow()
-    expect(() => noise.disconnect()).not.toThrow()
+    expect(() => { noise.connect(ctx.destination) }).not.toThrow()
+    expect(() => { noise.disconnect() }).not.toThrow()
   })
 
   it('connect returns self for chaining', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const noise = createNoise(ctx)
-    const result = noise.connect(ctx.destination)
-    expect(result).toBe(noise)
+    expect(noise.connect(ctx.destination)).toBe(noise)
   })
 
   it('dispose cleans up without throwing', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const noise = createNoise(ctx)
     noise.start()
     noise.connect(ctx.destination)
-    expect(() => { noise.dispose(); }).not.toThrow()
+    expect(() => { noise.dispose() }).not.toThrow()
   })
 
   it('delegates to backend createNoise', () => {
-    const mockCtx = createMockBackendContext()
-    createNoise(mockCtx, { type: 'pink' })
-    expect(mockCtx.createdNoises.length).toBe(1)
+    const mock = h.mockContext()
+    createNoise(mock, { type: 'pink' })
+    expect(mock.createdNoises.length).toBe(1)
   })
 })

--- a/packages/core/tests/noise.test.ts
+++ b/packages/core/tests/noise.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
 import { createNoise } from '../src/noise.js'
+import type { BackendContext } from '../src/backend/types.js'
 import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createNoise', () => {
-  const makeContext = () =>
-    createAudioContext({ offline: { length: 44100 } })
+  const contexts: BackendContext[] = []
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
+  const makeContext = () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    contexts.push(ctx)
+    return ctx
+  }
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()

--- a/packages/core/tests/noise.test.ts
+++ b/packages/core/tests/noise.test.ts
@@ -43,14 +43,14 @@ describe('createNoise', () => {
   it('start() does not throw', () => {
     const ctx = makeContext()
     const noise = createNoise(ctx)
-    expect(() => noise.start()).not.toThrow()
+    expect(() => { noise.start(); }).not.toThrow()
   })
 
   it('stop() after start does not throw', () => {
     const ctx = makeContext()
     const noise = createNoise(ctx)
     noise.start()
-    expect(() => noise.stop()).not.toThrow()
+    expect(() => { noise.stop(); }).not.toThrow()
   })
 
   it('connect and disconnect work without throwing', () => {
@@ -72,7 +72,7 @@ describe('createNoise', () => {
     const noise = createNoise(ctx)
     noise.start()
     noise.connect(ctx.destination)
-    expect(() => noise.dispose()).not.toThrow()
+    expect(() => { noise.dispose(); }).not.toThrow()
   })
 
   it('delegates to backend createNoise', () => {

--- a/packages/core/tests/oscillator.test.ts
+++ b/packages/core/tests/oscillator.test.ts
@@ -46,26 +46,26 @@ describe('createOscillator', () => {
   it('start() does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
-    expect(() => osc.start()).not.toThrow()
+    expect(() => { osc.start(); }).not.toThrow()
   })
 
   it('stop() after start does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
     osc.start()
-    expect(() => osc.stop()).not.toThrow()
+    expect(() => { osc.stop(); }).not.toThrow()
   })
 
   it('setFrequency does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
-    expect(() => osc.setFrequency(660)).not.toThrow()
+    expect(() => { osc.setFrequency(660); }).not.toThrow()
   })
 
   it('setDetune does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
-    expect(() => osc.setDetune(50)).not.toThrow()
+    expect(() => { osc.setDetune(50); }).not.toThrow()
   })
 
   it('connect and disconnect work without throwing', () => {
@@ -87,7 +87,7 @@ describe('createOscillator', () => {
     const osc = createOscillator(ctx, {})
     osc.start()
     osc.connect(ctx.destination)
-    expect(() => osc.dispose()).not.toThrow()
+    expect(() => { osc.dispose(); }).not.toThrow()
   })
 
   it('disconnect when not connected does not throw', () => {
@@ -99,7 +99,7 @@ describe('createOscillator', () => {
   it('dispose when never started does not throw', () => {
     const ctx = makeContext()
     const osc = createOscillator(ctx, {})
-    expect(() => osc.dispose()).not.toThrow()
+    expect(() => { osc.dispose(); }).not.toThrow()
   })
 
   it('delegates to backend createOscillator with props', () => {

--- a/packages/core/tests/oscillator.test.ts
+++ b/packages/core/tests/oscillator.test.ts
@@ -1,120 +1,93 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { createAudioContext } from '../src/context.js'
+import { useHarness } from './utils/harness.js'
 import { createOscillator } from '../src/oscillator.js'
-import type { BackendContext } from '../src/backend/types.js'
-import { createMockBackendContext } from './utils/audioTestUtils.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
 
 describe('createOscillator', () => {
-  const contexts: BackendContext[] = []
-
-  afterAll(async () => {
-    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-  })
-
-  const makeContext = () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
-    contexts.push(ctx)
-    return ctx
-  }
-
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(osc).toHaveProperty('connect')
-    expect(osc).toHaveProperty('disconnect')
-    expect(osc).toHaveProperty('dispose')
+    const osc = createOscillator(h.context(), {})
     expect(typeof osc.connect).toBe('function')
     expect(typeof osc.disconnect).toBe('function')
     expect(typeof osc.dispose).toBe('function')
   })
 
   it('has start and stop methods', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(osc).toHaveProperty('start')
-    expect(osc).toHaveProperty('stop')
+    const osc = createOscillator(h.context(), {})
+    expect(typeof osc.start).toBe('function')
+    expect(typeof osc.stop).toBe('function')
   })
 
-  it('respects custom type prop', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, { type: 'sawtooth' })
-    expect(osc).toBeDefined()
+  it('has setFrequency and setDetune methods', () => {
+    const osc = createOscillator(h.context(), {})
+    expect(typeof osc.setFrequency).toBe('function')
+    expect(typeof osc.setDetune).toBe('function')
   })
 
-  it('respects custom frequency prop', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, { frequency: 880 })
-    expect(osc).toBeDefined()
+  it('accepts custom type prop', () => {
+    expect(() => createOscillator(h.context(), { type: 'sawtooth' })).not.toThrow()
   })
 
-  it('respects detune prop', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, { detune: 100 })
-    expect(osc).toBeDefined()
+  it('accepts custom frequency prop', () => {
+    expect(() => createOscillator(h.context(), { frequency: 880 })).not.toThrow()
+  })
+
+  it('accepts detune prop', () => {
+    expect(() => createOscillator(h.context(), { detune: 100 })).not.toThrow()
   })
 
   it('start() does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(() => { osc.start(); }).not.toThrow()
+    const osc = createOscillator(h.context(), {})
+    expect(() => { osc.start() }).not.toThrow()
   })
 
   it('stop() after start does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
+    const osc = createOscillator(h.context(), {})
     osc.start()
-    expect(() => { osc.stop(); }).not.toThrow()
+    expect(() => { osc.stop() }).not.toThrow()
   })
 
   it('setFrequency does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(() => { osc.setFrequency(660); }).not.toThrow()
+    expect(() => { createOscillator(h.context(), {}).setFrequency(660) }).not.toThrow()
   })
 
   it('setDetune does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(() => { osc.setDetune(50); }).not.toThrow()
+    expect(() => { createOscillator(h.context(), {}).setDetune(50) }).not.toThrow()
   })
 
-  it('connect and disconnect work without throwing', () => {
-    const ctx = makeContext()
+  it('connect and disconnect work', () => {
+    const ctx = h.context()
     const osc = createOscillator(ctx, {})
-    expect(() => osc.connect(ctx.destination)).not.toThrow()
-    expect(() => osc.disconnect()).not.toThrow()
+    expect(() => { osc.connect(ctx.destination) }).not.toThrow()
+    expect(() => { osc.disconnect() }).not.toThrow()
   })
 
   it('connect returns self for chaining', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const osc = createOscillator(ctx, {})
-    const result = osc.connect(ctx.destination)
-    expect(result).toBe(osc)
+    expect(osc.connect(ctx.destination)).toBe(osc)
   })
 
   it('dispose cleans up without throwing', () => {
-    const ctx = makeContext()
+    const ctx = h.context()
     const osc = createOscillator(ctx, {})
     osc.start()
     osc.connect(ctx.destination)
-    expect(() => { osc.dispose(); }).not.toThrow()
+    expect(() => { osc.dispose() }).not.toThrow()
   })
 
   it('disconnect when not connected does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(() => osc.disconnect()).not.toThrow()
+    expect(() => { createOscillator(h.context(), {}).disconnect() }).not.toThrow()
   })
 
   it('dispose when never started does not throw', () => {
-    const ctx = makeContext()
-    const osc = createOscillator(ctx, {})
-    expect(() => { osc.dispose(); }).not.toThrow()
+    expect(() => { createOscillator(h.context(), {}).dispose() }).not.toThrow()
   })
 
-  it('delegates to backend createOscillator with props', () => {
-    const mockCtx = createMockBackendContext()
-    createOscillator(mockCtx, { type: 'square', frequency: 220, detune: 5 })
-    expect(mockCtx.createdOscillators.length).toBe(1)
+  it('delegates to backend createOscillator', () => {
+    const mock = h.mockContext()
+    createOscillator(mock, { type: 'square', frequency: 220 })
+    expect(mock.createdOscillators.length).toBe(1)
   })
 })

--- a/packages/core/tests/oscillator.test.ts
+++ b/packages/core/tests/oscillator.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
 import { createOscillator } from '../src/oscillator.js'
+import type { BackendContext } from '../src/backend/types.js'
 import { createMockBackendContext } from './utils/audioTestUtils.js'
 
 describe('createOscillator', () => {
-  const makeContext = () =>
-    createAudioContext({ offline: { length: 44100 } })
+  const contexts: BackendContext[] = []
+
+  afterAll(async () => {
+    await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+  })
+
+  const makeContext = () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    contexts.push(ctx)
+    return ctx
+  }
 
   it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
     const ctx = makeContext()

--- a/packages/core/tests/sample.test.ts
+++ b/packages/core/tests/sample.test.ts
@@ -1,12 +1,25 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { createAudioContext } from '../src/context.js'
 import { decodeSample, createSamplePlayer } from '../src/sample.js'
+import type { BackendContext } from '../src/backend/types.js'
 import { createMockBackendContext, createMockBuffer } from './utils/audioTestUtils.js'
 import { createTestWav } from './utils/createTestWav.js'
 
+const contexts: BackendContext[] = []
+
+afterAll(async () => {
+  await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+})
+
+const trackCtx = () => {
+  const ctx = createAudioContext({ offline: { length: 44100 } })
+  contexts.push(ctx)
+  return ctx
+}
+
 describe('decodeSample', () => {
   it('decodes valid audio data via backend', async () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const ctx = trackCtx()
     const wav = createTestWav()
     const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
     const buffer = await decodeSample(ctx, arrayBuffer)
@@ -18,7 +31,7 @@ describe('decodeSample', () => {
   })
 
   it('throws ScoreError for empty ArrayBuffer', async () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const ctx = trackCtx()
     await expect(decodeSample(ctx, new ArrayBuffer(0))).rejects.toThrow('Cannot decode empty audio data')
   })
 
@@ -31,7 +44,7 @@ describe('decodeSample', () => {
   })
 
   it('preserves sample rate from source file', async () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const ctx = trackCtx()
     const wav = createTestWav({ sampleRate: 44100 })
     const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
     const buffer = await decodeSample(ctx, arrayBuffer)
@@ -140,7 +153,7 @@ describe('createSamplePlayer', () => {
   })
 
   it('integration: decode and play with real backend', async () => {
-    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const ctx = trackCtx()
     const wav = createTestWav()
     const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
     const buffer = await decodeSample(ctx, arrayBuffer)

--- a/packages/core/tests/sample.test.ts
+++ b/packages/core/tests/sample.test.ts
@@ -1,29 +1,19 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { createAudioContext } from '../src/context.js'
+import { useHarness } from './utils/harness.js'
 import { decodeSample, createSamplePlayer } from '../src/sample.js'
-import type { BackendContext } from '../src/backend/types.js'
-import { createMockBackendContext, createMockBuffer } from './utils/audioTestUtils.js'
 import { createTestWav } from './utils/createTestWav.js'
 
-const contexts: BackendContext[] = []
+const h = useHarness()
+afterAll(() => h.cleanup())
 
-afterAll(async () => {
-  await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
-})
-
-const trackCtx = () => {
-  const ctx = createAudioContext({ offline: { length: 44100 } })
-  contexts.push(ctx)
-  return ctx
+const testWavData = (): ArrayBuffer => {
+  const wav = createTestWav()
+  return wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
 }
 
 describe('decodeSample', () => {
   it('decodes valid audio data via backend', async () => {
-    const ctx = trackCtx()
-    const wav = createTestWav()
-    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
-    const buffer = await decodeSample(ctx, arrayBuffer)
-    expect(buffer).toBeDefined()
+    const buffer = await decodeSample(h.context(), testWavData())
     expect(buffer.duration).toBeGreaterThan(0)
     expect(buffer.sampleRate).toBeGreaterThan(0)
     expect(buffer.numberOfChannels).toBeGreaterThanOrEqual(1)
@@ -31,32 +21,25 @@ describe('decodeSample', () => {
   })
 
   it('throws ScoreError for empty ArrayBuffer', async () => {
-    const ctx = trackCtx()
-    await expect(decodeSample(ctx, new ArrayBuffer(0))).rejects.toThrow('Cannot decode empty audio data')
+    await expect(decodeSample(h.context(), new ArrayBuffer(0)))
+      .rejects.toThrow('Cannot decode empty audio data')
   })
 
   it('delegates to backend decodeAudio', async () => {
-    const mockCtx = createMockBackendContext()
-    const wav = createTestWav()
-    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
-    const buffer = await decodeSample(mockCtx, arrayBuffer)
+    const mock = h.mockContext()
+    const buffer = await decodeSample(mock, testWavData())
     expect(buffer.duration).toBe(1.0) // mock default
   })
 
-  it('preserves sample rate from source file', async () => {
-    const ctx = trackCtx()
-    const wav = createTestWav({ sampleRate: 44100 })
-    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
-    const buffer = await decodeSample(ctx, arrayBuffer)
+  it('preserves sample rate from source', async () => {
+    const buffer = await decodeSample(h.context(), testWavData())
     expect(buffer.sampleRate).toBe(44100)
   })
 })
 
 describe('createSamplePlayer', () => {
-  it('returns an AudioComponent with start, stop, setPlaybackRate, setGain', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
+  it('has start, stop, setPlaybackRate, setGain, connect, disconnect, dispose', () => {
+    const player = createSamplePlayer(h.mockContext(), h.mockBuffer())
     expect(typeof player.start).toBe('function')
     expect(typeof player.stop).toBe('function')
     expect(typeof player.setPlaybackRate).toBe('function')
@@ -67,100 +50,81 @@ describe('createSamplePlayer', () => {
   })
 
   it('exposes the buffer reference', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer({ duration: 2.5 })
-    const player = createSamplePlayer(mockCtx, buffer)
-    expect(player.buffer).toBe(buffer)
+    const buf = h.mockBuffer({ duration: 2.5 })
+    const player = createSamplePlayer(h.mockContext(), buf)
+    expect(player.buffer).toBe(buf)
     expect(player.buffer.duration).toBe(2.5)
   })
 
   it('start creates a buffer source via backend', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
+    const mock = h.mockContext()
+    const player = createSamplePlayer(mock, h.mockBuffer())
     player.start()
-    expect(mockCtx.createdBufferSources.length).toBe(1)
+    expect(mock.createdBufferSources.length).toBe(1)
   })
 
-  it('each start creates a new buffer source (one-shot pattern)', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
+  it('each start creates a new source (one-shot pattern)', () => {
+    const mock = h.mockContext()
+    const player = createSamplePlayer(mock, h.mockBuffer())
     player.start()
     player.start()
-    expect(mockCtx.createdBufferSources.length).toBe(2)
+    expect(mock.createdBufferSources.length).toBe(2)
   })
 
   it('stop does not throw when nothing is playing', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
-    expect(() => { player.stop(); }).not.toThrow()
+    expect(() => { createSamplePlayer(h.mockContext(), h.mockBuffer()).stop() }).not.toThrow()
   })
 
   it('stop after start does not throw', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
+    const player = createSamplePlayer(h.mockContext(), h.mockBuffer())
     player.start()
-    expect(() => { player.stop(); }).not.toThrow()
+    expect(() => { player.stop() }).not.toThrow()
   })
 
   it('connect returns self for chaining', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
-    const result = player.connect(mockCtx.destination)
-    expect(result).toBe(player)
+    const mock = h.mockContext()
+    const player = createSamplePlayer(mock, h.mockBuffer())
+    expect(player.connect(mock.destination)).toBe(player)
   })
 
   it('disconnect does not throw', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
-    player.connect(mockCtx.destination)
-    expect(() => player.disconnect()).not.toThrow()
+    const mock = h.mockContext()
+    const player = createSamplePlayer(mock, h.mockBuffer())
+    player.connect(mock.destination)
+    expect(() => { player.disconnect() }).not.toThrow()
   })
 
   it('dispose cleans up without throwing', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
+    const mock = h.mockContext()
+    const player = createSamplePlayer(mock, h.mockBuffer())
     player.start()
-    player.connect(mockCtx.destination)
-    expect(() => { player.dispose(); }).not.toThrow()
+    player.connect(mock.destination)
+    expect(() => { player.dispose() }).not.toThrow()
   })
 
   it('dispose when never started does not throw', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    const player = createSamplePlayer(mockCtx, buffer)
-    expect(() => { player.dispose(); }).not.toThrow()
+    expect(() => { createSamplePlayer(h.mockContext(), h.mockBuffer()).dispose() }).not.toThrow()
   })
 
   it('creates gain node for volume control', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    createSamplePlayer(mockCtx, buffer, { gain: 0.5 })
-    expect(mockCtx.createdGains.length).toBe(1)
+    const mock = h.mockContext()
+    createSamplePlayer(mock, h.mockBuffer(), { gain: 0.5 })
+    expect(mock.createdGains.length).toBe(1)
   })
 
   it('respects custom gain prop', () => {
-    const mockCtx = createMockBackendContext()
-    const buffer = createMockBuffer()
-    createSamplePlayer(mockCtx, buffer, { gain: 0.7 })
-    expect(mockCtx.createdGains[0].gain).toBeCloseTo(0.7)
+    const mock = h.mockContext()
+    createSamplePlayer(mock, h.mockBuffer(), { gain: 0.7 })
+    expect(mock.createdGains[0].gain).toBeCloseTo(0.7)
   })
 
   it('integration: decode and play with real backend', async () => {
-    const ctx = trackCtx()
-    const wav = createTestWav()
-    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
-    const buffer = await decodeSample(ctx, arrayBuffer)
+    const ctx = h.context()
+    const buffer = await decodeSample(ctx, testWavData())
     const player = createSamplePlayer(ctx, buffer)
     player.connect(ctx.destination)
-    expect(() => { player.start(); }).not.toThrow()
-    expect(() => { player.stop(); }).not.toThrow()
-    expect(() => { player.dispose(); }).not.toThrow()
+    expect(() => { player.start() }).not.toThrow()
+    expect(() => { player.stop() }).not.toThrow()
+    expect(() => { player.dispose() }).not.toThrow()
   })
 })

--- a/packages/core/tests/sample.test.ts
+++ b/packages/core/tests/sample.test.ts
@@ -8,7 +8,7 @@ afterAll(() => h.cleanup())
 
 const testWavData = (): ArrayBuffer => {
   const wav = createTestWav()
-  return wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
+  return new Uint8Array(wav).buffer
 }
 
 describe('decodeSample', () => {
@@ -115,7 +115,7 @@ describe('createSamplePlayer', () => {
   it('respects custom gain prop', () => {
     const mock = h.mockContext()
     createSamplePlayer(mock, h.mockBuffer(), { gain: 0.7 })
-    expect(mock.createdGains[0].gain).toBeCloseTo(0.7)
+    expect(mock.createdGains[0]?.gain).toBeCloseTo(0.7)
   })
 
   it('integration: decode and play with real backend', async () => {

--- a/packages/core/tests/sample.test.ts
+++ b/packages/core/tests/sample.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { createAudioContext } from '../src/context.js'
+import { decodeSample, createSamplePlayer } from '../src/sample.js'
+import { createMockBackendContext, createMockBuffer } from './utils/audioTestUtils.js'
+import { createTestWav } from './utils/createTestWav.js'
+
+describe('decodeSample', () => {
+  it('decodes valid audio data via backend', async () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const wav = createTestWav()
+    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
+    const buffer = await decodeSample(ctx, arrayBuffer)
+    expect(buffer).toBeDefined()
+    expect(buffer.duration).toBeGreaterThan(0)
+    expect(buffer.sampleRate).toBeGreaterThan(0)
+    expect(buffer.numberOfChannels).toBeGreaterThanOrEqual(1)
+    expect(buffer.length).toBeGreaterThan(0)
+  })
+
+  it('throws ScoreError for empty ArrayBuffer', async () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    await expect(decodeSample(ctx, new ArrayBuffer(0))).rejects.toThrow('Cannot decode empty audio data')
+  })
+
+  it('delegates to backend decodeAudio', async () => {
+    const mockCtx = createMockBackendContext()
+    const wav = createTestWav()
+    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
+    const buffer = await decodeSample(mockCtx, arrayBuffer)
+    expect(buffer.duration).toBe(1.0) // mock default
+  })
+
+  it('preserves sample rate from source file', async () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const wav = createTestWav({ sampleRate: 44100 })
+    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
+    const buffer = await decodeSample(ctx, arrayBuffer)
+    expect(buffer.sampleRate).toBe(44100)
+  })
+})
+
+describe('createSamplePlayer', () => {
+  it('returns an AudioComponent with start, stop, setPlaybackRate, setGain', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    expect(typeof player.start).toBe('function')
+    expect(typeof player.stop).toBe('function')
+    expect(typeof player.setPlaybackRate).toBe('function')
+    expect(typeof player.setGain).toBe('function')
+    expect(typeof player.connect).toBe('function')
+    expect(typeof player.disconnect).toBe('function')
+    expect(typeof player.dispose).toBe('function')
+  })
+
+  it('exposes the buffer reference', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer({ duration: 2.5 })
+    const player = createSamplePlayer(mockCtx, buffer)
+    expect(player.buffer).toBe(buffer)
+    expect(player.buffer.duration).toBe(2.5)
+  })
+
+  it('start creates a buffer source via backend', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    player.start()
+    expect(mockCtx.createdBufferSources.length).toBe(1)
+  })
+
+  it('each start creates a new buffer source (one-shot pattern)', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    player.start()
+    player.start()
+    expect(mockCtx.createdBufferSources.length).toBe(2)
+  })
+
+  it('stop does not throw when nothing is playing', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    expect(() => { player.stop(); }).not.toThrow()
+  })
+
+  it('stop after start does not throw', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    player.start()
+    expect(() => { player.stop(); }).not.toThrow()
+  })
+
+  it('connect returns self for chaining', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    const result = player.connect(mockCtx.destination)
+    expect(result).toBe(player)
+  })
+
+  it('disconnect does not throw', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    player.connect(mockCtx.destination)
+    expect(() => player.disconnect()).not.toThrow()
+  })
+
+  it('dispose cleans up without throwing', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    player.start()
+    player.connect(mockCtx.destination)
+    expect(() => { player.dispose(); }).not.toThrow()
+  })
+
+  it('dispose when never started does not throw', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    const player = createSamplePlayer(mockCtx, buffer)
+    expect(() => { player.dispose(); }).not.toThrow()
+  })
+
+  it('creates gain node for volume control', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    createSamplePlayer(mockCtx, buffer, { gain: 0.5 })
+    expect(mockCtx.createdGains.length).toBe(1)
+  })
+
+  it('respects custom gain prop', () => {
+    const mockCtx = createMockBackendContext()
+    const buffer = createMockBuffer()
+    createSamplePlayer(mockCtx, buffer, { gain: 0.7 })
+    expect(mockCtx.createdGains[0].gain).toBeCloseTo(0.7)
+  })
+
+  it('integration: decode and play with real backend', async () => {
+    const ctx = createAudioContext({ offline: { length: 44100 } })
+    const wav = createTestWav()
+    const arrayBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)
+    const buffer = await decodeSample(ctx, arrayBuffer)
+    const player = createSamplePlayer(ctx, buffer)
+    player.connect(ctx.destination)
+    expect(() => { player.start(); }).not.toThrow()
+    expect(() => { player.stop(); }).not.toThrow()
+    expect(() => { player.dispose(); }).not.toThrow()
+  })
+})

--- a/packages/core/tests/utils/audioTestUtils.ts
+++ b/packages/core/tests/utils/audioTestUtils.ts
@@ -2,6 +2,8 @@
 // Used across all @score/* package tests — no real AudioContext required
 
 import type {
+  BackendBuffer,
+  BackendBufferSourceNode,
   BackendContext,
   BackendGainNode,
   BackendNode,
@@ -32,10 +34,16 @@ export type MockBackendNoiseNode = MockBackendNode & BackendNoiseNode & {
   readonly stopCalls: Array<{ readonly time: number | undefined }>
 }
 
+export type MockBackendBufferSourceNode = MockBackendNode & BackendBufferSourceNode & {
+  readonly startCalls: Array<{ readonly time: number | undefined; readonly offset: number | undefined; readonly duration: number | undefined }>
+  readonly stopCalls: Array<{ readonly time: number | undefined }>
+}
+
 export type MockBackendContext = BackendContext & {
   readonly createdOscillators: Array<MockBackendOscillatorNode>
   readonly createdGains: Array<MockBackendGainNode>
   readonly createdNoises: Array<MockBackendNoiseNode>
+  readonly createdBufferSources: Array<MockBackendBufferSourceNode>
 }
 
 // --- Factory functions ---
@@ -93,10 +101,43 @@ export const createMockNoiseNode = (): MockBackendNoiseNode => {
   }
 }
 
+export const createMockBuffer = (options?: {
+  duration?: number
+  length?: number
+  sampleRate?: number
+  numberOfChannels?: number
+}): BackendBuffer => ({
+  duration: options?.duration ?? 1.0,
+  length: options?.length ?? 44100,
+  sampleRate: options?.sampleRate ?? 44100,
+  numberOfChannels: options?.numberOfChannels ?? 1,
+})
+
+export const createMockBufferSourceNode = (): MockBackendBufferSourceNode => {
+  const base = createMockBackendNode()
+  const startCalls: MockBackendBufferSourceNode['startCalls'] = []
+  const stopCalls: Array<{ readonly time: number | undefined }> = []
+  let loopState = false
+
+  return {
+    ...base,
+    startCalls,
+    stopCalls,
+    get loop() { return loopState },
+    setLoop: (loop: boolean) => { loopState = loop },
+    setPlaybackRate: (_rate: number, _time?: number) => {},
+    start: (time?: number, offset?: number, duration?: number) => {
+      startCalls.push({ time, offset, duration })
+    },
+    stop: (time?: number) => { stopCalls.push({ time }) },
+  }
+}
+
 export const createMockBackendContext = (): MockBackendContext => {
   const createdOscillators: Array<MockBackendOscillatorNode> = []
   const createdGains: Array<MockBackendGainNode> = []
   const createdNoises: Array<MockBackendNoiseNode> = []
+  const createdBufferSources: Array<MockBackendBufferSourceNode> = []
 
   return {
     currentTime: 0,
@@ -106,8 +147,9 @@ export const createMockBackendContext = (): MockBackendContext => {
     createdOscillators,
     createdGains,
     createdNoises,
+    createdBufferSources,
 
-    createOscillator: (props) => {
+    createOscillator: (_props) => {
       const node = createMockOscillatorNode()
       createdOscillators.push(node)
       return node
@@ -119,9 +161,17 @@ export const createMockBackendContext = (): MockBackendContext => {
       return node
     },
 
-    createNoise: (props) => {
+    createNoise: (_props) => {
       const node = createMockNoiseNode()
       createdNoises.push(node)
+      return node
+    },
+
+    decodeAudio: (_data: ArrayBuffer) => Promise.resolve(createMockBuffer()),
+
+    createBufferSource: (_buffer, _props) => {
+      const node = createMockBufferSourceNode()
+      createdBufferSources.push(node)
       return node
     },
 

--- a/packages/core/tests/utils/backendContract.ts
+++ b/packages/core/tests/utils/backendContract.ts
@@ -1,0 +1,255 @@
+// Backend contract test suite — any BackendProvider implementation must pass these
+// Run with: runBackendContractTests(myBackend) inside a describe block
+
+import { describe, it, expect, afterAll } from 'vitest'
+import type { BackendContext, BackendProvider } from '../../src/backend/types.js'
+
+export const runBackendContractTests = (provider: BackendProvider) => {
+  const contexts: BackendContext[] = []
+  const makeCtx = (): BackendContext => {
+    const ctx = provider.createContext({ offline: { length: 44100 } })
+    contexts.push(ctx)
+    return ctx
+  }
+
+  afterAll(async () => {
+    for (const ctx of contexts) {
+      try { await ctx.close() } catch { /* offline contexts may not support close */ }
+    }
+  })
+
+  describe(`BackendProvider: ${provider.name}`, () => {
+    // --- Provider ---
+
+    it('has a name string', () => {
+      expect(typeof provider.name).toBe('string')
+      expect(provider.name.length).toBeGreaterThan(0)
+    })
+
+    it('createContext returns a BackendContext', () => {
+      const ctx = makeCtx()
+      expect(ctx).toBeDefined()
+      expect(typeof ctx.currentTime).toBe('number')
+      expect(typeof ctx.sampleRate).toBe('number')
+      expect(typeof ctx.state).toBe('string')
+      expect(ctx.destination).toBeDefined()
+    })
+
+    it('respects sampleRate option', () => {
+      const ctx = provider.createContext({ sampleRate: 48000, offline: { length: 48000 } })
+      contexts.push(ctx)
+      expect(ctx.sampleRate).toBe(48000)
+    })
+
+    // --- Context properties ---
+
+    it('currentTime is >= 0', () => {
+      const ctx = makeCtx()
+      expect(ctx.currentTime).toBeGreaterThanOrEqual(0)
+    })
+
+    it('sampleRate is positive', () => {
+      const ctx = makeCtx()
+      expect(ctx.sampleRate).toBeGreaterThan(0)
+    })
+
+    it('state is a valid string', () => {
+      const ctx = makeCtx()
+      expect(['running', 'suspended', 'closed']).toContain(ctx.state)
+    })
+
+    it('destination has connect and disconnect', () => {
+      const ctx = makeCtx()
+      expect(typeof ctx.destination.connect).toBe('function')
+      expect(typeof ctx.destination.disconnect).toBe('function')
+    })
+
+    // --- createOscillator ---
+
+    it('createOscillator returns a node with required methods', () => {
+      const ctx = makeCtx()
+      const osc = ctx.createOscillator()
+      expect(typeof osc.connect).toBe('function')
+      expect(typeof osc.disconnect).toBe('function')
+      expect(typeof osc.start).toBe('function')
+      expect(typeof osc.stop).toBe('function')
+      expect(typeof osc.setFrequency).toBe('function')
+      expect(typeof osc.setDetune).toBe('function')
+    })
+
+    it('createOscillator start/stop do not throw', () => {
+      const ctx = makeCtx()
+      const osc = ctx.createOscillator()
+      expect(() => { osc.start() }).not.toThrow()
+      expect(() => { osc.stop() }).not.toThrow()
+    })
+
+    it('createOscillator connects to destination', () => {
+      const ctx = makeCtx()
+      const osc = ctx.createOscillator()
+      expect(() => { osc.connect(ctx.destination) }).not.toThrow()
+    })
+
+    // --- createGain ---
+
+    it('createGain returns a node with required methods', () => {
+      const ctx = makeCtx()
+      const gain = ctx.createGain()
+      expect(typeof gain.connect).toBe('function')
+      expect(typeof gain.disconnect).toBe('function')
+      expect(typeof gain.gain).toBe('number')
+      expect(typeof gain.setGain).toBe('function')
+    })
+
+    it('createGain defaults to gain 1.0', () => {
+      const ctx = makeCtx()
+      const gain = ctx.createGain()
+      expect(gain.gain).toBeCloseTo(1.0)
+    })
+
+    it('createGain respects initial gain', () => {
+      const ctx = makeCtx()
+      const gain = ctx.createGain({ gain: 0.5 })
+      expect(gain.gain).toBeCloseTo(0.5)
+    })
+
+    it('createGain connects to destination', () => {
+      const ctx = makeCtx()
+      const gain = ctx.createGain()
+      expect(() => { gain.connect(ctx.destination) }).not.toThrow()
+    })
+
+    // --- createNoise ---
+
+    it('createNoise returns a node with required methods', () => {
+      const ctx = makeCtx()
+      const noise = ctx.createNoise()
+      expect(typeof noise.connect).toBe('function')
+      expect(typeof noise.disconnect).toBe('function')
+      expect(typeof noise.start).toBe('function')
+      expect(typeof noise.stop).toBe('function')
+    })
+
+    it('createNoise start/stop do not throw', () => {
+      const ctx = makeCtx()
+      const noise = ctx.createNoise()
+      expect(() => { noise.start() }).not.toThrow()
+      expect(() => { noise.stop() }).not.toThrow()
+    })
+
+    it('createNoise supports all noise types', () => {
+      const ctx = makeCtx()
+      expect(() => { ctx.createNoise({ type: 'white' }) }).not.toThrow()
+      expect(() => { ctx.createNoise({ type: 'pink' }) }).not.toThrow()
+      expect(() => { ctx.createNoise({ type: 'brown' }) }).not.toThrow()
+    })
+
+    // --- decodeAudio ---
+
+    it('decodeAudio returns a BackendBuffer', async () => {
+      const ctx = makeCtx()
+      // Minimal valid WAV: 44-byte header + 2 bytes of silence
+      const wav = createMinimalWav()
+      const buffer = await ctx.decodeAudio(wav)
+      expect(buffer).toBeDefined()
+      expect(typeof buffer.duration).toBe('number')
+      expect(typeof buffer.length).toBe('number')
+      expect(typeof buffer.sampleRate).toBe('number')
+      expect(typeof buffer.numberOfChannels).toBe('number')
+      expect(buffer.duration).toBeGreaterThan(0)
+      expect(buffer.length).toBeGreaterThan(0)
+      expect(buffer.sampleRate).toBeGreaterThan(0)
+      expect(buffer.numberOfChannels).toBeGreaterThanOrEqual(1)
+    })
+
+    // --- createBufferSource ---
+
+    it('createBufferSource returns a node with required methods', async () => {
+      const ctx = makeCtx()
+      const wav = createMinimalWav()
+      const buffer = await ctx.decodeAudio(wav)
+      const source = ctx.createBufferSource(buffer)
+      expect(typeof source.connect).toBe('function')
+      expect(typeof source.disconnect).toBe('function')
+      expect(typeof source.start).toBe('function')
+      expect(typeof source.stop).toBe('function')
+      expect(typeof source.loop).toBe('boolean')
+      expect(typeof source.setLoop).toBe('function')
+      expect(typeof source.setPlaybackRate).toBe('function')
+    })
+
+    it('createBufferSource start/stop do not throw', async () => {
+      const ctx = makeCtx()
+      const wav = createMinimalWav()
+      const buffer = await ctx.decodeAudio(wav)
+      const source = ctx.createBufferSource(buffer)
+      expect(() => { source.start() }).not.toThrow()
+      expect(() => { source.stop() }).not.toThrow()
+    })
+
+    it('createBufferSource respects loop prop', async () => {
+      const ctx = makeCtx()
+      const wav = createMinimalWav()
+      const buffer = await ctx.decodeAudio(wav)
+      const source = ctx.createBufferSource(buffer, { loop: true })
+      expect(source.loop).toBe(true)
+    })
+
+    // --- Node connectivity ---
+
+    it('nodes can chain: osc -> gain -> destination', () => {
+      const ctx = makeCtx()
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      expect(() => {
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+      }).not.toThrow()
+    })
+
+    // --- suspend/resume/close ---
+
+    it('suspend and resume are callable', () => {
+      const ctx = makeCtx()
+      expect(typeof ctx.suspend).toBe('function')
+      expect(typeof ctx.resume).toBe('function')
+      expect(typeof ctx.close).toBe('function')
+    })
+  })
+}
+
+// Minimal valid WAV file for contract tests (44 header + 100 samples of silence)
+const createMinimalWav = (): ArrayBuffer => {
+  const numSamples = 100
+  const dataSize = numSamples * 2
+  const buf = new ArrayBuffer(44 + dataSize)
+  const view = new DataView(buf)
+
+  // RIFF header
+  writeString(view, 0, 'RIFF')
+  view.setUint32(4, 36 + dataSize, true)
+  writeString(view, 8, 'WAVE')
+
+  // fmt chunk
+  writeString(view, 12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)       // PCM
+  view.setUint16(22, 1, true)       // mono
+  view.setUint32(24, 44100, true)   // sample rate
+  view.setUint32(28, 88200, true)   // byte rate
+  view.setUint16(32, 2, true)       // block align
+  view.setUint16(34, 16, true)      // bits per sample
+
+  // data chunk
+  writeString(view, 36, 'data')
+  view.setUint32(40, dataSize, true)
+  // samples are zero-initialized (silence)
+
+  return buf
+}
+
+const writeString = (view: DataView, offset: number, str: string): void => {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i))
+  }
+}

--- a/packages/core/tests/utils/createTestWav.ts
+++ b/packages/core/tests/utils/createTestWav.ts
@@ -1,0 +1,47 @@
+// Generate a minimal valid WAV file (44-byte header + samples) for testing
+// Produces a short sine wave at the given frequency
+
+export const createTestWav = (options?: {
+  sampleRate?: number
+  durationMs?: number
+  frequency?: number
+}): Buffer => {
+  const sampleRate = options?.sampleRate ?? 44100
+  const durationMs = options?.durationMs ?? 100
+  const frequency = options?.frequency ?? 440
+  const numSamples = Math.floor(sampleRate * durationMs / 1000)
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = numSamples * numChannels * bytesPerSample
+  const headerSize = 44
+  const buffer = Buffer.alloc(headerSize + dataSize)
+
+  // RIFF header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+
+  // fmt chunk
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)           // chunk size
+  buffer.writeUInt16LE(1, 20)            // PCM format
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28) // byte rate
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32) // block align
+  buffer.writeUInt16LE(bitsPerSample, 34)
+
+  // data chunk
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Write sine wave samples
+  for (let i = 0; i < numSamples; i++) {
+    const sample = Math.sin(2 * Math.PI * frequency * i / sampleRate)
+    const intSample = Math.max(-32768, Math.min(32767, Math.floor(sample * 32767)))
+    buffer.writeInt16LE(intSample, headerSize + i * bytesPerSample)
+  }
+
+  return buffer
+}

--- a/packages/core/tests/utils/harness.ts
+++ b/packages/core/tests/utils/harness.ts
@@ -1,0 +1,73 @@
+// Test harness — single import for all test infrastructure
+// Usage: const h = useHarness() at top of describe, afterAll(() => h.cleanup())
+
+import { createAudioContext } from '../../src/context.js'
+import type { BackendContext, BackendBuffer } from '../../src/backend/types.js'
+import type { ScoreErrorInstance } from '../../src/errors/ScoreError.js'
+import {
+  createMockBackendContext,
+  createMockBuffer,
+  createMockBackendNode,
+  createMockBackendProvider,
+  type MockBackendContext,
+} from './audioTestUtils.js'
+
+export type TestHarness = {
+  // Real backend context (integration tests) — auto-tracked for cleanup
+  readonly context: (opts?: Parameters<typeof createAudioContext>[0]) => BackendContext
+  // Mock backend context (unit tests) — no cleanup needed
+  readonly mockContext: () => MockBackendContext
+  // Mock buffer factory
+  readonly mockBuffer: (opts?: {
+    duration?: number
+    length?: number
+    sampleRate?: number
+    numberOfChannels?: number
+  }) => BackendBuffer
+  // Mock node factory
+  readonly mockNode: typeof createMockBackendNode
+  // Mock provider factory
+  readonly mockProvider: typeof createMockBackendProvider
+  // Assert error is ScoreError with fix field
+  readonly expectScoreError: (err: unknown) => void
+  // Cleanup all tracked contexts — call in afterAll
+  readonly cleanup: () => Promise<void>
+}
+
+export const useHarness = (): TestHarness => {
+  const contexts: BackendContext[] = []
+
+  return {
+    context: (opts) => {
+      const ctx = createAudioContext({ offline: { length: 44100 }, ...opts })
+      contexts.push(ctx)
+      return ctx
+    },
+
+    mockContext: () => createMockBackendContext(),
+
+    mockBuffer: (opts) => createMockBuffer(opts),
+
+    mockNode: createMockBackendNode,
+
+    mockProvider: createMockBackendProvider,
+
+    expectScoreError: (err: unknown) => {
+      if (!(err instanceof Error)) {
+        throw new Error(`Expected ScoreError, got ${typeof err}`)
+      }
+      if (err.name !== 'ScoreError') {
+        throw new Error(`Expected ScoreError, got ${err.name}: ${err.message}`)
+      }
+      const ctx = (err as ScoreErrorInstance).context
+      if (!ctx.fix || typeof ctx.fix !== 'string') {
+        throw new Error(`ScoreError missing fix field: ${err.message}`)
+      }
+    },
+
+    cleanup: async () => {
+      await Promise.all(contexts.map((ctx) => ctx.close().catch(() => {})))
+      contexts.length = 0
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.4
+      husky:
+        specifier: ^9.0.0
+        version: 9.1.7
+      lint-staged:
+        specifier: ^15.0.0
+        version: 15.5.2
       prettier:
         specifier: ^3.0.0
         version: 3.8.1
@@ -776,6 +782,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -821,6 +831,10 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -848,9 +862,21 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -858,6 +884,13 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -898,11 +931,18 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -969,6 +1009,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -999,6 +1046,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1027,6 +1078,14 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1046,6 +1105,15 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1071,9 +1139,25 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1130,12 +1214,29 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lint-staged@15.5.2:
+    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  listr2@8.3.3:
+    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
+    engines: {node: '>=18.0.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1159,6 +1260,21 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1202,6 +1318,18 @@ packages:
     resolution: {integrity: sha512-xEQs4ySdyQ28T0zf8FjP96AzkWwE6dObaBsBxqJAbB4kpYMrVfIdAD0HjpY5tdN0pEDfEHyQ3S+0fTEk8SlqrQ==}
     engines: {node: '>= 14'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1229,6 +1357,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -1243,9 +1375,18 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1281,6 +1422,13 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1313,6 +1461,14 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1323,6 +1479,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1331,12 +1491,20 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
@@ -1372,6 +1540,10 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -1529,8 +1701,17 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2103,6 +2284,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -2136,6 +2321,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.8
@@ -2165,13 +2354,28 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
+
+  commander@13.1.0: {}
 
   concat-map@0.0.1: {}
 
@@ -2199,9 +2403,13 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  environment@1.1.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2307,6 +2515,20 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2327,6 +2549,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -2354,6 +2580,10 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-east-asian-width@1.5.0: {}
+
+  get-stream@8.0.1: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -2373,6 +2603,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  human-signals@5.0.0: {}
+
+  husky@9.1.7: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2388,9 +2622,19 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-stream@3.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2446,11 +2690,45 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lilconfig@3.1.3: {}
+
+  lint-staged@15.5.2:
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+      debug: 4.4.3
+      execa: 8.0.1
+      lilconfig: 3.1.3
+      listr2: 8.3.3
+      micromatch: 4.0.8
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  listr2@8.3.3:
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   loose-envify@1.4.0:
     dependencies:
@@ -2477,6 +2755,17 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  merge-stream@2.0.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  mimic-fn@4.0.0: {}
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -2514,6 +2803,18 @@ snapshots:
       node-fetch: 3.3.2
       webidl-conversions: 7.0.0
 
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2541,6 +2842,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
@@ -2552,7 +2855,11 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.1: {}
+
   picomatch@4.0.3: {}
+
+  pidtree@0.6.0: {}
 
   postcss@8.5.8:
     dependencies:
@@ -2579,6 +2886,13 @@ snapshots:
       loose-envify: 1.4.0
 
   resolve-from@4.0.0: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
 
   rollup@4.59.0:
     dependencies:
@@ -2629,11 +2943,23 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2647,6 +2973,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2654,6 +2986,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-final-newline@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -2681,6 +3015,10 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -2826,6 +3164,14 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,10 +44,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/components:
     dependencies:
@@ -57,10 +57,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/core:
     dependencies:
@@ -68,12 +68,15 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/dsl:
     dependencies:
@@ -83,10 +86,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/effects:
     dependencies:
@@ -96,10 +99,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/gui:
     dependencies:
@@ -115,10 +118,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@25.5.0))
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -127,10 +130,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.5.0)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/mcp:
     dependencies:
@@ -140,10 +143,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/midi:
     dependencies:
@@ -153,10 +156,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/mixer:
     dependencies:
@@ -166,10 +169,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
   packages/sequencer:
     dependencies:
@@ -179,10 +182,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
 packages:
 
@@ -654,6 +657,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1601,6 +1607,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2099,6 +2108,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
@@ -2201,7 +2214,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.5.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2209,11 +2222,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9)':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.5.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -2227,7 +2240,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9
+      vitest: 2.1.9(@types/node@25.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2238,13 +2251,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21)':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.5.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.5.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -3068,6 +3081,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.18.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -3078,13 +3093,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@2.1.9:
+  vite-node@2.1.9(@types/node@25.5.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3096,18 +3111,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.5.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.8
       rollup: 4.59.0
     optionalDependencies:
+      '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitest@2.1.9:
+  vitest@2.1.9(@types/node@25.5.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21)
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.5.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -3123,9 +3139,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21
-      vite-node: 2.1.9
+      vite: 5.4.21(@types/node@25.5.0)
+      vite-node: 2.1.9(@types/node@25.5.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary
- **Phase 4 Sampler**: `decodeSample()` (ArrayBuffer → BackendBuffer), `createSamplePlayer()` with gain, playback rate, one-shot pattern. Backend-agnostic — no file I/O in core.
- **Backend types**: `BackendBuffer`, `BackendBufferSourceNode`, `decodeAudio()`, `createBufferSource()` added to BackendContext
- **Test harness**: `useHarness()` — single import for real/mock contexts, cleanup, error assertions. All 8 test files refactored.
- **Backend contract tests**: 22 tests any BackendProvider must pass (for future scsynth/custom backends)
- **Error propagation tests**: 10 tests verifying all errors surface as ScoreError with fix messages
- **Pre-commit hooks**: husky + lint-staged runs eslint --fix on staged .ts files
- **Fixes**: AudioContext cleanup in all tests, lint now covers tests dir, sounds/ gitignored, OfflineAudioContext.close() guard, memory leak fix on repeated start()

## Stats
- 122 tests across 8 files, all passing
- Coverage above 90/85/90/90 thresholds
- Lint clean (src + tests)

## Test plan
- [x] `pnpm test` — 122 tests pass
- [x] `eslint src tests` — 0 errors
- [x] TypeScript compiles
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)