### PR TITLE
feat: Phase 9/10/11 — ADSR, note names, --watch live coding, CLI polish

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,27 +1,31 @@
 import { execSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 
 export const doctor = (_args: string[]): void => {
-  console.log('Score Doctor — system check')
-  console.log('─'.repeat(44))
+  console.log('Score Doctor — system check\n')
 
-  const nodeVer = process.version
-  const nodeMajor = parseInt(nodeVer.slice(1))
+  // Node version
+  const nodeVersion = process.version
+  const nodeMajor = parseInt(nodeVersion.slice(1), 10)
   const nodeOk = nodeMajor >= 20
-  console.log(`Node.js ${nodeVer}${' '.repeat(Math.max(1, 28 - nodeVer.length))}${nodeOk ? '✅' : '❌ (need 20+)'}`)
+  console.log(`${nodeOk ? '✓' : '✗'} Node.js ${nodeVersion}${nodeOk ? '' : '  (requires v20+)'}`)
 
+  // pnpm
   try {
-    execSync('scsynth -v 2>&1', { stdio: 'ignore' })
-    console.log('SuperCollider                      ✅')
+    const v = execSync('pnpm --version', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+    console.log(`✓ pnpm ${v}`)
   } catch {
-    console.log('SuperCollider                      ⚠️  not found (Web Audio fallback active)')
+    console.log('✗ pnpm — not found')
   }
 
-  console.log('Web Audio (node-web-audio-api)     ✅')
-  console.log('')
-  if (nodeOk) {
-    console.log('Status: READY ✅')
-  } else {
-    console.log('Status: UPGRADE NODE ❌')
-    process.exit(1)
+  // node-web-audio-api
+  const req = createRequire(import.meta.url)
+  try {
+    req.resolve('node-web-audio-api')
+    console.log('✓ node-web-audio-api — available')
+  } catch {
+    console.log('✗ node-web-audio-api — not found  (run: pnpm install)')
   }
+
+  console.log('\nAll checks complete.')
 }

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,60 +1,72 @@
-import { resolve } from 'node:path'
 import { writeFileSync, existsSync } from 'node:fs'
-import { ScoreError } from '@score/core'
+import { resolve } from 'node:path'
 
-const SONG_TEMPLATE = `// Song — Score EDM Framework
-// Docs: https://score.dev/docs/dsl/song
+export const newSong = (args: string[]): void => {
+  if (args[0] !== 'song' || !args[1]) {
+    console.log('Usage:')
+    console.log('  score new song <name>    Create a new song from template')
+    return
+  }
 
-import { Song, Kick, Snare, HiHat, Intro, Drop, Outro } from '@score/dsl'
+  const name = args[1]
+  const fileName = name.endsWith('.js') ? name : `${name}.js`
+  const filePath = resolve(process.cwd(), fileName)
 
-// ── DRUMS ──────────────────────────────────────────────────────────────
+  if (existsSync(filePath)) {
+    console.error(`Score: File already exists: ${fileName}`)
+    process.exit(1)
+  }
+
+  const template = `// ${name} — Score song
+// Run with:  score play ${fileName}
+// Live mode: score play ${fileName} --watch
+
+import { Song, Kick, Snare, HiHat, Synth, Intro, Drop, Outro } from '@score/dsl'
+
+// ── DRUMS ─────────────────────────────────────────────────────────────────────
+// Pattern: 16-step array. 1 = hit, 0 = rest.
+
 const kick = Kick({
-  pattern: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
-  volume: 0.9,
+  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
+  volume: 0.85,
 })
 
 const snare = Snare({
-  pattern: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-  volume: 0.8,
+  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
+  volume: 0.5,
 })
 
 const hihat = HiHat({
-  pattern: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
-  volume: 0.6,
+  pattern: [1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0],
+  volume: 0.2,
 })
 
-// ── ARRANGEMENT ────────────────────────────────────────────────────────
-const arrangement = [
-  Intro(4,  [hihat]),
-  Drop(16,  [kick, snare, hihat]),
-  Outro(4,  [hihat]),
-]
+// ── SYNTHESIS ─────────────────────────────────────────────────────────────────
+// Use note names ('A2', 'D3', 'F#3') or Hz values. 0 = rest.
 
+const bass = Synth({
+  wave: 'sawtooth',
+  gain: 0.25,
+  envelope: { attack: 0.005, decay: 0.1, sustain: 0.6, release: 0.05 },
+  filter: { type: 'lowpass', frequency: 900 },
+  pattern: ['A2', 0, 'A2', 0,  0, 'A2', 0, 'D3',  'E3', 0, 'E3', 0,  0, 'A3', 0, 0],
+})
+
+// ── ARRANGEMENT ───────────────────────────────────────────────────────────────
 export default Song({
-  bpm: 140,
-  tracks: [kick, snare, hihat],
-  arrangement,
+  bpm: 128,
+  key: 'Am',
+  genre: 'electronic',
+  tracks: [kick, snare, hihat, bass],
+  arrangement: [
+    Intro(4,  [kick, bass]),
+    Drop(16,  [kick, snare, hihat, bass]),
+    Outro(4,  [kick, bass]),
+  ],
 })
 `
 
-export const newSong = (args: string[]): void => {
-  const [, name] = args
-  if (!name) {
-    throw ScoreError('Specify a song name', {
-      received: undefined,
-      fix: 'Usage: score new song <name.js>',
-      docs: 'https://score.dev/docs/cli/new',
-    })
-  }
-  const outPath = resolve(process.cwd(), name.endsWith('.js') ? name : `${name}.js`)
-  if (existsSync(outPath)) {
-    throw ScoreError(`File already exists: ${outPath}`, {
-      received: outPath,
-      fix: 'Choose a different name or delete the existing file first',
-      docs: 'https://score.dev/docs/cli/new',
-    })
-  }
-  writeFileSync(outPath, SONG_TEMPLATE, 'utf-8')
-  console.log(`Score: Created ${outPath}`)
-  console.log(`Score: Run with: score play ${name}`)
+  writeFileSync(filePath, template, 'utf-8')
+  console.log(`Score: Created ${fileName}`)
+  console.log(`Score: Play it — score play ${fileName}`)
 }

--- a/packages/cli/src/commands/play.ts
+++ b/packages/cli/src/commands/play.ts
@@ -1,12 +1,51 @@
 import { resolve } from 'node:path'
-import { existsSync } from 'node:fs'
+import { existsSync, watch as fsWatch } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import { ScoreError } from '@score/core'
 import type { SongDefinition } from '@score/dsl'
-import { createScoreEngine } from '../engine.js'
+import { createScoreEngine, type ScoreEngine } from '../engine.js'
+
+const loadSong = async (resolved: string, version: number): Promise<SongDefinition> => {
+  const url = version === 0
+    ? pathToFileURL(resolved).href
+    : pathToFileURL(resolved).href + '?v=' + String(version)
+  const mod = await import(url) as Record<string, unknown>
+  const raw: unknown = mod['default']
+  if (!raw || typeof raw !== 'object') {
+    throw ScoreError('Song file must have a default export', {
+      received: typeof raw,
+      fix: 'Add: export default Song({ bpm: 140, tracks: [...] })',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  const song = raw as SongDefinition
+  if (!song.bpm || song.bpm <= 0) {
+    throw ScoreError('Song must have a valid bpm', {
+      received: song.bpm,
+      fix: 'Song({ bpm: 140, ... }) — bpm must be a positive number',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  return song
+}
+
+const logSong = (song: SongDefinition): void => {
+  const keyStr   = song.key   ? ` — ${song.key}`   : ''
+  const genreStr = song.genre ? ` — ${song.genre}` : ''
+  console.log(`Score: Playing — ${String(song.bpm)} BPM${keyStr}${genreStr}`)
+  if (song.arrangement.length > 0) {
+    const sections = song.arrangement
+      .map((s) => `${s.sectionType}(${String(s.bars)}b)`)
+      .join(' → ')
+    console.log(`Score: Arrangement — ${sections}`)
+  }
+  console.log(`Score: ${String(song.tracks.length)} track(s) loaded`)
+}
 
 export const play = async (args: string[]): Promise<void> => {
+  const watch = args.includes('--watch') || args.includes('-w')
   const filePath = args.find(a => !a.startsWith('-'))
+
   if (!filePath) {
     throw ScoreError('No song file specified', {
       received: undefined,
@@ -24,51 +63,48 @@ export const play = async (args: string[]): Promise<void> => {
     })
   }
 
-  const mod: Record<string, unknown> = await import(pathToFileURL(resolved).href) as Record<string, unknown>
-  const rawSong: unknown = mod['default']
+  const song = await loadSong(resolved, 0)
+  logSong(song)
 
-  if (!rawSong || typeof rawSong !== 'object') {
-    throw ScoreError('Song file must have a default export', {
-      received: typeof rawSong,
-      fix: "Add: export default Song({ bpm: 140, tracks: [...] }) at the end of your song file",
-      docs: 'https://score.dev/docs/dsl/song',
-    })
-  }
-
-  const song = rawSong as SongDefinition
-
-  if (!song.bpm || song.bpm <= 0) {
-    throw ScoreError('Song must have a valid bpm', {
-      received: song.bpm,
-      fix: 'Song({ bpm: 140, ... }) — bpm must be a positive number',
-      docs: 'https://score.dev/docs/dsl/song',
-    })
-  }
-
-  const keyStr   = song.key   ? ` — ${song.key}`   : ''
-  const genreStr = song.genre ? ` — ${song.genre}` : ''
-  console.log(`Score: Playing — ${String(song.bpm)} BPM${keyStr}${genreStr}`)
-
-  if (song.arrangement.length > 0) {
-    const sections = song.arrangement
-      .map((s) => `${s.sectionType}(${String(s.bars)}b)`)
-      .join(' → ')
-    console.log(`Score: Arrangement — ${sections}`)
-  }
-
-  console.log(`Score: ${String(song.tracks.length)} track(s) loaded`)
-
-  const engine = createScoreEngine(song)
-  engine.start()
-  console.log('Score: Audio running — Press Ctrl+C to stop')
+  let currentEngine: ScoreEngine = createScoreEngine(song)
+  currentEngine.start()
+  console.log(`Score: Audio running — Press Ctrl+C to stop${watch ? ' (watch mode on)' : ''}`)
 
   const keepAlive = setInterval(() => {}, 1000)
 
   const cleanup = (): void => {
     clearInterval(keepAlive)
-    engine.dispose()
+    currentEngine.dispose()
     console.log('\nScore: Stopped')
     process.exit(0)
+  }
+
+  if (watch) {
+    let reloading = false
+    let reloadVersion = 1
+
+    fsWatch(resolved, () => {
+      if (reloading) return
+      reloading = true
+
+      setTimeout(() => {
+        void (async () => {
+          try {
+            console.log('\nScore: File changed — reloading...')
+            currentEngine.dispose()
+            const freshSong = await loadSong(resolved, reloadVersion++)
+            currentEngine = createScoreEngine(freshSong)
+            currentEngine.start()
+            console.log(`Score: Reloaded — ${String(freshSong.bpm)} BPM`)
+          } catch (err: unknown) {
+            console.error('Score: Reload failed —', err instanceof Error ? err.message : String(err))
+            console.error('Score: Keeping previous version')
+          } finally {
+            reloading = false
+          }
+        })()
+      }, 300)
+    })
   }
 
   process.once('SIGINT', cleanup)

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -4,13 +4,14 @@
 // synth voices. No sample files required — everything is synthesis.
 //
 // Synthesis models:
-//   kick  — sine sweep (80→30 Hz, 250ms) — classic electronic kick
+//   kick  — sine sweep (freq→30 Hz over pitchDrop sec)
 //   snare — band-pass filtered noise burst + sine transient
 //   hihat — high-pass filtered noise burst (short decay)
-//   synth — sawtooth / square / sine / triangle oscillator
+//   synth — oscillator with ADSR envelope + optional filter
 
 import { webAudioBackend } from '@score/core'
 import { createTransport, createStepSequencer } from '@score/sequencer'
+import { resolveFreq } from '@score/dsl'
 import type { SongDefinition, InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps } from '@score/dsl'
 
 type Context = ReturnType<typeof webAudioBackend.createContext>
@@ -26,41 +27,39 @@ const DEFAULT_SNARE_PATTERN = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
 const DEFAULT_HIHAT_PATTERN = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
 const DEFAULT_SYNTH_PATTERN = [1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
 
-const triggerKick = (ctx: Context, time: number, props: KickProps): void => {
+const triggerKick = (ctx: Context, time: number, props: KickProps, dest: ReturnType<Context['createGain']>): void => {
   const freq = props.synth?.frequency ?? 80
   const drop = props.synth?.pitchDrop ?? 0.1
   const gain = props.volume ?? 0.85
   const osc  = ctx.createOscillator({ type: 'sine', frequency: freq })
   const vol  = ctx.createGain({ gain })
   osc.connect(vol)
-  vol.connect(ctx.destination)
+  vol.connect(dest)
   osc.start(time)
   osc.setFrequency(30, time + drop)
   osc.stop(time + drop + 0.15)
 }
 
-const triggerSnare = (ctx: Context, time: number, props: SnareProps): void => {
+const triggerSnare = (ctx: Context, time: number, props: SnareProps, dest: ReturnType<Context['createGain']>): void => {
   const gain = props.volume ?? 0.5
-  // Sine transient (body)
   const body  = ctx.createOscillator({ type: 'sine', frequency: 185 })
   const bGain = ctx.createGain({ gain: gain * 0.7 })
   body.connect(bGain)
-  bGain.connect(ctx.destination)
+  bGain.connect(dest)
   body.start(time)
   body.setFrequency(100, time + 0.05)
   body.stop(time + 0.08)
-  // Noise (snappy)
   const noise  = ctx.createNoise({ type: 'white' })
   const filter = ctx.createFilter({ type: 'bandpass', frequency: 5000, Q: 0.8 })
   const nGain  = ctx.createGain({ gain: gain * 0.5 })
   noise.connect(filter)
   filter.connect(nGain)
-  nGain.connect(ctx.destination)
+  nGain.connect(dest)
   noise.start(time)
   noise.stop(time + 0.12)
 }
 
-const triggerHiHat = (ctx: Context, time: number, props: HiHatProps): void => {
+const triggerHiHat = (ctx: Context, time: number, props: HiHatProps, dest: ReturnType<Context['createGain']>): void => {
   const gain = props.volume ?? 0.25
   const dur  = props.open ? 0.3 : 0.06
   const noise  = ctx.createNoise({ type: 'white' })
@@ -68,9 +67,41 @@ const triggerHiHat = (ctx: Context, time: number, props: HiHatProps): void => {
   const vol    = ctx.createGain({ gain })
   noise.connect(filter)
   filter.connect(vol)
-  vol.connect(ctx.destination)
+  vol.connect(dest)
   noise.start(time)
   noise.stop(time + dur)
+}
+
+// Per-note synth — fresh osc + ADSR envelope per event
+const triggerSynth = (ctx: Context, time: number, props: SynthDSLProps, freq: number, dest: ReturnType<Context['createGain']>): void => {
+  const env     = props.envelope ?? {}
+  const attack  = env.attack  ?? 0.005
+  const decay   = env.decay   ?? 0.08
+  const sustain = env.sustain ?? 0.7
+  const release = env.release ?? 0.05
+  const peak    = props.gain  ?? 0.25
+  const noteDur = attack + decay + release + 0.02
+
+  const osc  = ctx.createOscillator({ type: props.wave ?? 'sawtooth', frequency: freq })
+  const gain = ctx.createGain({ gain: 0 })
+
+  if (props.filter) {
+    const filt = ctx.createFilter({
+      type: props.filter.type ?? 'lowpass',
+      frequency: props.filter.frequency ?? 2000,
+      ...(props.filter.Q !== undefined && { Q: props.filter.Q }),
+    })
+    osc.connect(filt)
+    filt.connect(gain)
+  } else {
+    osc.connect(gain)
+  }
+  gain.connect(dest)
+
+  gain.scheduleEnvelope({ peak, attack, decay, sustain, release, startTime: time, duration: noteDur })
+
+  osc.start(time)
+  osc.stop(time + noteDur)
 }
 
 export type ScoreEngine = {
@@ -79,20 +110,13 @@ export type ScoreEngine = {
   readonly dispose: () => void
 }
 
-// Per-note synth trigger — fresh oscillator per event, avoids gain scheduling conflicts
-const triggerSynth = (ctx: Context, time: number, props: SynthDSLProps, freq: number): void => {
-  const noteDur = 0.18  // note duration in seconds
-  const osc  = ctx.createOscillator({ type: props.wave ?? 'sawtooth', frequency: freq })
-  const gain = ctx.createGain({ gain: props.gain ?? 0.25 })
-  osc.connect(gain)
-  gain.connect(ctx.destination)
-  osc.start(time)
-  osc.stop(time + noteDur)
-}
-
 export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
   const ctx = webAudioBackend.createContext()
   const transport = createTransport(ctx, { bpm: song.bpm, ticksPerBeat: 4 })
+
+  // Master gain — all instruments route through here before ctx.destination
+  const master = ctx.createGain({ gain: 0.85 })
+  master.connect(ctx.destination)
 
   // Song authors pass InstrumentDescriptors directly as tracks (no Track() wrapper needed).
   // Validate at the JS boundary — t may be a bare InstrumentDescriptor or a TrackComponent.
@@ -106,7 +130,7 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
         const props = comp.props as KickProps
         const pattern = props.pattern ?? DEFAULT_KICK_PATTERN
         createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
-          if (hit) triggerKick(ctx, pos.time, props)
+          if (hit) triggerKick(ctx, pos.time, props, master)
         })
         break
       }
@@ -114,7 +138,7 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
         const props = comp.props as SnareProps
         const pattern = props.pattern ?? DEFAULT_SNARE_PATTERN
         createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
-          if (hit) triggerSnare(ctx, pos.time, props)
+          if (hit) triggerSnare(ctx, pos.time, props, master)
         })
         break
       }
@@ -122,15 +146,17 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
         const props = comp.props as HiHatProps
         const pattern = props.pattern ?? DEFAULT_HIHAT_PATTERN
         createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
-          if (hit) triggerHiHat(ctx, pos.time, props)
+          if (hit) triggerHiHat(ctx, pos.time, props, master)
         })
         break
       }
       case 'synth': {
         const props = comp.props as SynthDSLProps
-        const pattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
-        createStepSequencer(transport, { pattern: pattern as number[] }, (val, _step, pos) => {
-          if (val > 0) triggerSynth(ctx, pos.time, props, val)
+        const rawPattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
+        const pattern: (number | string)[] = Array.isArray(rawPattern) ? rawPattern : DEFAULT_SYNTH_PATTERN
+        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+          const freq = resolveFreq(val)
+          if (freq > 0) triggerSynth(ctx, pos.time, props, freq, master)
         })
         break
       }
@@ -138,8 +164,8 @@ export const createScoreEngine = (song: SongDefinition): ScoreEngine => {
   }
 
   return {
-    start:   () => { transport.play(); },
-    stop:    () => { transport.stop(); },
+    start:   () => { transport.play() },
+    stop:    () => { transport.stop() },
     dispose: () => {
       transport.dispose()
       ctx.close().catch(() => {})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,11 @@ import { doctor } from './commands/doctor.js'
 
 const [,, command, ...args] = process.argv
 
+if (command === '--version' || command === '-v') {
+  console.log('0.0.1')
+  process.exit(0)
+}
+
 const commands: Record<string, (args: string[]) => Promise<void> | void> = {
   play:   args => play(args),
   new:    args => { newSong(args); },
@@ -16,9 +21,11 @@ if (!handler) {
   console.log('Score — EDM audio framework')
   console.log('')
   console.log('Usage:')
-  console.log('  score play <song.js>     Play a song file')
-  console.log('  score new song <name>    Create a new song from template')
-  console.log('  score doctor             Check system requirements')
+  console.log('  score play <song.js>         Play a song file')
+  console.log('  score play <song.js> --watch Live reload on file save')
+  console.log('  score new song <name>        Create a new song from template')
+  console.log('  score doctor                 Check system requirements')
+  console.log('  score --version              Show version')
   process.exit(0)
 }
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// Mock child_process before importing doctor
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+vi.mock('node:module', () => ({
+  createRequire: vi.fn(() => ({
+    resolve: vi.fn(),
+  })),
+}))
+
+import { execSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { doctor } from '../src/commands/doctor.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('doctor', () => {
+  it('prints Node.js version', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(execSync).mockReturnValue('9.0.0\n' as unknown as string)
+    vi.mocked(createRequire).mockReturnValue({ resolve: vi.fn() } as unknown as ReturnType<typeof createRequire>)
+
+    doctor([])
+
+    const output = spy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('Node.js')
+    expect(output).toContain(process.version)
+    spy.mockRestore()
+  })
+
+  it('shows checkmark when Node >= 20', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(execSync).mockReturnValue('9.0.0\n' as unknown as string)
+    vi.mocked(createRequire).mockReturnValue({ resolve: vi.fn() } as unknown as ReturnType<typeof createRequire>)
+
+    doctor([])
+
+    // process.version in test environment is >= 20 (Node 20 LTS)
+    const nodeMajor = parseInt(process.version.slice(1), 10)
+    const output = spy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    if (nodeMajor >= 20) {
+      expect(output).toContain('✓ Node.js')
+    } else {
+      expect(output).toContain('✗ Node.js')
+    }
+    spy.mockRestore()
+  })
+
+  it('shows pnpm version when available', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(execSync).mockReturnValue('9.0.0\n' as unknown as string)
+    vi.mocked(createRequire).mockReturnValue({ resolve: vi.fn() } as unknown as ReturnType<typeof createRequire>)
+
+    doctor([])
+
+    const output = spy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('✓ pnpm 9.0.0')
+    spy.mockRestore()
+  })
+
+  it('shows error when pnpm not found', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(execSync).mockImplementation(() => { throw new Error('not found') })
+    vi.mocked(createRequire).mockReturnValue({ resolve: vi.fn() } as unknown as ReturnType<typeof createRequire>)
+
+    doctor([])
+
+    const output = spy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('✗ pnpm')
+    spy.mockRestore()
+  })
+
+  it('shows error when node-web-audio-api not found', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(execSync).mockReturnValue('9.0.0\n' as unknown as string)
+    const mockResolve = vi.fn().mockImplementation(() => { throw new Error('Cannot find module') })
+    vi.mocked(createRequire).mockReturnValue({ resolve: mockResolve } as unknown as ReturnType<typeof createRequire>)
+
+    doctor([])
+
+    const output = spy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('✗ node-web-audio-api')
+    spy.mockRestore()
+  })
+})

--- a/packages/cli/tests/new.test.ts
+++ b/packages/cli/tests/new.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolve } from 'node:path'
+
+vi.mock('node:fs', () => ({
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}))
+
+import { writeFileSync, existsSync } from 'node:fs'
+import { newSong } from '../src/commands/new.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('newSong', () => {
+  it('creates a .js file when given a name', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong(['song', 'my-track'])
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      resolve(process.cwd(), 'my-track.js'),
+      expect.any(String),
+      'utf-8',
+    )
+    logSpy.mockRestore()
+  })
+
+  it('appends .js extension if missing', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong(['song', 'test-song'])
+
+    const [path] = vi.mocked(writeFileSync).mock.calls[0] as [string, ...unknown[]]
+    expect(path).toMatch(/test-song\.js$/)
+    logSpy.mockRestore()
+  })
+
+  it('does not double-append .js if already present', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong(['song', 'already.js'])
+
+    const [path] = vi.mocked(writeFileSync).mock.calls[0] as [string, ...unknown[]]
+    expect(path).toMatch(/already\.js$/)
+    expect(path).not.toMatch(/already\.js\.js$/)
+    logSpy.mockRestore()
+  })
+
+  it('template contains note names in pattern', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong(['song', 'note-test'])
+
+    const [, content] = vi.mocked(writeFileSync).mock.calls[0] as [string, string, ...unknown[]]
+    expect(content).toContain("'A2'")
+    expect(content).toContain("'D3'")
+    logSpy.mockRestore()
+  })
+
+  it('exits when file already exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null) => { throw new Error('process.exit') })
+
+    expect(() => { newSong(['song', 'existing']); }).toThrow('process.exit')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('File already exists'))
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
+  it('prints usage when no name provided', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong(['song'])
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('Usage:')
+    expect(writeFileSync).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  it('prints usage when not given song subcommand', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    newSong([])
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')
+    expect(output).toContain('Usage:')
+    logSpy.mockRestore()
+  })
+})

--- a/packages/cli/tests/sequence-cli.test.ts
+++ b/packages/cli/tests/sequence-cli.test.ts
@@ -4,9 +4,13 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 describe('new command', () => {
-  it('throws ScoreError when no name given', async () => {
+  it('prints usage when no name given', async () => {
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((m: unknown) => { logs.push(String(m)) })
     const { newSong } = await import('../src/commands/new.js')
-    expect(() => { newSong(['song']); }).toThrow() // 'song' is subcommand, name is missing
+    newSong(['song']) // 'song' is subcommand, name is missing
+    expect(logs.some(l => l.includes('Usage') || l.includes('usage') || l.includes('score new'))).toBe(true)
+    vi.restoreAllMocks()
   })
 
   it('creates song file with template content', async () => {

--- a/packages/components/tests/utils/harness.ts
+++ b/packages/components/tests/utils/harness.ts
@@ -73,6 +73,7 @@ const createMockGainNode = (initialGain = 1.0): MockBackendGainNode => {
     ...base,
     get gain() { return currentGain },
     setGain: (value: number, _time?: number) => { currentGain = value },
+    scheduleEnvelope: ({ peak }: { peak: number; attack: number; decay: number; sustain: number; release: number; startTime: number; duration: number }) => { currentGain = peak },
   }
 }
 

--- a/packages/core/src/backend/types.ts
+++ b/packages/core/src/backend/types.ts
@@ -23,6 +23,16 @@ export type BackendOscillatorNode = BackendNode & {
 export type BackendGainNode = BackendNode & {
   readonly gain: number
   readonly setGain: (value: number, time?: number) => void
+  // ADSR envelope — schedules attack→decay→sustain→release without anchor conflicts
+  readonly scheduleEnvelope: (opts: {
+    peak: number
+    attack: number   // seconds
+    decay: number    // seconds
+    sustain: number  // 0-1 fraction of peak
+    release: number  // seconds
+    startTime: number
+    duration: number // total note duration (attack + decay + hold + release)
+  }) => void
 }
 
 export type BackendNoiseNode = BackendNode & {

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -149,6 +149,14 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
           gainNode.gain.setValueAtTime(gainNode.gain.value, t)
           gainNode.gain.linearRampToValueAtTime(value, t + MIN_RAMP)
         },
+        scheduleEnvelope: ({ peak, attack, decay, sustain, release, startTime }) => {
+          const g = gainNode.gain
+          g.cancelScheduledValues(startTime)
+          g.setValueAtTime(0, startTime)
+          g.linearRampToValueAtTime(peak, startTime + attack)
+          g.linearRampToValueAtTime(peak * sustain, startTime + attack + decay)
+          g.linearRampToValueAtTime(0, startTime + attack + decay + release)
+        },
       }
     },
 

--- a/packages/core/tests/utils/audioTestUtils.ts
+++ b/packages/core/tests/utils/audioTestUtils.ts
@@ -104,6 +104,7 @@ export const createMockGainNode = (initialGain = 1.0): MockBackendGainNode => {
     ...base,
     get gain() { return currentGain },
     setGain: (value: number, _time?: number) => { currentGain = value },
+    scheduleEnvelope: ({ peak }: { peak: number; attack: number; decay: number; sustain: number; release: number; startTime: number; duration: number }) => { currentGain = peak },
   }
 }
 

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -3,6 +3,7 @@ export { Intro, Buildup, Drop, Breakdown, Outro } from './sections.js'
 export { Track } from './track.js'
 export { Sequence } from './sequence.js'
 export { Kick, Snare, HiHat, Synth } from './instruments.js'
+export { noteHz, resolveFreq } from './notes.js'
 export type {
   SongDefinition,
   SongProps,

--- a/packages/dsl/src/notes.ts
+++ b/packages/dsl/src/notes.ts
@@ -1,0 +1,29 @@
+// noteHz — converts note names to frequencies
+// Formula: 440 * 2^((midi - 69) / 12)  where A4 = midi 69 = 440 Hz
+//
+// Supported format: letter + optional # or b + octave
+// Examples: 'A4' = 440, 'C4' = 261.63, 'F#3' = 185.0, 'Bb2' = 116.5
+
+const NOTE_SEMITONES: Record<string, number> = {
+  C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11,
+}
+
+export const noteHz = (name: string): number => {
+  const match = /^([A-G])(#|b)?(-?\d+)$/.exec(name)
+  if (!match) throw new Error(`Invalid note name: "${name}". Expected format: C4, F#3, Bb2`)
+  const letter     = match[1] as string
+  const accidental = match[2]
+  const octaveStr  = match[3] as string
+  const semitone   = NOTE_SEMITONES[letter] ?? 0
+  const acc        = accidental === '#' ? 1 : accidental === 'b' ? -1 : 0
+  const octave     = parseInt(octaveStr, 10)
+  const midi = semitone + acc + (octave + 1) * 12
+  return 440 * Math.pow(2, (midi - 69) / 12)
+}
+
+// Convenience: resolve a pattern value that may be a note name string or raw Hz number
+// Used by the engine to support both: pattern: ['A2', 0, 'D3'] and pattern: [110, 0, 146.8]
+export const resolveFreq = (val: number | string): number => {
+  if (typeof val === 'string') return noteHz(val)
+  return val
+}

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -24,8 +24,19 @@ export type SynthDSLProps = {
   readonly wave?: 'sine' | 'square' | 'sawtooth' | 'triangle'
   readonly frequency?: number
   readonly gain?: number
-  readonly pattern?: number[]
+  readonly pattern?: (number | string)[]
   readonly sequence?: string[]  // parsed Sequence output
+  readonly envelope?: {
+    readonly attack?: number   // seconds, default 0.005 — short=punchy, long=pad
+    readonly decay?: number    // seconds, default 0.08
+    readonly sustain?: number  // 0-1, default 0.7
+    readonly release?: number  // seconds, default 0.05
+  }
+  readonly filter?: {
+    readonly type?: 'lowpass' | 'highpass' | 'bandpass'
+    readonly frequency?: number  // Hz cutoff
+    readonly Q?: number          // resonance, default 1
+  }
 }
 
 export type InstrumentDescriptor = {

--- a/packages/dsl/tests/notes.test.ts
+++ b/packages/dsl/tests/notes.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { noteHz, resolveFreq } from '../src/notes.js'
+
+describe('noteHz', () => {
+  it('A4 = 440 Hz', () => { expect(noteHz('A4')).toBeCloseTo(440, 1); })
+  it('A2 = 110 Hz', () => { expect(noteHz('A2')).toBeCloseTo(110, 1); })
+  it('C4 = 261.63 Hz', () => { expect(noteHz('C4')).toBeCloseTo(261.63, 1); })
+  it('D3 = 146.83 Hz', () => { expect(noteHz('D3')).toBeCloseTo(146.83, 1); })
+  it('F#3 = 185.0 Hz', () => { expect(noteHz('F#3')).toBeCloseTo(185.0, 0); })
+  it('Bb2 = 116.54 Hz', () => { expect(noteHz('Bb2')).toBeCloseTo(116.54, 1); })
+  it('E4 = 329.63 Hz', () => { expect(noteHz('E4')).toBeCloseTo(329.63, 1); })
+  it('throws on invalid note name', () => { expect(() => noteHz('X9')).toThrow(); })
+  it('throws on malformed input', () => { expect(() => noteHz('hello')).toThrow(); })
+})
+
+describe('resolveFreq', () => {
+  it('returns number as-is', () => { expect(resolveFreq(440)).toBe(440); })
+  it('resolves string note name', () => { expect(resolveFreq('A4')).toBeCloseTo(440, 1); })
+  it('0 stays 0 (rest)', () => { expect(resolveFreq(0)).toBe(0); })
+})

--- a/packages/effects/tests/utils/harness.ts
+++ b/packages/effects/tests/utils/harness.ts
@@ -42,6 +42,7 @@ const createMockGainNode = (initialGain = 1.0, shouldThrowOnDisconnect = false):
     ...base,
     get gain() { return currentGain },
     setGain: (value: number, _time?: number) => { currentGain = value },
+    scheduleEnvelope: ({ peak }: { peak: number; attack: number; decay: number; sustain: number; release: number; startTime: number; duration: number }) => { currentGain = peak },
   }
 }
 

--- a/packages/mixer/tests/utils/harness.ts
+++ b/packages/mixer/tests/utils/harness.ts
@@ -42,6 +42,7 @@ const createMockGainNode = (initialGain = 1.0, shouldThrowOnDisconnect = false):
     ...base,
     get gain() { return currentGain },
     setGain: (value: number, _time?: number) => { currentGain = value },
+    scheduleEnvelope: ({ peak }: { peak: number; attack: number; decay: number; sustain: number; release: number; startTime: number; duration: number }) => { currentGain = peak },
   }
 }
 

--- a/packages/sequencer/tests/utils/harness.ts
+++ b/packages/sequencer/tests/utils/harness.ts
@@ -38,6 +38,7 @@ export const mockContext = (): MockContext => {
       ...createMockNode(),
       gain: _props?.gain ?? 1.0,
       setGain: (_value: number, _time?: number) => {},
+      scheduleEnvelope: (_opts: { peak: number; attack: number; decay: number; sustain: number; release: number; startTime: number; duration: number }) => {},
     }),
     createNoise: (_props?: { type?: 'white' | 'pink' | 'brown' }) => ({
       ...createMockNode(),

--- a/songs/example-deep-house.js
+++ b/songs/example-deep-house.js
@@ -45,15 +45,24 @@ const pad = Synth({
   pattern: ['F3', 0, 0, 0,  'A3', 0, 0, 0,  0, 0, 'F3', 0,  0, 0, 'A3', 0],
 })
 
+const sax = Synth({
+  wave: 'sawtooth',           // raw, harmonically rich — sax fundamental
+  gain: 0.22,
+  envelope: { attack: 0.02, decay: 0.15, sustain: 0.85, release: 0.08 },
+  filter: { type: 'lowpass', frequency: 1400, Q: 2.5 },  // cuts highs, adds body
+  pattern: ['D3', 0, 'F3', 0,  'A3', 0, 0, 0,  'G3', 0, 'E3', 0,  'D3', 0, 0, 0],
+})
+
+
 // ── ARRANGEMENT ───────────────────────────────────────────────────────────────
 export default Song({
   bpm: 124,
   key: 'Dm',
   genre: 'deep-house',
-  tracks: [kick, snare, hihat, bass, pad],
+  tracks: [kick, snare, hihat, bass, pad, sax],
   arrangement: [
     Intro(4,  [kick, bass]),
     Drop(16,  [kick, snare, hihat, bass, pad]),
-    Outro(4,  [kick, bass]),
+    Outro(16,  [kick, bass, sax]),
   ],
 })

--- a/songs/example-deep-house.js
+++ b/songs/example-deep-house.js
@@ -1,29 +1,13 @@
 // example-deep-house.js — Score demo song
-// Run with: score play songs/example-deep-house.js
+// Run with:  score play songs/example-deep-house.js
+// Live mode: score play songs/example-deep-house.js --watch
 //
-// KEY DEMO POINTS:
-//   • Song files are pure ESM — no build step, no compilation
-//   • Instruments are factory functions with pattern arrays — reads like music
-//   • The engine hydrates descriptors into actual audio — song author never touches AudioContext
-//   • Arrangement is structural: Intro/Drop/Outro with explicit bar counts
-//   • Ctrl+C stops cleanly — all audio resources disposed
+// D minor, 124 BPM. Warm, introspective — classic deep house tonality.
 
 import { Song, Kick, Snare, HiHat, Synth, Intro, Drop, Outro } from '@score/dsl'
 
-// ── KEY / SCALE ───────────────────────────────────────────────────────────────
-// D minor (warm, introspective — classic deep house tonality)
-// All frequencies are exact: D2=73.42 Hz, A2=110 Hz, F3=174.6 Hz etc.
-
-const D2 = 73.42
-const A2 = 110.0
-const C3 = 130.8
-const D3 = 146.8
-const F3 = 174.6
-const A3 = 220.0
-
 // ── DRUMS ─────────────────────────────────────────────────────────────────────
-// Patterns: 16-step arrays, 1 = hit, 0 = rest
-// 4 steps per beat × 4 beats = one bar
+// Pattern: 16-step array. 1 = hit, 0 = rest. 4 steps = 1 beat.
 
 const kick = Kick({
   pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],   // four on the floor
@@ -32,7 +16,7 @@ const kick = Kick({
 })
 
 const snare = Snare({
-  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],   // 2 and 4
+  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],   // beats 2 and 4
   volume: 0.5,
 })
 
@@ -42,34 +26,31 @@ const hihat = HiHat({
 })
 
 // ── SYNTHESIS ─────────────────────────────────────────────────────────────────
-// Sequence notation: note values separated by spaces, '.' = rest
-// Notes resolve to their frequency at play time
+// Note names: 'D2', 'A2', 'F#3', 'Bb4' etc. Sharp = #  Flat = b  0 = rest.
 
 const bass = Synth({
   wave: 'sawtooth',
   gain: 0.28,
-  // Dm root movement over 2 bars (collapsed to 16 steps)
-  pattern: [D2, 0, D2, 0,  0, D2, 0, A2,  C3, 0, C3, 0,  0, D3, 0, 0],
+  envelope: { attack: 0.003, decay: 0.12, sustain: 0.6, release: 0.05 },
+  filter: { type: 'lowpass', frequency: 900, Q: 1.2 },
+  // Dm root movement over 2 bars
+  pattern: ['D2', 0, 'D2', 0,  0, 'D2', 0, 'A2',  'C3', 0, 'C3', 0,  0, 'D3', 0, 0],
 })
 
 const pad = Synth({
   wave: 'triangle',
   gain: 0.12,
+  envelope: { attack: 0.08, decay: 0.2, sustain: 0.8, release: 0.15 },
   // Sparse chord stabs — syncopated deep house feel
-  pattern: [F3, 0, 0, 0,  A3, 0, 0, 0,  0,  0,  F3, 0,  0, 0, A3, 0],
+  pattern: ['F3', 0, 0, 0,  'A3', 0, 0, 0,  0, 0, 'F3', 0,  0, 0, 'A3', 0],
 })
 
-// ── ARRANGEMENT ──────────────────────────────────────────────────────────────
-// Sections describe structure — the engine schedules audio accordingly.
-// Numbers = bars. Tracks listed = which instruments are active.
-
+// ── ARRANGEMENT ───────────────────────────────────────────────────────────────
 export default Song({
-  bpm:    124,
-  key:    'Dm',
-  genre:  'deep-house',
-
+  bpm: 124,
+  key: 'Dm',
+  genre: 'deep-house',
   tracks: [kick, snare, hihat, bass, pad],
-
   arrangement: [
     Intro(4,  [kick, bass]),
     Drop(16,  [kick, snare, hihat, bass, pad]),

--- a/songs/example-techno.js
+++ b/songs/example-techno.js
@@ -1,111 +1,58 @@
-// example-techno.js — working demo song
-// Run with: score play songs/example-techno.js
+// example-techno.js — Score demo song
+// Run with:  score play songs/example-techno.js
+// Live mode: score play songs/example-techno.js --watch
 //
-// Uses oscillator-based synthesis — no sample files required.
-// Live mode: exports run(context) so the CLI produces actual audio.
+// A minor, 140 BPM. Industrial techno: driving bass, lead stabs, offbeat hats.
 
-import { Synth } from '@score/components'
-import { createTransport, createStepSequencer } from '@score/sequencer'
-import { Song, Track, Drop, Intro, Outro } from '@score/dsl'
+import { Song, Kick, Snare, HiHat, Synth, Intro, Drop, Breakdown, Outro } from '@score/dsl'
 
-// ── DSL DESCRIPTOR (structure + metadata) ────────────────────────────────────
+// ── DRUMS ─────────────────────────────────────────────────────────────────────
 
-const _kick  = Track({ component: { id: 'kick-desc',  type: 'kick',  connect: () => {}, disconnect: () => {}, dispose: () => {} } })
-const _bass  = Track({ component: { id: 'bass-desc',  type: 'synth', connect: () => {}, disconnect: () => {}, dispose: () => {} } })
-const _lead  = Track({ component: { id: 'lead-desc',  type: 'synth', connect: () => {}, disconnect: () => {}, dispose: () => {} } })
+const kick = Kick({
+  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],   // four on the floor
+  synth: { frequency: 60, pitchDrop: 0.07 },
+  volume: 0.92,
+})
 
+const snare = Snare({
+  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
+  volume: 0.55,
+})
+
+const hihat = HiHat({
+  pattern: [0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0],   // offbeat 8ths
+  volume: 0.18,
+})
+
+// ── SYNTHESIS ─────────────────────────────────────────────────────────────────
+// Note names: 'A2', 'D3', 'E4' etc. Sharp = #  Flat = b  0 = rest.
+
+const bass = Synth({
+  wave: 'sawtooth',
+  gain: 0.30,
+  envelope: { attack: 0.003, decay: 0.10, sustain: 0.5, release: 0.04 },
+  filter: { type: 'lowpass', frequency: 800, Q: 2.0 },
+  pattern: ['A2', 0, 'A2', 0,  0, 'A2', 0, 'D3',  'E3', 0, 'E3', 0,  0, 'G3', 0, 0],
+})
+
+const lead = Synth({
+  wave: 'square',
+  gain: 0.14,
+  envelope: { attack: 0.002, decay: 0.06, sustain: 0.3, release: 0.03 },
+  pattern: [0, 0, 'E4', 0,  0, 0, 'A3', 0,  0, 'E4', 0, 0,  'A3', 0, 0, 0],
+})
+
+// ── ARRANGEMENT ───────────────────────────────────────────────────────────────
 export default Song({
   bpm: 140,
   key: 'Am',
   genre: 'techno',
-  tracks: [_kick, _bass, _lead],
+  tracks: [kick, snare, hihat, bass, lead],
   arrangement: [
-    Intro(4,  [_kick, _bass]),
-    Drop(16,  [_kick, _bass, _lead]),
-    Outro(4,  [_kick, _bass]),
+    Intro(4,       [kick, bass]),
+    Drop(16,       [kick, snare, hihat, bass, lead]),
+    Breakdown(8,   [hihat, bass]),
+    Drop(16,       [kick, snare, hihat, bass, lead]),
+    Outro(4,       [kick, bass]),
   ],
 })
-
-// ── LIVE ENGINE (produces actual audio) ──────────────────────────────────────
-// The CLI calls run(context) when this export is present.
-
-const A2 = 110
-const D3 = 147
-const E3 = 165
-const G3 = 196
-
-// Bass sequence in A minor — 16-step
-const bassPattern = [
-  A2, 0,   A2, 0,   0,   A2, 0,   A2,
-  D3, 0,   D3, 0,   E3,  0,  G3,  0,
-]
-
-// Lead stab pattern — sparse, on-beat hits
-const leadPattern = [
-  0,    0,    E3*2, 0,    0,    0,    G3*2, 0,
-  0,    A2*4, 0,    0,    E3*2, 0,    0,    0,
-]
-
-// Kick pattern — four on the floor
-const kickPattern = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
-
-export const run = (context) => {
-  const t = context.currentTime
-
-  // Bass synth — sawtooth, lowpass filter approximated via gain envelope
-  const bass = Synth(context, { wave: 'sawtooth', frequency: A2, gain: 0.0 })
-  bass.connect(context.destination)
-  bass.start(t)
-
-  // Lead synth — square wave, high register
-  const lead = Synth(context, { wave: 'square', frequency: E3 * 2, gain: 0.0 })
-  lead.connect(context.destination)
-  lead.start(t)
-
-  // Kick — sine sweep (oscillator drops from 100→40 Hz over 80ms)
-  // Each hit creates a fresh oscillator so we get clean transients
-  const triggerKick = (time) => {
-    const osc  = context.createOscillator({ type: 'sine', frequency: 100 })
-    const gain = context.createGain({ gain: 0.8 })
-    osc.connect(gain)
-    gain.connect(context.destination)
-    osc.start(time)
-    osc.setFrequency(40, time + 0.08)
-    osc.stop(time + 0.2)
-  }
-
-  const transport = createTransport(context, { bpm: 140, ticksPerBeat: 4 })
-
-  // Step duration in seconds
-  const stepSec = () => 60 / (transport.bpm * 4)
-
-  createStepSequencer(transport, { pattern: kickPattern }, (_val, _step) => {
-    if (_val) triggerKick(context.currentTime + stepSec() * 0.5)
-  })
-
-  createStepSequencer(transport, { pattern: bassPattern }, (freq) => {
-    if (freq > 0) {
-      bass.setFrequency(freq, context.currentTime)
-      bass.setGain(0.25, context.currentTime)
-      bass.setGain(0.0,  context.currentTime + stepSec() * 0.75)
-    }
-  })
-
-  createStepSequencer(transport, { pattern: leadPattern }, (freq) => {
-    if (freq > 0) {
-      lead.setFrequency(freq, context.currentTime)
-      lead.setGain(0.12, context.currentTime)
-      lead.setGain(0.0,  context.currentTime + stepSec() * 0.4)
-    }
-  })
-
-  transport.play()
-
-  return {
-    dispose: () => {
-      transport.dispose()
-      bass.dispose()
-      lead.dispose()
-    },
-  }
-}


### PR DESCRIPTION
## Summary

### Phase 9 — Cleaner Sound
- **ADSR envelope** on Synth: `envelope: { attack, decay, sustain, release }`
- **Filter** per Synth: `filter: { type: 'lowpass', frequency, Q }`
- **`scheduleEnvelope()`** added to `BackendGainNode` — proper multi-stage gain automation without anchor conflicts
- **Master gain node** — all instruments route through a single 0.85 output node
- **Note name support** — `'A2'`, `'F#3'`, `'Bb4'` in patterns instead of raw Hz
  - `noteHz('A4')` = 440, formula: `440 × 2^((midi - 69) / 12)`
  - `resolveFreq(val)` handles both strings and numbers
- **Rewrote `example-techno.js`** — pure DSL, removed old `run(context)` API
- **Updated `example-deep-house.js`** — envelope + filter props, note name patterns

### Phase 10 — CLI Polish
- `score doctor` — checks Node ≥ 20, pnpm, node-web-audio-api
- `score new song <name>` — creates song from template using note name syntax
- `score --version` / `-v` — prints version
- Updated help text

### Phase 11 — Live Coding
- `score play <song> --watch` — reloads engine on file save
- 300ms debounce prevents double-reload
- Reload errors keep old version playing
- `-w` short alias

## Usage
```bash
# Note names in patterns
const bass = Synth({
  pattern: ['A2', 0, 'D3', 0, 'E3', 0, 'G3', 0],
  envelope: { attack: 0.003, decay: 0.1, sustain: 0.6, release: 0.05 },
  filter: { type: 'lowpass', frequency: 800, Q: 2.0 },
})

# Live coding
score play songs/my-song.js --watch
# Edit file, save → engine reloads automatically
```

## Test plan
- [ ] pnpm test passes (634 tests)
- [ ] pnpm typecheck clean
- [ ] pnpm lint clean
- [ ] score play songs/example-deep-house.js — richer sound with envelopes
- [ ] score play songs/example-techno.js — pure DSL, no run(context)
- [ ] score play songs/example-deep-house.js --watch — edit + save reloads

🤖 Generated with Claude Code