### PR TITLE
feat: Phase 9 Song DSL + Phase 10 CLI play command with ScoreEngine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ samples/**/*
 sounds/**/*
 !sounds/**/.gitkeep
 !sounds/README.md
+
+# Claude Code local state
+.claude/
+mcp-servers/score-codebase/node_modules/

--- a/SCORE_HANDOFF.md
+++ b/SCORE_HANDOFF.md
@@ -106,8 +106,10 @@ Phase 7b   ⬜  Mastering chain — Multiband Compressor, Saturation/Tape, Auto-
 Phase 8    ✅  Sequencer + Transport + TempoMap + Swing/Groove
 Phase 8b   ⬜  Core primitives — ADSR Envelope, LFO modulation source
 Phase 9    ⬜  Song format + Automation system + Pattern reuse + Arpeggiator
-Phase 9b   ⬜  @score/math — mathematical music toolkit
-Phase 9c   ⬜  @score/pattern — functional pattern model (TidalCycles-inspired)
+Phase 9b   ⬜  @score/math — mathematical music toolkit [ships in v1.0 — advanced feature]
+Phase 9c   ⬜  @score/pattern — functional Pattern<T> model, Strudel migration path [ships in v1.0 — advanced feature]
+Phase 9d   ⬜  @score/musical — plain language DSL (describe() function)
+Phase 9e   ⬜  Song file security — AST validator + module resolver + Zod export validation
 Phase 10   ⬜  CLI — all commands + stem export + freeze/bounce
 Phase 10b  ⬜  score-audio MCP — effect catalog, signal flow, backend nodes, component catalog
 Phase 10b2 ⬜  score-game-tools MCP — song inspector, mixer state, transport state, audio graph
@@ -784,7 +786,25 @@ const lead = Synth({
 
 ## 9c. Functional Pattern System (@score/pattern — Phase 9c)
 
-TidalCycles-inspired pattern model. Patterns are functions from time to events:
+### Design goal — TidalCycles power, readable as music
+
+Score's pattern system is inspired by TidalCycles but prioritises
+human readability over terseness. A Score pattern should sound like
+it reads. A musician with no coding background should be able to
+follow what the code is doing by reading it aloud.
+
+TidalCycles is the academic inspiration — Score is the musician's
+implementation.
+
+```ts
+// TidalCycles style (terse, powerful, cryptic to newcomers)
+d1 $ every 4 (fast 2) $ sound "bd sd hh cp"
+
+// Score style (same result — reads like a production note)
+const kick = Kick({ pattern: every(4, fast(2), beat(1,0,1,0)) })
+```
+
+The core type is functions from time arcs to events:
 
 ```ts
 type Arc = [Time, Time]
@@ -794,12 +814,12 @@ type Pattern<T> = (arc: Arc) => Event<T>[]
 This enables composable transformations that nest freely:
 
 ```ts
-// All of these are functions that take patterns and return patterns
-fast(2, pat)              // speed up any pattern
-every(4, fn, pat)         // apply function every 4 cycles
-stack(...pats)            // layer patterns
-fmap(fn, pat)             // transform pattern values
-degrade(0.8, pat)         // randomly drop 20% of events
+fast(2, pat)              // double time — reads: "play this twice as fast"
+slow(2, pat)              // half time — reads: "play this half as fast"
+every(4, fast(2), pat)    // reads: "every 4 bars, play this twice as fast"
+stack(kick, snare, hihat) // reads: "layer kick, snare, and hihat together"
+degrade(0.8, pat)         // reads: "randomly drop 20% of hits"
+rev(pat)                  // reads: "reverse this pattern"
 ```
 
 ### Backward compatibility — arrays always work
@@ -808,9 +828,9 @@ The existing array format `[1,0,0,0]` is supported permanently.
 The functional pattern type is additive, not a replacement.
 
 ```ts
-// Both of these always work
-const kick = Kick({ pattern: [1,0,0,0,1,0,0,0] })                    // array
-const kick = Kick({ pattern: every(4, fast(2), Seq(1,0,0,0)) })      // functional
+// Both of these always work — arrays never removed
+const kick = Kick({ pattern: [1,0,0,0,1,0,0,0] })
+const kick = Kick({ pattern: every(4, fast(2), beat(1,0,0,0)) })
 ```
 
 ### PatternInput type union (built into Phase 8)
@@ -892,6 +912,210 @@ score> viz(kick)
 - @score/components — type widening only (non-breaking)
 - @score/sequencer — PatternInput type union (one change in Phase 8)
 - Existing song files and tests — no changes ever
+
+---
+
+## 9d. Plain Language Layer (@score/musical — Phase 9d)
+
+### Design goal — any musician can write Score on day one
+
+Score supports two syntaxes that produce identical audio output.
+The choice is entirely the artist's. Both are permanent.
+
+```js
+// Developer syntax — explicit component model
+const kick = Kick({
+  pattern:   [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0],
+  sidechain: true,
+  volume:    0.9,
+})
+
+// Musician syntax — plain language
+const kick = describe('deep kick hits every beat pumps hard loud')
+```
+
+Same audio. Different surface.
+
+### The `describe()` function
+
+`describe()` tokenizes the string and matches phrases to component
+props via a vocabulary system. It builds the component from matched
+vocabulary — no AI, no generation, just a lookup table.
+
+```
+Phrase                        Maps to
+──────────────────────────    ────────────────────────────────────
+"deep kick"                → Kick({ synth: { frequency: 58, pitchDrop: 0.06 } })
+"punchy kick"              → Kick({ synth: { frequency: 80, pitchDrop: 0.03 } })
+"hits every beat"          → pattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0]
+"hits on 2 and 4"          → pattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0]
+"straight eighths"         → pattern: [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0]
+"pumps hard"               → sidechain: true, compression: { ratio: 6 }
+"pumps gently"             → sidechain: true, compression: { ratio: 2 }
+"sits far back in reverb"  → reverb: 0.75
+"sits in reverb"           → reverb: 0.45
+"sits in reverb slightly"  → reverb: 0.25
+"loud"                     → volume: 0.85
+"quiet"                    → volume: 0.45
+"gritty"                   → distortion: 0.2
+"warm fm bass"             → FM({ modRatio: 1, modIndex: 3 })
+"soft string pad"          → PhysicalString({ coef: 0.3, decay: 4 })
+"filter wanders slowly"    → filter: { frequency: OUProcess({...}) }
+```
+
+### Arrangement in plain language
+
+```js
+// Musician syntax — reads like a track breakdown note
+const arrangement = song`
+  intro 8 bars
+    just hihat
+
+  drop 32 bars
+    full kit
+    bass and pad
+    kick pumps hard
+
+  breakdown 16 bars
+    strip to sax and pad
+    let it breathe
+`
+```
+
+### What plain language does NOT do
+
+It does not generate musical decisions. It does not choose patterns,
+notes, arrangements, or effects. It only translates descriptions of
+musical decisions the artist has already made into component props.
+All creative decisions are always the artist's.
+
+### The learning path this creates
+
+```
+Week 1  — artist writes: describe('deep kick hits every beat pumps hard')
+          Score Studio shows the code equivalent in the side panel
+          Artist sees: pattern: [1,0,0,0,1,0,0,0]
+
+Week 4  — artist starts writing pattern arrays directly
+
+Week 8  — artist discovers euclidean(3, 8) and @score/pattern
+          starts exploring functional transformations
+          learning through music
+```
+
+### Package structure
+
+```
+@score/musical
+└── src/
+    ├── vocabulary/
+    │   ├── sounds.ts        ← instrument character descriptors
+    │   ├── patterns.ts      ← rhythm plain language
+    │   ├── feel.ts          ← sidechain, humanize, distortion
+    │   ├── space.ts         ← reverb/delay descriptions
+    │   ├── volume.ts        ← loud/quiet/whisper
+    │   └── arrangement.ts   ← intro/drop/breakdown words
+    ├── parser.ts            ← tokenizer + component builder
+    ├── describe.ts          ← describe() exported function
+    └── index.ts
+```
+
+---
+
+## 9e. Song File Security (Phase 9e)
+
+### Why — song files are executable JavaScript
+
+A malicious song file from an untrusted source could import `fs`,
+spawn processes, or make network requests. The solution is
+language-level restriction before execution, not sandboxing.
+
+### Two-layer enforcement
+
+**Layer 1 — AST validation before execution (`SongValidator`):**
+Parses the file to an AST and rejects:
+- Blocked module imports (`fs`, `child_process`, `net`, `http`, `https`)
+- `process.*` access
+- `eval()` and `Function()` constructor calls
+- Dynamic `import()` calls
+
+Clear ScoreError with line number and exact fix shown to artist.
+
+```bash
+$ score play ~/Downloads/sketchy-track.js
+
+✖ Score: Song validation failed
+
+  Line 3: Blocked import "fs" — not allowed in Score songs
+  Fix: Remove this import — Score songs only use @score/* packages
+
+  Line 7: "process.exit" is not allowed in Score songs
+  Fix: Score songs do not have access to Node.js process
+
+  2 errors found. Fix these before playing.
+```
+
+**Layer 2 — Module resolver at runtime (`ScoreModuleResolver`):**
+Intercepts all imports and checks the allowlist. Second line of
+defence after AST validation passes.
+
+**Layer 3 — Zod export validation (`SongExportValidator`):**
+After execution, the exported Song object is Zod-validated before
+the engine receives it. Catches structural problems regardless of
+how they got there.
+
+### Allowed in song files
+
+```
+@score/core, @score/math, @score/pattern, @score/musical
+@score/dsl, @score/components, @score/effects
+Local relative imports (./sounds/my-library.js etc)
+Math, Array, Object, Map, Set, String, Number, JSON, Date
+console.log (debugging only)
+```
+
+### Blocked in song files
+
+```
+fs, fs/promises, child_process, net, http, https
+fetch, WebSocket
+process (no process control)
+eval, Function() (no dynamic execution)
+setTimeout, setInterval (use Score transport)
+require() (use ESM imports)
+Any npm package not in @score/*)
+```
+
+### Mathematical operations are completely unaffected
+
+All @score/math exports (Lorenz, OUProcess, Euclidean, entropy etc)
+are fully available. Restrictions target dangerous system operations
+only. Live input, physical modeling, crowd recording — all work.
+
+### The --trust flag
+
+```bash
+score play --trust my-plugin-test.js
+# Skips validation — always shows warning
+# Developer use only — never for shared files
+```
+
+### New runtime folder in @score/cli
+
+```
+@score/cli/src/runtime/
+├── ScoreModuleResolver.ts   ← import allowlist enforcement
+├── SongValidator.ts         ← AST analysis before execution
+├── ScoreGlobals.ts          ← restricted global environment
+└── SongExportValidator.ts   ← Zod schema validation of export
+```
+
+### New dependencies
+
+```
+acorn        — JavaScript AST parser
+acorn-walk   — AST traversal
+```
 
 ---
 
@@ -1038,6 +1262,15 @@ Major festivals       → Multiple shows documented, established tool
 17. Mixer requires sub bus output and hard brick-wall limiter
 18. XDJ profiles support all three mixer modes — score-mixer, hardware-mixer, hybrid
 19. All code is functional — factory functions, `const`, arrow functions, zero classes
+20. Song files are AST-validated before execution — SongValidator runs first, rejects blocked imports
+21. Only @score/* and local relative imports are valid in song files
+22. Blocked in song files: fs, child_process, net, http, https, fetch, process, eval, setTimeout
+23. Song exports are Zod-validated before the engine receives them
+24. --trust flag skips validation — developer-only, never document as safe for shared files
+25. @score/musical plain language compiles to component model — identical audio output, no AI
+26. PatternInput in sequencer accepts both number[] and Pattern<T> — arrays never removed
+27. Pattern<T> type is (arc: Arc) => Event<T>[] — functions from time, not data arrays
+28. @score/pattern and @score/math ship in v1.0 — advanced features, not required for basic songs
 
 ---
 
@@ -1121,6 +1354,12 @@ For Score users building songs with AI assistance. Exposes the public API surfac
 | `meyda` | Real-time audio feature extraction |
 | `midi-parser-js` | MIDI file parsing |
 
+### Song File Security (Phase 9e)
+| Package | Purpose |
+|---------|---------|
+| `acorn` | JavaScript AST parser for SongValidator |
+| `acorn-walk` | AST traversal for import/eval detection |
+
 ### Never Use — Ever
 | Thing | Reason |
 |-------|--------|
@@ -1150,6 +1389,7 @@ Format: `YYYY-MM-DD sNNN — What was completed or significantly advanced`
 2026-03-16 s003 — Architecture compliance (ramp rule, id/type, ScoreError fields), tech debt cleanup, handoff v3
 2026-03-16 s004 — Handoff v4 unification, pre-Phase 7 audit, @score-music scope decision
 2026-03-16 s005 — Phase 6 completion (8 effects + chain + 2 backend nodes), Phase 7 Mixer, Phase 8 Sequencer — 553 tests
+2026-03-16 s006 — score-codebase MCP loaded; incorporated language+security decisions: Phase 9d (describe()), 9e (AST security), rules 20-28, @score/pattern design philosophy
 ```
 
 ---

--- a/SCORE_HANDOFF.md
+++ b/SCORE_HANDOFF.md
@@ -113,6 +113,7 @@ Phase 10b  ⬜  score-audio MCP — effect catalog, signal flow, backend nodes, 
 Phase 10b2 ⬜  score-game-tools MCP — song inspector, mixer state, transport state, audio graph
 Phase 10c  ⬜  Decode — audio analysis + format import (Rekordbox, Serato, FL Studio, MIDI)
 Phase 11   ⬜  Hot reload + live coding (3 levels)
+Phase 11b  ⬜  Live coding visualization — punchcard, piano roll, scope, pattern graph, waveform
 Phase 12   ⬜  MIDI bridge + XDJ profiles + hardware mixer modes
 Phase 12b  ⬜  Jam session — @score/session
 Phase 12c  ⬜  SuperCollider backend — fully embedded
@@ -823,6 +824,67 @@ const resolvePattern = <T>(input: PatternInput<T>, cycle: number = 0): T[] =>
   Array.isArray(input)
     ? input
     : input([cycle, cycle + 1]).map(e => e.value)
+```
+
+### Score pattern language — code is music, read it as music
+
+Score patterns are designed to look like what they sound like:
+
+```ts
+// Score's native pattern syntax — readable, composable, functional
+const kick   = Kick({ pattern: beat(1, 0, 0, 0) })           // four-on-the-floor
+const snare  = Snare({ pattern: beat(0, 0, 1, 0) })          // backbeat
+const hihat  = HiHat({ pattern: every(16, beat(1, 1, 1, 1)) }) // 16ths
+const bass   = Synth({ pattern: euclidean(3, 8) })            // euclidean rhythm
+
+// Transforms read like music directions
+const buildup = fast(2, kick.pattern)                // double time
+const breakdown = degrade(0.3, hihat.pattern)        // thin out to 30%
+const drop = stack(kick, snare, hihat, bass)         // layer everything
+```
+
+### Strudel/TidalCycles migration path
+
+Score includes a `mini()` adapter for Strudel users migrating existing patterns:
+
+```ts
+// Strudel users can bring their patterns directly
+const pat = mini("bd sd [hh hh] cp")       // Strudel mini-notation → Score Pattern
+const pat = mini("bd(3,8)")                 // euclidean via mini-notation
+
+// But Score's native syntax is preferred — more readable, fully typed
+const pat = euclidean(3, 8)                 // Score native equivalent
+```
+
+Mini-notation is a **migration bridge**, not the primary interface.
+Score patterns are always arrays, functions, or composable transforms.
+
+### Live coding visualization (Phase 11b)
+
+Score provides real-time visual feedback for live coding sessions:
+
+- **Punchcard view** — grid showing active steps per track (like Strudel)
+- **Piano roll** — time-scrolling note display for melodic patterns
+- **Oscilloscope / spectrum** — real-time audio waveform + FFT via AnalyserNode
+- **Pattern graph** — visual DAG of pattern transformations (fast, every, stack, etc.)
+- **Waveform display** — rendered waveform of samples/audio buffers
+
+All visualizations are driven by the pattern system and transport position.
+GUI renders them (Phase 13), but data is available headlessly for terminal/REPL output.
+
+### REPL with live output (Phase 13f)
+
+```
+score> const kick = Kick({ pattern: mini("bd*4") })
+♪ Playing: bd bd bd bd  [120 BPM]
+
+score> kick.pattern = mini("bd ~ bd bd")
+♪ Updated: bd _ bd bd  [120 BPM]
+
+score> viz(kick)
+┌─┬─┬─┬─┬─┬─┬─┬─┐
+│●│ │●│●│●│ │●│●│  ← punchcard
+└─┴─┴─┴─┴─┴─┴─┴─┘
 ```
 
 ### Impact on existing code — minimal

--- a/mcp-servers/score-codebase/index.js
+++ b/mcp-servers/score-codebase/index.js
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+// score-codebase MCP — Code intelligence for Claude Code sessions working on Score
+// Tools: architecture_rules, package_graph, api_surface, project_status, adr_lookup
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCORE_ROOT = resolve(__dirname, '../../')
+
+const readFile = (path) => {
+  try {
+    return existsSync(path) ? readFileSync(path, 'utf-8') : null
+  } catch {
+    return null
+  }
+}
+
+const readJson = (path) => {
+  const content = readFile(path)
+  if (!content) return null
+  try {
+    return JSON.parse(content)
+  } catch {
+    return null
+  }
+}
+
+// ─── Tool: architecture_rules ────────────────────────────────────────
+
+const SECTION_MAP = {
+  'code-style': /## .*Code Style|## .*Functional/i,
+  'non-negotiables': /## .*Non-Negotiable|## .*Never Violate/i,
+  'git-workflow': /## .*Git Workflow/i,
+  'testing': /## .*Testing|coverage/i,
+  'audio-rules': /## .*Architectural Rules|## .*Audio/i,
+}
+
+const extractSection = (content, pattern) => {
+  const lines = content.split('\n')
+  let capturing = false
+  let result = []
+  for (const line of lines) {
+    if (pattern.test(line)) {
+      capturing = true
+      result.push(line)
+      continue
+    }
+    if (capturing) {
+      if (/^## /.test(line) && result.length > 1) break
+      result.push(line)
+    }
+  }
+  return result.length > 0 ? result.join('\n').trim() : null
+}
+
+const architectureRules = {
+  name: 'architecture_rules',
+  description: 'Returns architecture rules, code style, non-negotiables, git workflow, testing standards, and audio rules from CLAUDE.md and SCORE_HANDOFF.md. Query a specific section or get everything.',
+  inputSchema: {
+    section: z.enum(['all', 'code-style', 'non-negotiables', 'git-workflow', 'testing', 'audio-rules'])
+      .optional().default('all')
+      .describe('Which section to return. "all" returns both CLAUDE.md and key HANDOFF sections.'),
+  },
+  handler: async ({ section }) => {
+    const claudeMd = readFile(join(SCORE_ROOT, 'CLAUDE.md')) ?? '(CLAUDE.md not found)'
+    const handoff = readFile(join(SCORE_ROOT, 'SCORE_HANDOFF.md')) ?? '(SCORE_HANDOFF.md not found)'
+
+    if (section === 'all') {
+      return { content: [{ type: 'text', text: `# CLAUDE.md\n\n${claudeMd}\n\n---\n\n# SCORE_HANDOFF.md (key sections)\n\n${extractSection(handoff, /## .*Architectural Rules/) ?? ''}\n\n${extractSection(handoff, /## .*Code Style|## .*Functional/) ?? ''}` }] }
+    }
+
+    const pattern = SECTION_MAP[section]
+    const fromHandoff = pattern ? extractSection(handoff, pattern) : null
+    const fromClaude = pattern ? extractSection(claudeMd, pattern) : null
+    const result = [fromClaude, fromHandoff].filter(Boolean).join('\n\n---\n\n')
+    return { content: [{ type: 'text', text: result || `No section found for "${section}"` }] }
+  },
+}
+
+// ─── Tool: package_graph ─────────────────────────────────────────────
+
+const packageGraph = {
+  name: 'package_graph',
+  description: 'Show the dependency graph of all workspace packages. Shows which packages depend on which, export counts, and stub status.',
+  inputSchema: {
+    filter: z.string().optional().describe('Optional substring filter on package name'),
+  },
+  handler: async ({ filter }) => {
+    const pkgsDir = join(SCORE_ROOT, 'packages')
+    if (!existsSync(pkgsDir)) return { content: [{ type: 'text', text: 'packages/ directory not found' }] }
+
+    const dirs = readdirSync(pkgsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .filter((name) => !filter || name.includes(filter))
+
+    const packages = dirs.map((name) => {
+      const pkg = readJson(join(pkgsDir, name, 'package.json'))
+      if (!pkg) return null
+
+      const indexContent = readFile(join(pkgsDir, name, 'src', 'index.ts')) ?? ''
+      const isStub = indexContent.includes('_stub')
+      const exportCount = (indexContent.match(/^export /gm) ?? []).length
+
+      const deps = Object.keys(pkg.dependencies ?? {})
+        .filter((d) => d.startsWith('@score/'))
+
+      return { name: pkg.name, version: pkg.version, deps, isStub, exportCount, scripts: Object.keys(pkg.scripts ?? {}) }
+    }).filter(Boolean)
+
+    const lines = packages.map((p) => {
+      const status = p.isStub ? ' [STUB]' : ''
+      const depsStr = p.deps.length > 0 ? ` → ${p.deps.join(', ')}` : ''
+      return `${p.name}${status} (${p.exportCount} exports)${depsStr}`
+    })
+
+    return { content: [{ type: 'text', text: `# Package Graph\n\n${lines.join('\n')}` }] }
+  },
+}
+
+// ─── Tool: api_surface ───────────────────────────────────────────────
+
+const apiSurface = {
+  name: 'api_surface',
+  description: 'List all exports from a package\'s src/index.ts with their signatures. Shows factory functions, types, and props.',
+  inputSchema: {
+    package: z.string().describe('Package name (e.g., "effects", "core", "mixer", "sequencer")'),
+  },
+  handler: async ({ package: pkgName }) => {
+    const indexPath = join(SCORE_ROOT, 'packages', pkgName, 'src', 'index.ts')
+    const content = readFile(indexPath)
+    if (!content) return { content: [{ type: 'text', text: `Package "${pkgName}" not found or has no src/index.ts` }] }
+
+    // Parse exports
+    const exportLines = content.split('\n').filter((l) => l.startsWith('export'))
+    const result = []
+
+    for (const line of exportLines) {
+      // export { createFoo } from './foo.js'
+      const reExport = line.match(/export\s+\{\s*(\w+)\s*\}\s+from\s+'\.\/(\S+?)(?:\.js)?'/)
+      const typeExport = line.match(/export\s+type\s+\{\s*(\w+)\s*\}\s+from/)
+
+      if (typeExport) {
+        result.push(`  type ${typeExport[1]}`)
+      } else if (reExport) {
+        const funcName = reExport[1]
+        const srcFile = reExport[2]
+        // Try to read the source file for the signature
+        const srcPath = join(SCORE_ROOT, 'packages', pkgName, 'src', `${srcFile}.ts`)
+        const srcContent = readFile(srcPath)
+        if (srcContent) {
+          const sigMatch = srcContent.match(new RegExp(`export const ${funcName}\\s*=\\s*\\([^)]*\\)`))
+          if (sigMatch) {
+            result.push(`  ${sigMatch[0].replace('export const ', '')}`)
+          } else {
+            result.push(`  ${funcName}`)
+          }
+        } else {
+          result.push(`  ${funcName}`)
+        }
+      } else if (line.startsWith('export *')) {
+        result.push(`  ${line.trim()}`)
+      }
+    }
+
+    return { content: [{ type: 'text', text: `# @score/${pkgName} API Surface\n\n${result.join('\n')}` }] }
+  },
+}
+
+// ─── Tool: project_status ────────────────────────────────────────────
+
+const projectStatus = {
+  name: 'project_status',
+  description: 'Get current project status: phase roadmap, blockers, and test counts per package.',
+  inputSchema: {
+    section: z.enum(['all', 'phases', 'blockers', 'tests'])
+      .optional().default('all')
+      .describe('"phases" shows build status, "blockers" shows blocked items, "tests" runs pnpm test and parses counts, "all" shows phases + blockers.'),
+  },
+  handler: async ({ section }) => {
+    const handoff = readFile(join(SCORE_ROOT, 'SCORE_HANDOFF.md')) ?? ''
+
+    if (section === 'tests') {
+      try {
+        const output = execSync('pnpm test 2>&1', { cwd: SCORE_ROOT, timeout: 60000, encoding: 'utf-8' })
+        const testLines = output.split('\n').filter((l) => /Tests.*passed/.test(l) || /Tests.*failed/.test(l))
+        return { content: [{ type: 'text', text: `# Test Results\n\n${testLines.join('\n')}` }] }
+      } catch (err) {
+        return { content: [{ type: 'text', text: `# Test Results\n\nError running tests: ${err.message}` }] }
+      }
+    }
+
+    const phases = extractSection(handoff, /## .*Build Status/)
+    const blockers = extractSection(handoff, /## .*Blocked/)
+
+    if (section === 'phases') return { content: [{ type: 'text', text: phases ?? 'No phase status found' }] }
+    if (section === 'blockers') return { content: [{ type: 'text', text: blockers ?? 'No blockers found' }] }
+
+    return { content: [{ type: 'text', text: `${phases ?? ''}\n\n---\n\n${blockers ?? 'No blockers'}` }] }
+  },
+}
+
+// ─── Tool: adr_lookup ────────────────────────────────────────────────
+
+const adrLookup = {
+  name: 'adr_lookup',
+  description: 'Query Architecture Decision Records. Pass a number to read a specific ADR, a keyword to search, or omit to list all.',
+  inputSchema: {
+    query: z.string().optional().describe('ADR number (e.g. "001") or keyword (e.g. "backend"). Omit to list all ADRs.'),
+  },
+  handler: async ({ query }) => {
+    const adrDir = join(SCORE_ROOT, 'docs', 'adr')
+    if (!existsSync(adrDir)) {
+      return { content: [{ type: 'text', text: 'No ADRs yet. Create them in docs/adr/ with format: 001-title.md' }] }
+    }
+
+    const files = readdirSync(adrDir).filter((f) => f.endsWith('.md')).sort()
+
+    if (!query) {
+      return { content: [{ type: 'text', text: `# ADR Index\n\n${files.map((f) => `- ${f}`).join('\n') || 'No ADRs found'}` }] }
+    }
+
+    // Search by number
+    const byNumber = files.find((f) => f.startsWith(query.padStart(3, '0')))
+    if (byNumber) {
+      const content = readFile(join(adrDir, byNumber))
+      return { content: [{ type: 'text', text: content ?? `Could not read ${byNumber}` }] }
+    }
+
+    // Search by keyword
+    const matches = files.filter((f) => {
+      const content = readFile(join(adrDir, f)) ?? ''
+      return content.toLowerCase().includes(query.toLowerCase()) || f.toLowerCase().includes(query.toLowerCase())
+    })
+
+    if (matches.length === 0) return { content: [{ type: 'text', text: `No ADRs match "${query}"` }] }
+
+    const results = matches.map((f) => {
+      const content = readFile(join(adrDir, f)) ?? ''
+      const firstLine = content.split('\n').find((l) => l.startsWith('#')) ?? f
+      return `- **${f}**: ${firstLine.replace(/^#+\s*/, '')}`
+    })
+
+    return { content: [{ type: 'text', text: `# ADR Search: "${query}"\n\n${results.join('\n')}` }] }
+  },
+}
+
+// ─── Server ──────────────────────────────────────────────────────────
+
+const tools = [architectureRules, packageGraph, apiSurface, projectStatus, adrLookup]
+
+const createServer = () => {
+  const server = new McpServer({
+    name: 'score-codebase',
+    version: '0.1.0',
+  })
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.inputSchema, tool.handler)
+  }
+
+  return server
+}
+
+const main = async () => {
+  const server = createServer()
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}
+
+main().catch((err) => {
+  process.stderr.write(`score-codebase MCP error: ${err}\n`)
+  process.exit(1)
+})

--- a/mcp-servers/score-codebase/index.js
+++ b/mcp-servers/score-codebase/index.js
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url'
 import { execSync } from 'node:child_process'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const SCORE_ROOT = resolve(__dirname, '../../')
+const SCORE_ROOT = resolve(__dirname, '../../../')
 
 const readFile = (path) => {
   try {

--- a/mcp-servers/score-codebase/package.json
+++ b/mcp-servers/score-codebase/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "score-codebase-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/mcp-servers/score-codebase/package.json
+++ b/mcp-servers/score-codebase/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "build": "npx esbuild index.js --bundle --platform=node --format=esm --outfile=dist/index.js",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,9 +19,12 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@score/core": "workspace:*"
+    "@score/core": "workspace:*",
+    "@score/dsl": "workspace:*",
+    "@score/sequencer": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^2.0.0",
     "vitest": "^2.0.0"
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'node:child_process'
+
+export const doctor = (_args: string[]): void => {
+  console.log('Score Doctor — system check')
+  console.log('─'.repeat(44))
+
+  const nodeVer = process.version
+  const nodeMajor = parseInt(nodeVer.slice(1))
+  const nodeOk = nodeMajor >= 20
+  console.log(`Node.js ${nodeVer}${' '.repeat(Math.max(1, 28 - nodeVer.length))}${nodeOk ? '✅' : '❌ (need 20+)'}`)
+
+  try {
+    execSync('scsynth -v 2>&1', { stdio: 'ignore' })
+    console.log('SuperCollider                      ✅')
+  } catch {
+    console.log('SuperCollider                      ⚠️  not found (Web Audio fallback active)')
+  }
+
+  console.log('Web Audio (node-web-audio-api)     ✅')
+  console.log('')
+  if (nodeOk) {
+    console.log('Status: READY ✅')
+  } else {
+    console.log('Status: UPGRADE NODE ❌')
+    process.exit(1)
+  }
+}

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,0 +1,60 @@
+import { resolve } from 'node:path'
+import { writeFileSync, existsSync } from 'node:fs'
+import { ScoreError } from '@score/core'
+
+const SONG_TEMPLATE = `// Song — Score EDM Framework
+// Docs: https://score.dev/docs/dsl/song
+
+import { Song, Kick, Snare, HiHat, Intro, Drop, Outro } from '@score/dsl'
+
+// ── DRUMS ──────────────────────────────────────────────────────────────
+const kick = Kick({
+  pattern: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+  volume: 0.9,
+})
+
+const snare = Snare({
+  pattern: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+  volume: 0.8,
+})
+
+const hihat = HiHat({
+  pattern: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+  volume: 0.6,
+})
+
+// ── ARRANGEMENT ────────────────────────────────────────────────────────
+const arrangement = [
+  Intro(4,  [hihat]),
+  Drop(16,  [kick, snare, hihat]),
+  Outro(4,  [hihat]),
+]
+
+export default Song({
+  bpm: 140,
+  tracks: [kick, snare, hihat],
+  arrangement,
+})
+`
+
+export const newSong = (args: string[]): void => {
+  const [, name] = args
+  if (!name) {
+    throw ScoreError('Specify a song name', {
+      received: undefined,
+      fix: 'Usage: score new song <name.js>',
+      docs: 'https://score.dev/docs/cli/new',
+    })
+  }
+  const outPath = resolve(process.cwd(), name.endsWith('.js') ? name : `${name}.js`)
+  if (existsSync(outPath)) {
+    throw ScoreError(`File already exists: ${outPath}`, {
+      received: outPath,
+      fix: 'Choose a different name or delete the existing file first',
+      docs: 'https://score.dev/docs/cli/new',
+    })
+  }
+  writeFileSync(outPath, SONG_TEMPLATE, 'utf-8')
+  console.log(`Score: Created ${outPath}`)
+  console.log(`Score: Run with: score play ${name}`)
+}

--- a/packages/cli/src/commands/play.ts
+++ b/packages/cli/src/commands/play.ts
@@ -6,7 +6,7 @@ import type { SongDefinition } from '@score/dsl'
 import { createScoreEngine } from '../engine.js'
 
 export const play = async (args: string[]): Promise<void> => {
-  const filePath = args[0]
+  const filePath = args.find(a => !a.startsWith('-'))
   if (!filePath) {
     throw ScoreError('No song file specified', {
       received: undefined,

--- a/packages/cli/src/commands/play.ts
+++ b/packages/cli/src/commands/play.ts
@@ -1,0 +1,76 @@
+import { resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { ScoreError } from '@score/core'
+import type { SongDefinition } from '@score/dsl'
+import { createScoreEngine } from '../engine.js'
+
+export const play = async (args: string[]): Promise<void> => {
+  const filePath = args[0]
+  if (!filePath) {
+    throw ScoreError('No song file specified', {
+      received: undefined,
+      fix: 'Usage: score play <song.js>',
+      docs: 'https://score.dev/docs/cli/play',
+    })
+  }
+
+  const resolved = resolve(process.cwd(), filePath)
+  if (!existsSync(resolved)) {
+    throw ScoreError(`Song file not found: ${filePath}`, {
+      received: resolved,
+      fix: 'Check the file path and try again',
+      docs: 'https://score.dev/docs/cli/play',
+    })
+  }
+
+  const mod: Record<string, unknown> = await import(pathToFileURL(resolved).href) as Record<string, unknown>
+  const rawSong: unknown = mod['default']
+
+  if (!rawSong || typeof rawSong !== 'object') {
+    throw ScoreError('Song file must have a default export', {
+      received: typeof rawSong,
+      fix: "Add: export default Song({ bpm: 140, tracks: [...] }) at the end of your song file",
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+
+  const song = rawSong as SongDefinition
+
+  if (!song.bpm || song.bpm <= 0) {
+    throw ScoreError('Song must have a valid bpm', {
+      received: song.bpm,
+      fix: 'Song({ bpm: 140, ... }) — bpm must be a positive number',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+
+  const keyStr   = song.key   ? ` — ${song.key}`   : ''
+  const genreStr = song.genre ? ` — ${song.genre}` : ''
+  console.log(`Score: Playing — ${String(song.bpm)} BPM${keyStr}${genreStr}`)
+
+  if (song.arrangement.length > 0) {
+    const sections = song.arrangement
+      .map((s) => `${s.sectionType}(${String(s.bars)}b)`)
+      .join(' → ')
+    console.log(`Score: Arrangement — ${sections}`)
+  }
+
+  console.log(`Score: ${String(song.tracks.length)} track(s) loaded`)
+
+  const engine = createScoreEngine(song)
+  engine.start()
+  console.log('Score: Audio running — Press Ctrl+C to stop')
+
+  const keepAlive = setInterval(() => {}, 1000)
+
+  const cleanup = (): void => {
+    clearInterval(keepAlive)
+    engine.dispose()
+    console.log('\nScore: Stopped')
+    process.exit(0)
+  }
+
+  process.once('SIGINT', cleanup)
+  process.once('SIGTERM', cleanup)
+}

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -117,24 +117,24 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
       case 'kick': {
         const props = comp.props as KickProps
         const pattern = props.pattern ?? DEFAULT_KICK_PATTERN
-        createStepSequencer(transport, { pattern }, (hit) => {
-          if (hit) triggerKick(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+          if (hit) triggerKick(ctx, pos.time, props)
         })
         break
       }
       case 'snare': {
         const props = comp.props as SnareProps
         const pattern = props.pattern ?? DEFAULT_SNARE_PATTERN
-        createStepSequencer(transport, { pattern }, (hit) => {
-          if (hit) triggerSnare(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+          if (hit) triggerSnare(ctx, pos.time, props)
         })
         break
       }
       case 'hihat': {
         const props = comp.props as HiHatProps
         const pattern = props.pattern ?? DEFAULT_HIHAT_PATTERN
-        createStepSequencer(transport, { pattern }, (hit) => {
-          if (hit) triggerHiHat(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+          if (hit) triggerHiHat(ctx, pos.time, props)
         })
         break
       }
@@ -143,11 +143,11 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
         const pattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
         const voice = makeSynthVoice(props)
         synthVoices.push(voice)
-        createStepSequencer(transport, { pattern: pattern as number[] }, (val) => {
+        createStepSequencer(transport, { pattern: pattern as number[] }, (val, _step, pos) => {
           if (val > 0) {
-            voice.setFrequency(val, ctx.currentTime)
-            voice.setGain(props.gain ?? 0.25, ctx.currentTime)
-            voice.setGain(0.0, ctx.currentTime + step16thSec() * 0.75)
+            voice.setFrequency(val, pos.time)
+            voice.setGain(props.gain ?? 0.25, pos.time)
+            voice.setGain(0.0, pos.time + step16thSec() * 0.75)
           }
         })
         break

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -94,9 +94,10 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
   const ctx = webAudioBackend.createContext()
   const transport = createTransport(ctx, { bpm: song.bpm, ticksPerBeat: 4 })
 
-  // Validate at boundary — song files are plain JS, component may not be a descriptor
+  // Song authors pass InstrumentDescriptors directly as tracks (no Track() wrapper needed).
+  // Validate at the JS boundary — t may be a bare InstrumentDescriptor or a TrackComponent.
   const descriptors = song.tracks
-    .map(t => t.component)
+    .map(t => isInstrumentDescriptor(t) ? t : t.component)
     .filter(isInstrumentDescriptor)
 
   for (const comp of descriptors) {

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -79,33 +79,20 @@ export type ScoreEngine = {
   readonly dispose: () => void
 }
 
+// Per-note synth trigger — fresh oscillator per event, avoids gain scheduling conflicts
+const triggerSynth = (ctx: Context, time: number, props: SynthDSLProps, freq: number): void => {
+  const noteDur = 0.18  // note duration in seconds
+  const osc  = ctx.createOscillator({ type: props.wave ?? 'sawtooth', frequency: freq })
+  const gain = ctx.createGain({ gain: props.gain ?? 0.25 })
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+  osc.start(time)
+  osc.stop(time + noteDur)
+}
+
 export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
   const ctx = webAudioBackend.createContext()
   const transport = createTransport(ctx, { bpm: song.bpm, ticksPerBeat: 4 })
-
-  const step16thSec = (): number => 60 / (transport.bpm * 4)
-
-  // Build a sustained oscillator for synth tracks
-  type SynthVoice = { setFrequency: (f: number, t?: number) => void; setGain: (g: number, t?: number) => void; dispose: () => void }
-
-  const synthVoices: SynthVoice[] = []
-
-  const makeSynthVoice = (props: SynthDSLProps): SynthVoice => {
-    const osc  = ctx.createOscillator({ type: props.wave ?? 'sawtooth', frequency: props.frequency ?? 110 })
-    const gain = ctx.createGain({ gain: 0.0 })
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-    osc.start(ctx.currentTime)
-    return {
-      setFrequency: (f, t) => { osc.setFrequency(f, t); },
-      setGain:      (g, t) => { gain.setGain(g, t); },
-      dispose: () => {
-        try { osc.stop() } catch { /* already stopped */ }
-        try { osc.disconnect() } catch { /* already disconnected */ }
-        try { gain.disconnect() } catch { /* already disconnected */ }
-      },
-    }
-  }
 
   // Validate at boundary — song files are plain JS, component may not be a descriptor
   const descriptors = song.tracks
@@ -141,14 +128,8 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
       case 'synth': {
         const props = comp.props as SynthDSLProps
         const pattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
-        const voice = makeSynthVoice(props)
-        synthVoices.push(voice)
         createStepSequencer(transport, { pattern: pattern as number[] }, (val, _step, pos) => {
-          if (val > 0) {
-            voice.setFrequency(val, pos.time)
-            voice.setGain(props.gain ?? 0.25, pos.time)
-            voice.setGain(0.0, pos.time + step16thSec() * 0.75)
-          }
+          if (val > 0) triggerSynth(ctx, pos.time, props, val)
         })
         break
       }
@@ -160,7 +141,6 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
     stop:    () => { transport.stop(); },
     dispose: () => {
       transport.dispose()
-      for (const v of synthVoices) v.dispose()
       ctx.close().catch(() => {})
     },
   }

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -1,0 +1,167 @@
+// ScoreEngine — hydrates a SongDefinition into real audio.
+//
+// Interprets InstrumentDescriptor tracks by building oscillator-based
+// synth voices. No sample files required — everything is synthesis.
+//
+// Synthesis models:
+//   kick  — sine sweep (80→30 Hz, 250ms) — classic electronic kick
+//   snare — band-pass filtered noise burst + sine transient
+//   hihat — high-pass filtered noise burst (short decay)
+//   synth — sawtooth / square / sine / triangle oscillator
+
+import { webAudioBackend } from '@score/core'
+import { createTransport, createStepSequencer } from '@score/sequencer'
+import type { SongDefinition, InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps } from '@score/dsl'
+
+type Context = ReturnType<typeof webAudioBackend.createContext>
+
+// Type guard — validates at the JS/TS boundary (song files are plain JS)
+const isInstrumentDescriptor = (comp: unknown): comp is InstrumentDescriptor => {
+  if (typeof comp !== 'object' || comp === null) return false
+  return (comp as { _type?: unknown })._type === 'InstrumentDescriptor'
+}
+
+const DEFAULT_KICK_PATTERN  = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
+const DEFAULT_SNARE_PATTERN = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
+const DEFAULT_HIHAT_PATTERN = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+const DEFAULT_SYNTH_PATTERN = [1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+
+const triggerKick = (ctx: Context, time: number, props: KickProps): void => {
+  const freq = props.synth?.frequency ?? 80
+  const drop = props.synth?.pitchDrop ?? 0.1
+  const gain = props.volume ?? 0.85
+  const osc  = ctx.createOscillator({ type: 'sine', frequency: freq })
+  const vol  = ctx.createGain({ gain })
+  osc.connect(vol)
+  vol.connect(ctx.destination)
+  osc.start(time)
+  osc.setFrequency(30, time + drop)
+  osc.stop(time + drop + 0.15)
+}
+
+const triggerSnare = (ctx: Context, time: number, props: SnareProps): void => {
+  const gain = props.volume ?? 0.5
+  // Sine transient (body)
+  const body  = ctx.createOscillator({ type: 'sine', frequency: 185 })
+  const bGain = ctx.createGain({ gain: gain * 0.7 })
+  body.connect(bGain)
+  bGain.connect(ctx.destination)
+  body.start(time)
+  body.setFrequency(100, time + 0.05)
+  body.stop(time + 0.08)
+  // Noise (snappy)
+  const noise  = ctx.createNoise({ type: 'white' })
+  const filter = ctx.createFilter({ type: 'bandpass', frequency: 5000, Q: 0.8 })
+  const nGain  = ctx.createGain({ gain: gain * 0.5 })
+  noise.connect(filter)
+  filter.connect(nGain)
+  nGain.connect(ctx.destination)
+  noise.start(time)
+  noise.stop(time + 0.12)
+}
+
+const triggerHiHat = (ctx: Context, time: number, props: HiHatProps): void => {
+  const gain = props.volume ?? 0.25
+  const dur  = props.open ? 0.3 : 0.06
+  const noise  = ctx.createNoise({ type: 'white' })
+  const filter = ctx.createFilter({ type: 'highpass', frequency: 8000 })
+  const vol    = ctx.createGain({ gain })
+  noise.connect(filter)
+  filter.connect(vol)
+  vol.connect(ctx.destination)
+  noise.start(time)
+  noise.stop(time + dur)
+}
+
+export type ScoreEngine = {
+  readonly start: () => void
+  readonly stop: () => void
+  readonly dispose: () => void
+}
+
+export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
+  const ctx = webAudioBackend.createContext()
+  const transport = createTransport(ctx, { bpm: song.bpm, ticksPerBeat: 4 })
+
+  const step16thSec = (): number => 60 / (transport.bpm * 4)
+
+  // Build a sustained oscillator for synth tracks
+  type SynthVoice = { setFrequency: (f: number, t?: number) => void; setGain: (g: number, t?: number) => void; dispose: () => void }
+
+  const synthVoices: SynthVoice[] = []
+
+  const makeSynthVoice = (props: SynthDSLProps): SynthVoice => {
+    const osc  = ctx.createOscillator({ type: props.wave ?? 'sawtooth', frequency: props.frequency ?? 110 })
+    const gain = ctx.createGain({ gain: 0.0 })
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.start(ctx.currentTime)
+    return {
+      setFrequency: (f, t) => { osc.setFrequency(f, t); },
+      setGain:      (g, t) => { gain.setGain(g, t); },
+      dispose: () => {
+        try { osc.stop() } catch { /* already stopped */ }
+        try { osc.disconnect() } catch { /* already disconnected */ }
+        try { gain.disconnect() } catch { /* already disconnected */ }
+      },
+    }
+  }
+
+  // Validate at boundary — song files are plain JS, component may not be a descriptor
+  const descriptors = song.tracks
+    .map(t => t.component)
+    .filter(isInstrumentDescriptor)
+
+  for (const comp of descriptors) {
+    switch (comp.instrumentType) {
+      case 'kick': {
+        const props = comp.props as KickProps
+        const pattern = props.pattern ?? DEFAULT_KICK_PATTERN
+        createStepSequencer(transport, { pattern }, (hit) => {
+          if (hit) triggerKick(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        })
+        break
+      }
+      case 'snare': {
+        const props = comp.props as SnareProps
+        const pattern = props.pattern ?? DEFAULT_SNARE_PATTERN
+        createStepSequencer(transport, { pattern }, (hit) => {
+          if (hit) triggerSnare(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        })
+        break
+      }
+      case 'hihat': {
+        const props = comp.props as HiHatProps
+        const pattern = props.pattern ?? DEFAULT_HIHAT_PATTERN
+        createStepSequencer(transport, { pattern }, (hit) => {
+          if (hit) triggerHiHat(ctx, ctx.currentTime + step16thSec() * 0.5, props)
+        })
+        break
+      }
+      case 'synth': {
+        const props = comp.props as SynthDSLProps
+        const pattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
+        const voice = makeSynthVoice(props)
+        synthVoices.push(voice)
+        createStepSequencer(transport, { pattern: pattern as number[] }, (val) => {
+          if (val > 0) {
+            voice.setFrequency(val, ctx.currentTime)
+            voice.setGain(props.gain ?? 0.25, ctx.currentTime)
+            voice.setGain(0.0, ctx.currentTime + step16thSec() * 0.75)
+          }
+        })
+        break
+      }
+    }
+  }
+
+  return {
+    start:   () => { transport.play(); },
+    stop:    () => { transport.stop(); },
+    dispose: () => {
+      transport.dispose()
+      for (const v of synthVoices) v.dispose()
+      ctx.close().catch(() => {})
+    },
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,28 @@
-// @score/cli — Phase 1 stub
-export const _stub = true // Phase 1: stub only
+#!/usr/bin/env node
+import { play } from './commands/play.js'
+import { newSong } from './commands/new.js'
+import { doctor } from './commands/doctor.js'
+
+const [,, command, ...args] = process.argv
+
+const commands: Record<string, (args: string[]) => Promise<void> | void> = {
+  play:   args => play(args),
+  new:    args => { newSong(args); },
+  doctor: args => { doctor(args); },
+}
+
+const handler = commands[command ?? '']
+if (!handler) {
+  console.log('Score — EDM audio framework')
+  console.log('')
+  console.log('Usage:')
+  console.log('  score play <song.js>     Play a song file')
+  console.log('  score new song <name>    Create a new song from template')
+  console.log('  score doctor             Check system requirements')
+  process.exit(0)
+}
+
+void Promise.resolve(handler(args)).catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/packages/cli/tests/play.test.ts
+++ b/packages/cli/tests/play.test.ts
@@ -3,6 +3,15 @@ import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
+// Mock the engine so tests never open a real audio context (avoids JACK dependency on CI)
+vi.mock('../src/engine.js', () => ({
+  createScoreEngine: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}))
+
 // Helper — write a temp song file and return its path
 const writeTempSong = (content: string): string => {
   const dir = join(tmpdir(), 'score-cli-tests')

--- a/packages/cli/tests/play.test.ts
+++ b/packages/cli/tests/play.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Helper — write a temp song file and return its path
+const writeTempSong = (content: string): string => {
+  const dir = join(tmpdir(), 'score-cli-tests')
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, `test-song-${String(Date.now())}.mjs`)
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+describe('play command', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws ScoreError when no file arg given', async () => {
+    const { play } = await import('../src/commands/play.js')
+    await expect(play([])).rejects.toThrow()
+  })
+
+  it('throws ScoreError when file does not exist', async () => {
+    const { play } = await import('../src/commands/play.js')
+    await expect(play(['/nonexistent/path/song.js'])).rejects.toThrow()
+  })
+
+  it('throws ScoreError when default export is not an object', async () => {
+    const path = writeTempSong(`export default 42`)
+    const { play } = await import('../src/commands/play.js')
+    await expect(play([path])).rejects.toThrow()
+    unlinkSync(path)
+  })
+
+  it('throws ScoreError when bpm is missing', async () => {
+    const path = writeTempSong(`export default { tracks: [{}] }`)
+    const { play } = await import('../src/commands/play.js')
+    await expect(play([path])).rejects.toThrow()
+    unlinkSync(path)
+  })
+
+  it('plays a valid song — logs BPM and track count', async () => {
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: unknown) => { logs.push(String(msg)) })
+
+    // Mock process.once to prevent test from hanging
+    const onceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+    vi.spyOn(global, 'setInterval').mockReturnValue(1 as unknown as ReturnType<typeof setInterval>)
+
+    const path = writeTempSong(`
+      export default {
+        _type: 'SongDefinition',
+        bpm: 140,
+        key: 'Am',
+        genre: 'techno',
+        tracks: [{ _type: 'TrackComponent', component: {} }],
+        arrangement: [
+          { _type: 'SectionDefinition', sectionType: 'drop', bars: 16, tracks: [] }
+        ],
+      }
+    `)
+
+    const { play } = await import('../src/commands/play.js')
+    await play([path])
+
+    expect(logs.some(l => l.includes('140 BPM'))).toBe(true)
+    expect(logs.some(l => l.includes('Am'))).toBe(true)
+    expect(logs.some(l => l.includes('techno'))).toBe(true)
+    expect(logs.some(l => l.includes('1 track'))).toBe(true)
+
+    unlinkSync(path)
+    onceSpy.mockRestore()
+  })
+
+  // Memory leak check: setInterval is cleared on SIGINT
+  it('clears keepAlive interval on SIGINT (no leak)', async () => {
+    const clearSpy = vi.spyOn(global, 'clearInterval')
+    let sigintHandler: (() => void) | undefined
+
+    vi.spyOn(process, 'once').mockImplementation((event: string | symbol, handler: (...args: unknown[]) => void) => {
+      if (event === 'SIGINT') sigintHandler = handler as () => void
+      return process
+    })
+    vi.spyOn(global, 'setInterval').mockReturnValue(99 as unknown as ReturnType<typeof setInterval>)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const path = writeTempSong(`
+      export default { _type: 'SongDefinition', bpm: 120, tracks: [{}], arrangement: [] }
+    `)
+
+    const { play } = await import('../src/commands/play.js')
+
+    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never)
+    await play([path])
+
+    if (sigintHandler) sigintHandler()
+
+    expect(clearSpy).toHaveBeenCalledWith(99)
+    expect(exitSpy).toHaveBeenCalledWith(0)
+    unlinkSync(path)
+    exitSpy.mockRestore()
+  })
+})

--- a/packages/cli/tests/sequence-cli.test.ts
+++ b/packages/cli/tests/sequence-cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+describe('new command', () => {
+  it('throws ScoreError when no name given', async () => {
+    const { newSong } = await import('../src/commands/new.js')
+    expect(() => { newSong(['song']); }).toThrow() // 'song' is subcommand, name is missing
+  })
+
+  it('creates song file with template content', async () => {
+    const { newSong } = await import('../src/commands/new.js')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const dir = join(tmpdir(), 'score-new-test')
+    mkdirSync(dir, { recursive: true })
+    const name = join(dir, `test-${String(Date.now())}.js`)
+    newSong(['song', name])
+    const { readFileSync } = await import('node:fs')
+    const content = readFileSync(name, 'utf-8')
+    expect(content).toContain('export default Song(')
+    expect(content).toContain('bpm:')
+    unlinkSync(name)
+    vi.restoreAllMocks()
+  })
+
+  it('throws ScoreError if file already exists', async () => {
+    const { newSong } = await import('../src/commands/new.js')
+    const dir = join(tmpdir(), 'score-new-test-2')
+    mkdirSync(dir, { recursive: true })
+    const name = join(dir, `existing-${String(Date.now())}.js`)
+    writeFileSync(name, 'existing', 'utf-8')
+    expect(() => { newSong(['song', name]); }).toThrow()
+    unlinkSync(name)
+  })
+})

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -22,6 +22,7 @@
     "@score/core": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^2.0.0",
     "vitest": "^2.0.0"
   }

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -1,2 +1,18 @@
-// @score/dsl — Phase 1 stub
-export const _stub = true // Phase 1: stub only
+export { Song } from './song.js'
+export { Intro, Buildup, Drop, Breakdown, Outro } from './sections.js'
+export { Track } from './track.js'
+export { Sequence } from './sequence.js'
+export { Kick, Snare, HiHat, Synth } from './instruments.js'
+export type {
+  SongDefinition,
+  SongProps,
+  SectionDefinition,
+  SectionType,
+  TrackComponent,
+  TrackProps,
+  InstrumentDescriptor,
+  KickProps,
+  SnareProps,
+  HiHatProps,
+  SynthDSLProps,
+} from './types.js'

--- a/packages/dsl/src/instruments.ts
+++ b/packages/dsl/src/instruments.ts
@@ -1,0 +1,31 @@
+// DSL-level instrument factories — return pure data descriptors.
+// No AudioContext is created here. The ScoreEngine hydrates these at play time.
+//
+// These satisfy the AudioComponent interface minimally so Track() accepts them.
+// connect/disconnect/dispose are no-ops; the engine replaces them at hydration.
+
+import type { BackendNode } from '@score/core'
+import { uid } from '@score/core'
+import type { InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps } from './types.js'
+
+const makeDescriptor = (
+  instrumentType: InstrumentDescriptor['instrumentType'],
+  props: InstrumentDescriptor['props'],
+): InstrumentDescriptor => {
+  const desc: InstrumentDescriptor = {
+    _type: 'InstrumentDescriptor',
+    instrumentType,
+    props,
+    id: uid(instrumentType),
+    type: instrumentType,
+    connect: (_dest: BackendNode) => desc,
+    disconnect: () => desc,
+    dispose: () => {},
+  }
+  return desc
+}
+
+export const Kick  = (props?: KickProps):     InstrumentDescriptor => makeDescriptor('kick',  props ?? {})
+export const Snare = (props?: SnareProps):    InstrumentDescriptor => makeDescriptor('snare', props ?? {})
+export const HiHat = (props?: HiHatProps):   InstrumentDescriptor => makeDescriptor('hihat', props ?? {})
+export const Synth = (props?: SynthDSLProps): InstrumentDescriptor => makeDescriptor('synth', props ?? {})

--- a/packages/dsl/src/sections.ts
+++ b/packages/dsl/src/sections.ts
@@ -1,0 +1,15 @@
+import type { SectionDefinition, SectionType, TrackComponent } from './types.js'
+
+const makeSection = (sectionType: SectionType) =>
+  (bars: number, tracks: TrackComponent[]): SectionDefinition => ({
+    _type: 'SectionDefinition',
+    sectionType,
+    bars,
+    tracks,
+  })
+
+export const Intro     = makeSection('intro')
+export const Buildup   = makeSection('buildup')
+export const Drop      = makeSection('drop')
+export const Breakdown = makeSection('breakdown')
+export const Outro     = makeSection('outro')

--- a/packages/dsl/src/sequence.ts
+++ b/packages/dsl/src/sequence.ts
@@ -1,0 +1,21 @@
+import { ScoreError } from '@score/core'
+
+/**
+ * Parse a space-separated note notation string.
+ * '.' represents a rest (null). Consecutive spaces are collapsed.
+ *
+ * @example
+ * Sequence('A1 . C2 . G1') // → ['A1', null, 'C2', null, 'G1']
+ */
+export const Sequence = (notation: string): (string | null)[] => {
+  if (typeof notation !== 'string') {
+    throw ScoreError('Sequence notation must be a string', {
+      received: notation,
+      fix: "Pass a space-separated note string — e.g. Sequence('A1 . C2 . G1')",
+      docs: 'https://score.dev/docs/dsl/sequence',
+    })
+  }
+  const trimmed = notation.trim()
+  if (trimmed === '') return []
+  return trimmed.split(/\s+/).map(token => (token === '.' ? null : token))
+}

--- a/packages/dsl/src/song.ts
+++ b/packages/dsl/src/song.ts
@@ -1,0 +1,29 @@
+import { ScoreError } from '@score/core'
+import type { SongProps, SongDefinition } from './types.js'
+
+export const Song = (props: SongProps): SongDefinition => {
+  if (!props.bpm || props.bpm <= 0) {
+    throw ScoreError('Song bpm must be a positive number', {
+      received: props.bpm,
+      fix: 'Provide a positive bpm — e.g. Song({ bpm: 140, tracks: [...] })',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  if (props.tracks.length === 0) {
+    throw ScoreError('Song requires at least one track', {
+      received: props.tracks,
+      fix: 'Provide an array of tracks — e.g. Song({ bpm: 140, tracks: [kick] })',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  return {
+    _type: 'SongDefinition',
+    bpm: props.bpm,
+    tracks: props.tracks,
+    arrangement: props.arrangement ?? [],
+    ...(props.key     !== undefined && { key:     props.key }),
+    ...(props.genre   !== undefined && { genre:   props.genre }),
+    ...(props.backend !== undefined && { backend: props.backend }),
+    ...(props.xdj     !== undefined && { xdj:     props.xdj }),
+  }
+}

--- a/packages/dsl/src/track.ts
+++ b/packages/dsl/src/track.ts
@@ -1,0 +1,11 @@
+import type { AudioComponent } from '@score/core'
+import type { TrackComponent, TrackProps } from './types.js'
+
+export const Track = (component: AudioComponent, props?: TrackProps): TrackComponent => ({
+  _type: 'TrackComponent',
+  component,
+  ...(props?.volume !== undefined && { volume: props.volume }),
+  ...(props?.pan    !== undefined && { pan:    props.pan }),
+  ...(props?.mute   !== undefined && { mute:   props.mute }),
+  ...(props?.solo   !== undefined && { solo:   props.solo }),
+})

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -1,0 +1,83 @@
+import type { AudioComponent } from '@score/core'
+
+// ── Instrument descriptors ────────────────────────────────────────────────────
+// Pure data — no AudioContext. The engine hydrates these at play time.
+
+export type KickProps = {
+  readonly pattern?: number[]
+  readonly volume?: number
+  readonly synth?: { frequency?: number; pitchDrop?: number }
+}
+
+export type SnareProps = {
+  readonly pattern?: number[]
+  readonly volume?: number
+}
+
+export type HiHatProps = {
+  readonly pattern?: number[]
+  readonly volume?: number
+  readonly open?: boolean
+}
+
+export type SynthDSLProps = {
+  readonly wave?: 'sine' | 'square' | 'sawtooth' | 'triangle'
+  readonly frequency?: number
+  readonly gain?: number
+  readonly pattern?: number[]
+  readonly sequence?: string[]  // parsed Sequence output
+}
+
+export type InstrumentDescriptor = {
+  readonly _type: 'InstrumentDescriptor'
+  readonly instrumentType: 'kick' | 'snare' | 'hihat' | 'synth'
+  readonly props: KickProps | SnareProps | HiHatProps | SynthDSLProps
+  // Minimal AudioComponent shape so Track() accepts it
+  readonly id: string
+  readonly type: string
+  readonly connect: AudioComponent['connect']
+  readonly disconnect: AudioComponent['disconnect']
+  readonly dispose: AudioComponent['dispose']
+}
+
+export type SongProps = {
+  readonly bpm: number
+  readonly key?: string
+  readonly genre?: string
+  readonly tracks: TrackComponent[]
+  readonly arrangement?: SectionDefinition[]
+  readonly backend?: 'web-audio' | 'scsynth' | 'jack'
+  readonly xdj?: { mode: 'score-mixer' | 'hardware-mixer' | 'hybrid' }
+}
+
+export type SongDefinition = {
+  readonly _type: 'SongDefinition'
+  readonly bpm: number
+  readonly key?: string
+  readonly genre?: string
+  readonly tracks: TrackComponent[]
+  readonly arrangement: SectionDefinition[]
+  readonly backend?: string
+  readonly xdj?: { mode: 'score-mixer' | 'hardware-mixer' | 'hybrid' }
+}
+
+export type SectionType = 'intro' | 'buildup' | 'drop' | 'breakdown' | 'outro'
+
+export type SectionDefinition = {
+  readonly _type: 'SectionDefinition'
+  readonly sectionType: SectionType
+  readonly bars: number
+  readonly tracks: TrackComponent[]
+}
+
+export type TrackProps = {
+  readonly volume?: number
+  readonly pan?: number
+  readonly mute?: boolean
+  readonly solo?: boolean
+}
+
+export type TrackComponent = TrackProps & {
+  readonly _type: 'TrackComponent'
+  readonly component: AudioComponent
+}

--- a/packages/dsl/tests/sections.test.ts
+++ b/packages/dsl/tests/sections.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { Intro, Buildup, Drop, Breakdown, Outro } from '../src/sections.js'
+import { Track } from '../src/track.js'
+import { createMockComponent } from './utils.js'
+
+describe('Section factories', () => {
+  const makeTrack = () => Track(createMockComponent())
+
+  it.each([
+    ['Intro',     Intro,     'intro'    ],
+    ['Buildup',   Buildup,   'buildup'  ],
+    ['Drop',      Drop,      'drop'     ],
+    ['Breakdown', Breakdown, 'breakdown'],
+    ['Outro',     Outro,     'outro'    ],
+  ] as const)('%s sets correct sectionType', (_name, factory, expectedType) => {
+    const section = factory(8, [makeTrack()])
+    expect(section._type).toBe('SectionDefinition')
+    expect(section.sectionType).toBe(expectedType)
+    expect(section.bars).toBe(8)
+  })
+
+  it('preserves track references (no copies)', () => {
+    const track = makeTrack()
+    const section = Drop(16, [track])
+    expect(section.tracks[0]).toBe(track)
+  })
+
+  // Memory leak check: sections are plain data, no retained closures
+  it('section holds no closures or hidden state', () => {
+    const tracks = [makeTrack(), makeTrack()]
+    const section = Drop(32, tracks)
+    expect(Object.keys(section)).toEqual(['_type', 'sectionType', 'bars', 'tracks'])
+  })
+})

--- a/packages/dsl/tests/sequence.test.ts
+++ b/packages/dsl/tests/sequence.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { Sequence } from '../src/sequence.js'
+
+describe('Sequence', () => {
+  it('parses notes and rests', () => {
+    expect(Sequence('A1 . C2 . G1')).toEqual(['A1', null, 'C2', null, 'G1'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(Sequence('')).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(Sequence('   ')).toEqual([])
+  })
+
+  it('handles single note', () => {
+    expect(Sequence('A1')).toEqual(['A1'])
+  })
+
+  it('handles single rest', () => {
+    expect(Sequence('.')).toEqual([null])
+  })
+
+  it('collapses multiple spaces', () => {
+    expect(Sequence('A1  .  C2')).toEqual(['A1', null, 'C2'])
+  })
+
+  it('handles all rests', () => {
+    expect(Sequence('. . . .')).toEqual([null, null, null, null])
+  })
+
+  it('preserves octave and accidental notation', () => {
+    expect(Sequence('C#4 Db3 F#2')).toEqual(['C#4', 'Db3', 'F#2'])
+  })
+
+  it('throws ScoreError for non-string input', () => {
+    expect(() => Sequence(null as unknown as string)).toThrow()
+  })
+})

--- a/packages/dsl/tests/song.test.ts
+++ b/packages/dsl/tests/song.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { Song } from '../src/song.js'
+import { Track } from '../src/track.js'
+import { createMockComponent } from './utils.js'
+
+describe('Song', () => {
+  const makeTrack = () => Track(createMockComponent())
+
+  it('creates a SongDefinition with required fields', () => {
+    const song = Song({ bpm: 140, tracks: [makeTrack()] })
+    expect(song._type).toBe('SongDefinition')
+    expect(song.bpm).toBe(140)
+  })
+
+  it('defaults arrangement to empty array', () => {
+    const song = Song({ bpm: 140, tracks: [makeTrack()] })
+    expect(song.arrangement).toEqual([])
+  })
+
+  it('preserves optional fields', () => {
+    const song = Song({ bpm: 128, key: 'Am', genre: 'techno', tracks: [makeTrack()] })
+    expect(song.key).toBe('Am')
+    expect(song.genre).toBe('techno')
+  })
+
+  it('throws ScoreError when bpm is 0', () => {
+    expect(() => Song({ bpm: 0, tracks: [makeTrack()] })).toThrow()
+  })
+
+  it('throws ScoreError when bpm is negative', () => {
+    expect(() => Song({ bpm: -120, tracks: [makeTrack()] })).toThrow()
+  })
+
+  it('throws ScoreError when tracks is empty', () => {
+    expect(() => Song({ bpm: 140, tracks: [] })).toThrow()
+  })
+
+  // Memory leak check: SongDefinition holds no references beyond what was passed in
+  it('does not retain extra references (memory leak check)', () => {
+    const comp = createMockComponent()
+    const track = Track(comp)
+    const song = Song({ bpm: 140, tracks: [track] })
+    // Verify song holds exactly the tracks passed — no hidden copies
+    expect(song.tracks).toHaveLength(1)
+    expect(song.tracks[0]).toBe(track)
+    // Disposing underlying component does not corrupt song definition
+    comp.dispose()
+    expect(comp.disposed).toBe(true)
+    expect(song.bpm).toBe(140) // Song definition unaffected
+  })
+})

--- a/packages/dsl/tests/track.test.ts
+++ b/packages/dsl/tests/track.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { Track } from '../src/track.js'
+import { createMockComponent } from './utils.js'
+
+describe('Track', () => {
+  it('wraps a component', () => {
+    const comp = createMockComponent()
+    const track = Track(comp)
+    expect(track._type).toBe('TrackComponent')
+    expect(track.component).toBe(comp)
+  })
+
+  it('applies optional props', () => {
+    const track = Track(createMockComponent(), { volume: 0.8, pan: -0.5, mute: false, solo: true })
+    expect(track.volume).toBe(0.8)
+    expect(track.pan).toBe(-0.5)
+    expect(track.mute).toBe(false)
+    expect(track.solo).toBe(true)
+  })
+
+  it('leaves optional props undefined when not provided', () => {
+    const track = Track(createMockComponent())
+    expect(track.volume).toBeUndefined()
+    expect(track.pan).toBeUndefined()
+    expect(track.mute).toBeUndefined()
+    expect(track.solo).toBeUndefined()
+  })
+
+  // Memory leak check: Track holds component reference — disposing component is caller's responsibility
+  it('component can be disposed without corrupting track wrapper', () => {
+    const comp = createMockComponent()
+    const track = Track(comp)
+    comp.dispose()
+    expect(comp.disposed).toBe(true)
+    expect(track._type).toBe('TrackComponent') // wrapper unaffected
+  })
+})

--- a/packages/dsl/tests/utils.ts
+++ b/packages/dsl/tests/utils.ts
@@ -1,0 +1,15 @@
+import type { AudioComponent, BackendNode } from '@score/core'
+
+// Tracks disposal to catch memory leaks
+export const createMockComponent = (): AudioComponent & { disposed: boolean; connectedNodes: BackendNode[] } => {
+  const comp = {
+    id: `mock-${Math.random().toString(36).slice(2)}`,
+    type: 'mock',
+    disposed: false,
+    connectedNodes: [] as BackendNode[],
+    connect(dest: BackendNode): AudioComponent { comp.connectedNodes.push(dest); return comp },
+    disconnect(): AudioComponent { comp.connectedNodes.length = 0; return comp },
+    dispose(): void { comp.disposed = true; comp.connectedNodes.length = 0 },
+  }
+  return comp
+}

--- a/packages/mixer/src/group.ts
+++ b/packages/mixer/src/group.ts
@@ -1,0 +1,92 @@
+// Group bus — submix bus that aggregates multiple channels before the master
+// Audio flow: input (channels connect here) → EQ → volume → output (connects to master)
+// Use for drum bus, synth bus, etc. — apply shared processing to a group of tracks
+
+import type { AudioComponent, ScoreAudioContext, ScoreAudioNode, BackendNode } from '@score/core'
+import { uid } from '@score/core'
+import { createEQ, createEffectsChain } from '@score/effects'
+import type { EQProps } from '@score/effects'
+
+export type GroupProps = {
+  readonly name?: string
+  readonly volume?: number      // 0-1, default 0.8
+  readonly effects?: ReadonlyArray<AudioComponent>
+  readonly eq?: EQProps
+}
+
+export const createGroup = (
+  context: ScoreAudioContext,
+  props?: GroupProps,
+) => {
+  const groupName = props?.name ?? 'Group'
+
+  const inputGain = context.createGain({ gain: 1.0 })
+  const outputGain = context.createGain({ gain: 1.0 })
+
+  // Effects chain (optional)
+  const effects = props?.effects ? [...props.effects] : []
+  const chain = effects.length > 0 ? createEffectsChain(context, effects) : null
+
+  if (chain) {
+    inputGain.connect(chain.input)
+  }
+
+  // EQ
+  const eq = createEQ(context, props?.eq)
+
+  // Connect chain output (or input directly) to EQ
+  if (chain) {
+    chain.connect(eq as unknown as BackendNode)
+  } else {
+    inputGain.connect(eq as unknown as BackendNode)
+  }
+
+  // Volume
+  const volumeGain = context.createGain({ gain: props?.volume ?? 0.8 })
+  eq.connect(volumeGain)
+  volumeGain.connect(outputGain)
+
+  const component: AudioComponent & {
+    readonly input: BackendNode
+    readonly name: string
+    readonly setVolume: (value: number, time?: number) => void
+    readonly setEQ: (eqProps: EQProps) => void
+  } = {
+    id: uid('group'),
+    type: 'group' as const,
+    input: inputGain,
+    get name() { return groupName },
+
+    setVolume: (value: number, time?: number) => {
+      volumeGain.setGain(value, time)
+    },
+
+    setEQ: (eqProps: EQProps) => {
+      if (eqProps.low !== undefined) { eq.setLow(eqProps.low) }
+      if (eqProps.mid !== undefined) { eq.setMid(eqProps.mid) }
+      if (eqProps.high !== undefined) { eq.setHigh(eqProps.high) }
+    },
+
+    connect: (destination: ScoreAudioNode) => {
+      outputGain.connect(destination)
+      return component
+    },
+
+    disconnect: () => {
+      try { outputGain.disconnect() } catch { /* already disconnected */ }
+      return component
+    },
+
+    dispose: () => {
+      if (chain) {
+        try { chain.dispose() } catch { /* already disposed */ }
+      }
+      try { eq.dispose() } catch { /* already disposed */ }
+      try { inputGain.disconnect() } catch { /* already disconnected */ }
+      try { volumeGain.disconnect() } catch { /* already disconnected */ }
+      try { outputGain.disconnect() } catch { /* already disconnected */ }
+    },
+  }
+
+  return component
+}

--- a/packages/mixer/src/index.ts
+++ b/packages/mixer/src/index.ts
@@ -1,8 +1,10 @@
 // @score/mixer — Mixing console for the Score EDM framework
 
 export { createChannel } from './channel.js'
-export type { ChannelProps } from './channel.js'
+export type { ChannelProps, SendComponent } from './channel.js'
 export { createReturn } from './return.js'
 export type { ReturnProps } from './return.js'
+export { createGroup } from './group.js'
+export type { GroupProps } from './group.js'
 export { createMixer } from './mixer.js'
 export type { MixerProps } from './mixer.js'

--- a/packages/mixer/src/mixer.ts
+++ b/packages/mixer/src/mixer.ts
@@ -9,10 +9,13 @@ import { createChannel } from './channel.js'
 import type { ChannelProps } from './channel.js'
 import { createReturn } from './return.js'
 import type { ReturnProps } from './return.js'
+import { createGroup } from './group.js'
+import type { GroupProps } from './group.js'
 
 export type MixerProps = {
   readonly channels?: ReadonlyArray<ChannelProps>
   readonly returns?: ReadonlyArray<ReturnProps>
+  readonly groups?: ReadonlyArray<GroupProps>
   readonly masterVolume?: number  // 0-1, default 0.8
   readonly limiterCeiling?: number // dB, default -0.3
 }
@@ -35,9 +38,10 @@ export const createMixer = (
   subOutputGain.connect(limiter as unknown as BackendNode)
   limiter.connect(context.destination)
 
-  // Channel and return arrays (mutable for add/remove)
+  // Channel, return, and group arrays (mutable for add/remove)
   const channels: Array<ReturnType<typeof createChannel>> = []
   const returns: Array<ReturnType<typeof createReturn>> = []
+  const groups: Array<ReturnType<typeof createGroup>> = []
 
   // Solo state management
   const updateSoloState = () => {
@@ -69,12 +73,23 @@ export const createMixer = (
     }
   }
 
+  // Create initial groups (output to master by default)
+  if (props?.groups) {
+    for (const grpProps of props.groups) {
+      const grp = createGroup(context, grpProps)
+      grp.connect(masterGain)
+      groups.push(grp)
+    }
+  }
+
   const component: AudioComponent & {
     readonly getChannel: (index: number) => ReturnType<typeof createChannel> | undefined
     readonly getReturn: (index: number) => ReturnType<typeof createReturn> | undefined
+    readonly getGroup: (index: number) => ReturnType<typeof createGroup> | undefined
     readonly setMasterVolume: (value: number, time?: number) => void
     readonly addChannel: (channelProps?: ChannelProps) => ReturnType<typeof createChannel>
     readonly removeChannel: (index: number) => void
+    readonly addGroup: (groupProps?: GroupProps) => ReturnType<typeof createGroup>
   } = {
     id: uid('mixer'),
     type: 'mixer' as const,
@@ -89,6 +104,11 @@ export const createMixer = (
       return ret ? ret : undefined
     },
 
+    getGroup: (index: number) => {
+      const grp = groups[index]
+      return grp ? grp : undefined
+    },
+
     setMasterVolume: (value: number, time?: number) => {
       masterGain.setGain(value, time)
     },
@@ -98,6 +118,13 @@ export const createMixer = (
       ch.connect(masterGain)
       channels.push(ch)
       return ch
+    },
+
+    addGroup: (groupProps?: GroupProps) => {
+      const grp = createGroup(context, groupProps)
+      grp.connect(masterGain)
+      groups.push(grp)
+      return grp
     },
 
     removeChannel: (index: number) => {
@@ -134,6 +161,10 @@ export const createMixer = (
       for (const ret of returns) {
         try { ret.disconnect() } catch { /* already disconnected */ }
         try { ret.dispose() } catch { /* already disposed */ }
+      }
+      for (const grp of groups) {
+        try { grp.disconnect() } catch { /* already disconnected */ }
+        try { grp.dispose() } catch { /* already disposed */ }
       }
       try { masterEQ.dispose() } catch { /* already disposed */ }
       try { limiter.dispose() } catch { /* already disposed */ }

--- a/packages/mixer/tests/group.test.ts
+++ b/packages/mixer/tests/group.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { useHarness } from './utils/harness.js'
+import { createGroup } from '../src/group.js'
+
+const h = useHarness()
+afterAll(() => h.cleanup())
+
+describe('createGroup', () => {
+  it('returns an AudioComponent (has connect, disconnect, dispose)', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(typeof g.connect).toBe('function')
+    expect(typeof g.disconnect).toBe('function')
+    expect(typeof g.dispose).toBe('function')
+  })
+
+  it('has input property for channel connections', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(g.input).toBeDefined()
+    expect(typeof g.input.connect).toBe('function')
+  })
+
+  it('has name property with default', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(g.name).toBe('Group')
+  })
+
+  it('accepts custom name', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx, { name: 'Drums' })
+    expect(g.name).toBe('Drums')
+  })
+
+  it('creates EQ filters and gain nodes', () => {
+    const ctx = h.mockContext()
+    createGroup(ctx)
+    // EQ = 3 filters, inputGain + volumeGain + outputGain = 3 gains
+    expect(ctx.createdFilters.length).toBe(3)
+    expect(ctx.createdGains.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('accepts custom volume', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx, { volume: 0.6 })
+    expect(g).toBeDefined()
+  })
+
+  it('accepts custom eq props', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx, { eq: { low: -3, mid: 2 } })
+    expect(g).toBeDefined()
+  })
+
+  it('setVolume does not throw', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(() => { g.setVolume(0.5) }).not.toThrow()
+  })
+
+  it('setVolume accepts optional time parameter', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(() => { g.setVolume(0.5, 1.0) }).not.toThrow()
+  })
+
+  it('setEQ does not throw', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(() => { g.setEQ({ low: -3, mid: 2, high: 1 }) }).not.toThrow()
+  })
+
+  it('setEQ with partial props does not throw', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(() => { g.setEQ({ low: -3 }) }).not.toThrow()
+  })
+
+  it('connect returns self for chaining', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(g.connect(ctx.destination)).toBe(g)
+  })
+
+  it('disconnect returns self for chaining', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    g.connect(ctx.destination)
+    expect(g.disconnect()).toBe(g)
+  })
+
+  it('dispose cleans up without throwing', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    g.connect(ctx.destination)
+    expect(() => { g.dispose() }).not.toThrow()
+  })
+
+  it('dispose when not connected does not throw', () => {
+    const ctx = h.mockContext()
+    const g = createGroup(ctx)
+    expect(() => { g.dispose() }).not.toThrow()
+  })
+
+  it('disconnect swallows error when already disconnected', () => {
+    const ctx = h.mockThrowingContext()
+    const g = createGroup(ctx)
+    expect(() => { g.disconnect() }).not.toThrow()
+  })
+
+  it('dispose swallows errors when nodes already disconnected', () => {
+    const ctx = h.mockThrowingContext()
+    const g = createGroup(ctx)
+    expect(() => { g.dispose() }).not.toThrow()
+  })
+})

--- a/packages/mixer/tests/mixer.test.ts
+++ b/packages/mixer/tests/mixer.test.ts
@@ -216,4 +216,37 @@ describe('createMixer', () => {
     expect(ch0.solo).toBe(false)
     expect(ch1.solo).toBe(false)
   })
+
+  it('creates initial groups from props', () => {
+    const ctx = h.mockContext()
+    const mixer = createMixer(ctx, {
+      groups: [{ name: 'Drums' }],
+    })
+    const grp = mixer.getGroup(0)
+    expect(grp).toBeDefined()
+    expect(grp!.name).toBe('Drums')
+  })
+
+  it('getGroup returns undefined for out-of-range index', () => {
+    const ctx = h.mockContext()
+    const mixer = createMixer(ctx)
+    expect(mixer.getGroup(0)).toBeUndefined()
+  })
+
+  it('addGroup creates and returns a new group', () => {
+    const ctx = h.mockContext()
+    const mixer = createMixer(ctx)
+    const grp = mixer.addGroup({ name: 'Synths' })
+    expect(grp).toBeDefined()
+    expect(grp.name).toBe('Synths')
+    expect(mixer.getGroup(0)).toBe(grp)
+  })
+
+  it('dispose cleans up groups without throwing', () => {
+    const ctx = h.mockContext()
+    const mixer = createMixer(ctx, {
+      groups: [{ name: 'Drums' }],
+    })
+    expect(() => { mixer.dispose() }).not.toThrow()
+  })
 })

--- a/packages/sequencer/package.json
+++ b/packages/sequencer/package.json
@@ -22,6 +22,7 @@
     "@score/core": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^2.0.0",
     "vitest": "^2.0.0"
   }

--- a/packages/sequencer/src/transport.ts
+++ b/packages/sequencer/src/transport.ts
@@ -32,7 +32,7 @@ export const createTransport = (context: ClockContext, props?: TransportProps): 
 
   // Mutable state
   let currentState: TransportState = 'stopped'
-  let pos: Position = { bar: 0, beat: 0, tick: 0 }
+  let pos: Position = { bar: 0, beat: 0, tick: 0, time: 0 }
 
   const tickCallbacks: Array<(position: Position) => void> = []
   const beatCallbacks: Array<(position: Position) => void> = []
@@ -43,7 +43,7 @@ export const createTransport = (context: ClockContext, props?: TransportProps): 
     ticksPerBeat,
   })
 
-  clock.onTick((_tickTime: number, _tickNumber: number): void => {
+  clock.onTick((tickTime: number, _tickNumber: number): void => {
     const prevBeat = pos.beat
     const prevBar = pos.bar
 
@@ -61,7 +61,7 @@ export const createTransport = (context: ClockContext, props?: TransportProps): 
       nextBar += 1
     }
 
-    pos = { bar: nextBar, beat: nextBeat, tick: nextTick }
+    pos = { bar: nextBar, beat: nextBeat, tick: nextTick, time: tickTime }
 
     const snapshot = { ...pos }
 
@@ -93,7 +93,7 @@ export const createTransport = (context: ClockContext, props?: TransportProps): 
       if (currentState === 'stopped') return
       currentState = 'stopped'
       clock.stop()
-      pos = { bar: 0, beat: 0, tick: 0 }
+      pos = { bar: 0, beat: 0, tick: 0, time: 0 }
     },
 
     pause: (): void => {
@@ -103,7 +103,7 @@ export const createTransport = (context: ClockContext, props?: TransportProps): 
     },
 
     seek: (bar: number, beat?: number, tick?: number): void => {
-      pos = { bar, beat: beat ?? 0, tick: tick ?? 0 }
+      pos = { bar, beat: beat ?? 0, tick: tick ?? 0, time: pos.time }
     },
 
     get position() { return { ...pos } },

--- a/packages/sequencer/src/types.ts
+++ b/packages/sequencer/src/types.ts
@@ -1,5 +1,5 @@
 export type PatternInput<T = number> = T[] | Pattern<T>
 export type Pattern<T> = (step: number, bar: number) => T
 export type TransportState = 'stopped' | 'playing' | 'paused'
-export type Position = { bar: number; beat: number; tick: number }
+export type Position = { bar: number; beat: number; tick: number; time: number }
 export type SwingConfig = { amount: number } // 0-1, 0 = straight, 1 = full triplet

--- a/packages/sequencer/tests/transport.test.ts
+++ b/packages/sequencer/tests/transport.test.ts
@@ -78,29 +78,29 @@ describe('createTransport', () => {
     transport.dispose()
   })
 
-  it('initial position is { bar: 0, beat: 0, tick: 0 }', () => {
+  it('initial position is { bar: 0, beat: 0, tick: 0, time: 0 }', () => {
     const transport = createTransport(mockContext())
-    expect(transport.position).toEqual({ bar: 0, beat: 0, tick: 0 })
+    expect(transport.position).toEqual({ bar: 0, beat: 0, tick: 0, time: 0 })
   })
 
-  it('stop() resets position to { bar: 0, beat: 0, tick: 0 }', () => {
+  it('stop() resets position to { bar: 0, beat: 0, tick: 0, time: 0 }', () => {
     const transport = createTransport(mockContext())
     transport.play()
     transport.seek(2, 3, 1)
     transport.stop()
-    expect(transport.position).toEqual({ bar: 0, beat: 0, tick: 0 })
+    expect(transport.position).toEqual({ bar: 0, beat: 0, tick: 0, time: 0 })
   })
 
   it('seek() updates position', () => {
     const transport = createTransport(mockContext())
     transport.seek(2, 1, 3)
-    expect(transport.position).toEqual({ bar: 2, beat: 1, tick: 3 })
+    expect(transport.position).toMatchObject({ bar: 2, beat: 1, tick: 3 })
   })
 
   it('seek() with only bar param defaults beat/tick to 0', () => {
     const transport = createTransport(mockContext())
     transport.seek(5)
-    expect(transport.position).toEqual({ bar: 5, beat: 0, tick: 0 })
+    expect(transport.position).toMatchObject({ bar: 5, beat: 0, tick: 0 })
   })
 
   it('default BPM is 120', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,16 @@ importers:
       '@score/core':
         specifier: workspace:*
         version: link:../core
+      '@score/dsl':
+        specifier: workspace:*
+        version: link:../dsl
+      '@score/sequencer':
+        specifier: workspace:*
+        version: link:../sequencer
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
@@ -87,6 +96,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))
@@ -189,6 +201,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9(@types/node@25.5.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,18 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@25.5.0)
 
+  songs:
+    dependencies:
+      '@score/components':
+        specifier: workspace:*
+        version: link:../packages/components
+      '@score/dsl':
+        specifier: workspace:*
+        version: link:../packages/dsl
+      '@score/sequencer':
+        specifier: workspace:*
+        version: link:../packages/sequencer
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "songs"

--- a/songs/example-deep-house.js
+++ b/songs/example-deep-house.js
@@ -1,0 +1,78 @@
+// example-deep-house.js — Score demo song
+// Run with: score play songs/example-deep-house.js
+//
+// KEY DEMO POINTS:
+//   • Song files are pure ESM — no build step, no compilation
+//   • Instruments are factory functions with pattern arrays — reads like music
+//   • The engine hydrates descriptors into actual audio — song author never touches AudioContext
+//   • Arrangement is structural: Intro/Drop/Outro with explicit bar counts
+//   • Ctrl+C stops cleanly — all audio resources disposed
+
+import { Song, Kick, Snare, HiHat, Synth, Intro, Drop, Outro } from '@score/dsl'
+
+// ── KEY / SCALE ───────────────────────────────────────────────────────────────
+// D minor (warm, introspective — classic deep house tonality)
+// All frequencies are exact: D2=73.42 Hz, A2=110 Hz, F3=174.6 Hz etc.
+
+const D2 = 73.42
+const A2 = 110.0
+const C3 = 130.8
+const D3 = 146.8
+const F3 = 174.6
+const A3 = 220.0
+
+// ── DRUMS ─────────────────────────────────────────────────────────────────────
+// Patterns: 16-step arrays, 1 = hit, 0 = rest
+// 4 steps per beat × 4 beats = one bar
+
+const kick = Kick({
+  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],   // four on the floor
+  synth: { frequency: 75, pitchDrop: 0.09 },                         // tuned to D
+  volume: 0.9,
+})
+
+const snare = Snare({
+  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],   // 2 and 4
+  volume: 0.5,
+})
+
+const hihat = HiHat({
+  pattern: [1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0],   // 8th notes
+  volume: 0.2,
+})
+
+// ── SYNTHESIS ─────────────────────────────────────────────────────────────────
+// Sequence notation: note values separated by spaces, '.' = rest
+// Notes resolve to their frequency at play time
+
+const bass = Synth({
+  wave: 'sawtooth',
+  gain: 0.28,
+  // Dm root movement over 2 bars (collapsed to 16 steps)
+  pattern: [D2, 0, D2, 0,  0, D2, 0, A2,  C3, 0, C3, 0,  0, D3, 0, 0],
+})
+
+const pad = Synth({
+  wave: 'triangle',
+  gain: 0.12,
+  // Sparse chord stabs — syncopated deep house feel
+  pattern: [F3, 0, 0, 0,  A3, 0, 0, 0,  0,  0,  F3, 0,  0, 0, A3, 0],
+})
+
+// ── ARRANGEMENT ──────────────────────────────────────────────────────────────
+// Sections describe structure — the engine schedules audio accordingly.
+// Numbers = bars. Tracks listed = which instruments are active.
+
+export default Song({
+  bpm:    124,
+  key:    'Dm',
+  genre:  'deep-house',
+
+  tracks: [kick, snare, hihat, bass, pad],
+
+  arrangement: [
+    Intro(4,  [kick, bass]),
+    Drop(16,  [kick, snare, hihat, bass, pad]),
+    Outro(4,  [kick, bass]),
+  ],
+})

--- a/songs/example-techno.js
+++ b/songs/example-techno.js
@@ -1,31 +1,111 @@
-// example-techno.js — starter song file
-// Run with: node play songs/example-techno.js  (Phase 10+)
+// example-techno.js — working demo song
+// Run with: score play songs/example-techno.js
 //
-// This file shows the Score song format.
-// Everything here is a placeholder — components are built Phase 3–9.
+// Uses oscillator-based synthesis — no sample files required.
+// Live mode: exports run(context) so the CLI produces actual audio.
 
-// ── INSTRUMENTS ──────────────────────────────────────────────────────────────
+import { Synth } from '@score/components'
+import { createTransport, createStepSequencer } from '@score/sequencer'
+import { Song, Track, Drop, Intro, Outro } from '@score/dsl'
 
-// const kick = Kick({
-//   sample:    './samples/kicks/deep-kick.wav',
-//   pattern:   [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0],
-//   sidechain: true,
-//   volume:    0.9,
-// })
+// ── DSL DESCRIPTOR (structure + metadata) ────────────────────────────────────
 
-// ── SONG ─────────────────────────────────────────────────────────────────────
+const _kick  = Track({ component: { id: 'kick-desc',  type: 'kick',  connect: () => {}, disconnect: () => {}, dispose: () => {} } })
+const _bass  = Track({ component: { id: 'bass-desc',  type: 'synth', connect: () => {}, disconnect: () => {}, dispose: () => {} } })
+const _lead  = Track({ component: { id: 'lead-desc',  type: 'synth', connect: () => {}, disconnect: () => {}, dispose: () => {} } })
 
-// export default Song({
-//   bpm:    140,
-//   key:    'Am',
-//   genre:  'techno',
-//   tracks: [kick],
-//   arrangement: [
-//     Intro(4,  [kick]),
-//     Drop(16,  [kick]),
-//     Outro(4,  [kick]),
-//   ],
-// })
+export default Song({
+  bpm: 140,
+  key: 'Am',
+  genre: 'techno',
+  tracks: [_kick, _bass, _lead],
+  arrangement: [
+    Intro(4,  [_kick, _bass]),
+    Drop(16,  [_kick, _bass, _lead]),
+    Outro(4,  [_kick, _bass]),
+  ],
+})
 
-// Components not yet built — uncomment as each phase completes.
-export const _placeholder = true
+// ── LIVE ENGINE (produces actual audio) ──────────────────────────────────────
+// The CLI calls run(context) when this export is present.
+
+const A2 = 110
+const D3 = 147
+const E3 = 165
+const G3 = 196
+
+// Bass sequence in A minor — 16-step
+const bassPattern = [
+  A2, 0,   A2, 0,   0,   A2, 0,   A2,
+  D3, 0,   D3, 0,   E3,  0,  G3,  0,
+]
+
+// Lead stab pattern — sparse, on-beat hits
+const leadPattern = [
+  0,    0,    E3*2, 0,    0,    0,    G3*2, 0,
+  0,    A2*4, 0,    0,    E3*2, 0,    0,    0,
+]
+
+// Kick pattern — four on the floor
+const kickPattern = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
+
+export const run = (context) => {
+  const t = context.currentTime
+
+  // Bass synth — sawtooth, lowpass filter approximated via gain envelope
+  const bass = Synth(context, { wave: 'sawtooth', frequency: A2, gain: 0.0 })
+  bass.connect(context.destination)
+  bass.start(t)
+
+  // Lead synth — square wave, high register
+  const lead = Synth(context, { wave: 'square', frequency: E3 * 2, gain: 0.0 })
+  lead.connect(context.destination)
+  lead.start(t)
+
+  // Kick — sine sweep (oscillator drops from 100→40 Hz over 80ms)
+  // Each hit creates a fresh oscillator so we get clean transients
+  const triggerKick = (time) => {
+    const osc  = context.createOscillator({ type: 'sine', frequency: 100 })
+    const gain = context.createGain({ gain: 0.8 })
+    osc.connect(gain)
+    gain.connect(context.destination)
+    osc.start(time)
+    osc.setFrequency(40, time + 0.08)
+    osc.stop(time + 0.2)
+  }
+
+  const transport = createTransport(context, { bpm: 140, ticksPerBeat: 4 })
+
+  // Step duration in seconds
+  const stepSec = () => 60 / (transport.bpm * 4)
+
+  createStepSequencer(transport, { pattern: kickPattern }, (_val, _step) => {
+    if (_val) triggerKick(context.currentTime + stepSec() * 0.5)
+  })
+
+  createStepSequencer(transport, { pattern: bassPattern }, (freq) => {
+    if (freq > 0) {
+      bass.setFrequency(freq, context.currentTime)
+      bass.setGain(0.25, context.currentTime)
+      bass.setGain(0.0,  context.currentTime + stepSec() * 0.75)
+    }
+  })
+
+  createStepSequencer(transport, { pattern: leadPattern }, (freq) => {
+    if (freq > 0) {
+      lead.setFrequency(freq, context.currentTime)
+      lead.setGain(0.12, context.currentTime)
+      lead.setGain(0.0,  context.currentTime + stepSec() * 0.4)
+    }
+  })
+
+  transport.play()
+
+  return {
+    dispose: () => {
+      transport.dispose()
+      bass.dispose()
+      lead.dispose()
+    },
+  }
+}

--- a/songs/package.json
+++ b/songs/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@score/songs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@score/components": "workspace:*",
+    "@score/dsl": "workspace:*",
+    "@score/sequencer": "workspace:*"
+  }
+}


### PR DESCRIPTION
## Summary

- **Phase 9 — @score/dsl**: Pure data Song/Track/Section/Instrument descriptor factories. Song files have no AudioContext — the engine hydrates at play time.
- **Phase 10 — @score/cli**: `score play <file>` command with a ScoreEngine that converts descriptors to real oscillator audio (kick=sine sweep, snare=noise+body, hihat=filtered noise, synth=oscillator voice).
- **Demo song** — `songs/example-deep-house.js` in D minor at 124 BPM, matching the handoff DSL spec.

**710 tests passing. Lint + typecheck clean.**

### Song file format (matches handoff spec)
```js
import { Song, Kick, Snare, HiHat, Synth, Intro, Drop, Outro } from '@score/dsl'

const kick = Kick({ pattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0], volume: 0.9 })
const bass = Synth({ wave: 'sawtooth', pattern: [D2, 0, D2, 0, ...] })

export default Song({ bpm: 124, key: 'Dm', genre: 'deep-house', tracks: [kick, bass], arrangement: [...] })
```

### Demo
```bash
pnpm build
node packages/cli/dist/index.js play songs/example-deep-house.js
```

## Test plan
- [ ] `pnpm test` — 710 tests pass
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean
- [ ] `node packages/cli/dist/index.js play songs/example-deep-house.js` — audio plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)