### PR TITLE
feat(mcp): score-audio MCP server — Phase 10b

### DIFF
--- a/mcp-servers/score-audio/index.js
+++ b/mcp-servers/score-audio/index.js
@@ -1,0 +1,448 @@
+#!/usr/bin/env node
+
+// score-audio MCP — Audio domain intelligence for AI-assisted composition and debugging
+// Tools: effect_catalog, signal_flow, backend_nodes, component_catalog
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCORE_ROOT = resolve(__dirname, '../../')
+
+const readFile = (path) => {
+  try {
+    return existsSync(path) ? readFileSync(path, 'utf-8') : null
+  } catch {
+    return null
+  }
+}
+
+// Extract a Props type block from TS source
+const extractPropsType = (content, typeName) => {
+  const lines = content.split('\n')
+  let capturing = false
+  let depth = 0
+  const result = []
+  for (const line of lines) {
+    if (!capturing && line.includes(`export type ${typeName}`)) {
+      capturing = true
+    }
+    if (capturing) {
+      result.push(line)
+      depth += (line.match(/\{/g) ?? []).length
+      depth -= (line.match(/\}/g) ?? []).length
+      if (depth <= 0 && result.length > 1) break
+    }
+  }
+  return result.length > 0 ? result.join('\n').trim() : null
+}
+
+// Extract TSDoc block immediately above a line matching pattern
+const extractJsDoc = (content, pattern) => {
+  const lines = content.split('\n')
+  const idx = lines.findIndex((l) => pattern.test(l))
+  if (idx === -1) return null
+  const docLines = []
+  let i = idx - 1
+  while (i >= 0 && (lines[i].trim().startsWith('*') || lines[i].trim().startsWith('/**') || lines[i].trim().startsWith('*/'))) {
+    docLines.unshift(lines[i])
+    if (lines[i].trim().startsWith('/**')) break
+    i--
+  }
+  return docLines.length > 0 ? docLines.join('\n').trim() : null
+}
+
+// Extract connect() routing lines from an effect file
+const extractRouting = (content) => {
+  const lines = content.split('\n')
+  const routing = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('// Route') || trimmed.startsWith('// Feedback') || trimmed.startsWith('// route')) {
+      routing.push(trimmed)
+    } else if (trimmed.match(/\w+\.connect\(\w+\)/) && !trimmed.startsWith('//')) {
+      routing.push(trimmed.replace(/,$/, ''))
+    }
+  }
+  return routing
+}
+
+// Extract context.createXxx() calls to find which backend nodes an effect uses
+const extractBackendNodes = (content) => {
+  const matches = content.match(/context\.create\w+/g) ?? []
+  return [...new Set(matches)].sort()
+}
+
+// ─── Tool: effect_catalog ─────────────────────────────────────────────
+
+const EFFECTS_DIR = join(SCORE_ROOT, 'packages', 'effects', 'src')
+
+// Static catalog entries for each effect — category, description, EDM use cases
+const EFFECT_META = {
+  delay:               { category: 'time',        desc: 'Feedback delay with echo tails',          edm: 'dub, house, ambient' },
+  reverb:              { category: 'time',        desc: 'Convolution-style reverb for space',      edm: 'ambient, pad wash, snare room' },
+  filter:              { category: 'filter',      desc: 'Resonant multi-mode filter',              edm: 'filter sweep, acid bass, hihat shaping' },
+  eq:                  { category: 'filter',      desc: '3-band parametric EQ',                    edm: 'mix bus, vocal presence, low-end control' },
+  compressor:          { category: 'dynamics',    desc: 'Dynamic range compressor',                edm: 'drums, bus glue, vocal control' },
+  'multiband-compressor': { category: 'dynamics', desc: '3-band multiband compressor',            edm: 'mastering chain, bass/mid/high control' },
+  limiter:             { category: 'dynamics',    desc: 'Brick-wall limiter',                      edm: 'master bus ceiling, loudness maximiser' },
+  gate:                { category: 'dynamics',    desc: 'Noise gate with threshold',               edm: 'gated snare, parallel drum gating' },
+  sidechain:           { category: 'dynamics',    desc: 'Sidechain compression (duck on input)',   edm: 'EDM pumping, kick-vs-bass ducking' },
+  distortion:          { category: 'saturation',  desc: 'Wave-shaper distortion with drive',      edm: 'growl bass, distorted lead, lo-fi' },
+  saturation:          { category: 'saturation',  desc: 'Soft-clip tape saturation',              edm: 'warmth, analog glue, transient rounding' },
+  bitcrusher:          { category: 'saturation',  desc: 'Bit depth and sample rate reducer',       edm: 'lo-fi, glitch, retro game' },
+  chorus:              { category: 'modulation',  desc: 'Multi-voice chorus',                      edm: 'pad thickening, 80s synths, detune' },
+  flanger:             { category: 'modulation',  desc: 'Short modulated delay with feedback',    edm: 'sweeping jet effect, comb filtering' },
+  phaser:              { category: 'modulation',  desc: 'All-pass phase shifting cascade',         edm: 'funk guitar feel, psychedelic sweep' },
+  autopan:             { category: 'modulation',  desc: 'LFO-driven stereo panning',              edm: 'ping-pong delay feel, stereo movement' },
+  'stereo-widener':    { category: 'spatial',     desc: 'Mid-side stereo width control',           edm: 'mix bus width, pad spreading' },
+  chain:               { category: 'routing',     desc: 'Serial effects chain builder',            edm: 'insert chain, DSP signal path' },
+}
+
+const effectCatalog = {
+  name: 'effect_catalog',
+  description: 'List all @score/effects with their props, signal routing, backend nodes used, and EDM use cases. Query a specific effect or list all by category.',
+  inputSchema: {
+    effect: z.string().optional()
+      .describe('Effect name (e.g. "delay", "reverb", "compressor"). Omit to list all.'),
+    category: z.enum(['all', 'time', 'filter', 'dynamics', 'saturation', 'modulation', 'spatial', 'routing'])
+      .optional().default('all')
+      .describe('Filter by category when listing all effects.'),
+  },
+  handler: async ({ effect, category }) => {
+    // Single effect — full detail
+    if (effect) {
+      const fileName = effect.endsWith('.ts') ? effect : `${effect}.ts`
+      const filePath = join(EFFECTS_DIR, fileName)
+      const content = readFile(filePath)
+      if (!content) {
+        const available = readdirSync(EFFECTS_DIR).filter((f) => f.endsWith('.ts') && f !== 'index.ts').map((f) => f.replace('.ts', ''))
+        return { content: [{ type: 'text', text: `Effect "${effect}" not found.\n\nAvailable: ${available.join(', ')}` }] }
+      }
+
+      const effectName = effect.replace('.ts', '')
+      const meta = EFFECT_META[effectName] ?? { category: 'unknown', desc: '', edm: '' }
+
+      // Find Props type name from file
+      const propsMatch = content.match(/export type (\w+Props)/)
+      const propsTypeName = propsMatch?.[1]
+      const props = propsTypeName ? extractPropsType(content, propsTypeName) : null
+
+      // Find factory function name
+      const factoryMatch = content.match(/export const (create\w+)/)
+      const factoryName = factoryMatch?.[1]
+      const jsdoc = factoryName ? extractJsDoc(content, new RegExp(`export const ${factoryName}`)) : null
+
+      const routing = extractRouting(content)
+      const backendNodes = extractBackendNodes(content)
+
+      const sections = [
+        `# ${effectName} — ${meta.desc}`,
+        `**Category:** ${meta.category}  **EDM uses:** ${meta.edm}`,
+        '',
+        jsdoc ? `## TSDoc\n\n${jsdoc}` : '',
+        props ? `## Props\n\n\`\`\`ts\n${props}\n\`\`\`` : '',
+        routing.length > 0 ? `## Signal Routing\n\n${routing.map((l) => `  ${l}`).join('\n')}` : '',
+        backendNodes.length > 0 ? `## Backend Nodes Used\n\n${backendNodes.map((n) => `- \`${n}\``).join('\n')}` : '',
+        `## Factory\n\n\`${factoryName ?? 'unknown'}(context, props?)\``,
+      ].filter(Boolean)
+
+      return { content: [{ type: 'text', text: sections.join('\n\n') }] }
+    }
+
+    // List all — optionally filtered by category
+    const files = readdirSync(EFFECTS_DIR)
+      .filter((f) => f.endsWith('.ts') && f !== 'index.ts')
+      .sort()
+
+    const lines = files.map((f) => {
+      const name = f.replace('.ts', '')
+      const meta = EFFECT_META[name] ?? { category: 'unknown', desc: '', edm: '' }
+      if (category !== 'all' && meta.category !== category) return null
+      return `**${name}** (${meta.category}) — ${meta.desc}`
+    }).filter(Boolean)
+
+    const grouped = {}
+    files.forEach((f) => {
+      const name = f.replace('.ts', '')
+      const meta = EFFECT_META[name] ?? { category: 'other', desc: '', edm: '' }
+      if (category !== 'all' && meta.category !== category) return
+      if (!grouped[meta.category]) grouped[meta.category] = []
+      grouped[meta.category].push(`  - \`${name}\` — ${meta.desc}`)
+    })
+
+    const output = Object.entries(grouped).map(([cat, items]) => `### ${cat}\n${items.join('\n')}`).join('\n\n')
+
+    return { content: [{ type: 'text', text: `# @score/effects Catalog\n\nImport: \`import { createDelay } from '@score/effects'\`\n\n${output}\n\nUse \`effect_catalog({ effect: "name" })\` for full detail on any effect.` }] }
+  },
+}
+
+// ─── Tool: signal_flow ────────────────────────────────────────────────
+
+const PACKAGE_DIRS = {
+  effects: join(SCORE_ROOT, 'packages', 'effects', 'src'),
+  mixer:   join(SCORE_ROOT, 'packages', 'mixer', 'src'),
+  components: join(SCORE_ROOT, 'packages', 'components', 'src'),
+  modulation: join(SCORE_ROOT, 'packages', 'modulation', 'src'),
+}
+
+const findComponentFile = (name) => {
+  for (const [pkg, dir] of Object.entries(PACKAGE_DIRS)) {
+    const path = join(dir, `${name}.ts`)
+    if (existsSync(path)) return { path, pkg }
+    // Try without create prefix
+    const noCreate = name.replace(/^create/, '').toLowerCase()
+    const altPath = join(dir, `${noCreate}.ts`)
+    if (existsSync(altPath)) return { path: altPath, pkg }
+  }
+  return null
+}
+
+const signalFlow = {
+  name: 'signal_flow',
+  description: 'Trace the audio signal routing for a component — shows how nodes connect, which nodes sit in the signal path, and where input/output are. Works for effects, mixer channels, instruments, and modulation.',
+  inputSchema: {
+    component: z.string()
+      .describe('Component name: effect (e.g. "delay", "reverb"), mixer (e.g. "channel", "mixer"), or instrument (e.g. "kick", "synth"). Case-insensitive.'),
+  },
+  handler: async ({ component }) => {
+    const name = component.toLowerCase()
+    const found = findComponentFile(name)
+
+    if (!found) {
+      return { content: [{ type: 'text', text: `Component "${component}" not found.\n\nSearched in: effects, mixer, components, modulation.\nTry: delay, reverb, compressor, channel, mixer, kick, synth, chorus, lfo` }] }
+    }
+
+    const content = readFile(found.path)
+    if (!content) return { content: [{ type: 'text', text: `Could not read ${found.path}` }] }
+
+    const routing = extractRouting(content)
+    const backendNodes = extractBackendNodes(content)
+
+    // Extract all .connect() calls for a comprehensive flow diagram
+    const connectCalls = content.split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.match(/^\w+\.connect\(\w+\)/) || l.startsWith('// Route') || l.startsWith('// Feedback'))
+
+    // Find what the component returns (output node)
+    const connectMethod = content.match(/connect:\s*\(destination[^)]*\)\s*=>\s*\{[^}]*?(\w+)\.connect\(destination\)/s)
+    const outputNode = connectMethod?.[1] ?? 'unknown'
+
+    // Find input — usually first node created or inputGain
+    const inputMatch = content.match(/const (\w*(?:input|in)\w*)\s*=\s*context\.create/)
+    const inputNode = inputMatch?.[1] ?? 'first created node'
+
+    const sections = [
+      `# Signal Flow — ${name} (${found.pkg})`,
+      '',
+      `**Input node:** \`${inputNode}\`  **Output node:** \`${outputNode}\``,
+      '',
+      '## Routing',
+      connectCalls.length > 0
+        ? connectCalls.map((l) => `  ${l}`).join('\n')
+        : '  (no explicit routing — single-node component)',
+      '',
+      '## Backend Nodes',
+      backendNodes.map((n) => `- \`${n}\``).join('\n') || '  none',
+    ]
+
+    return { content: [{ type: 'text', text: sections.join('\n') }] }
+  },
+}
+
+// ─── Tool: backend_nodes ─────────────────────────────────────────────
+
+const WEB_AUDIO_MAP = {
+  BackendOscillatorNode:   'OscillatorNode',
+  BackendGainNode:         'GainNode',
+  BackendNoiseNode:        'AudioWorkletNode (custom)',
+  BackendBufferSourceNode: 'AudioBufferSourceNode',
+  BackendFilterNode:       'BiquadFilterNode',
+  BackendDelayNode:        'DelayNode',
+  BackendCompressorNode:   'DynamicsCompressorNode',
+  BackendWaveShaperNode:   'WaveShaperNode',
+  BackendStereoPannerNode: 'StereoPannerNode',
+  BackendContext:          'AudioContext',
+  BackendAudioParam:       'AudioParam (modulatable wrapper)',
+}
+
+const backendNodes = {
+  name: 'backend_nodes',
+  description: 'List all BackendNode types in @score/core with their methods, properties, and the Web Audio API node each maps to. Score abstracts all Web Audio behind these types.',
+  inputSchema: {
+    node: z.string().optional()
+      .describe('Specific node type (e.g. "BackendGainNode", "BackendFilterNode"). Omit to list all.'),
+  },
+  handler: async ({ node }) => {
+    const typesPath = join(SCORE_ROOT, 'packages', 'core', 'src', 'backend', 'types.ts')
+    const content = readFile(typesPath)
+    if (!content) return { content: [{ type: 'text', text: 'backend/types.ts not found' }] }
+
+    const lines = content.split('\n')
+
+    // Parse all exported types
+    const parseNodeType = (typeName) => {
+      let capturing = false
+      let depth = 0
+      const result = []
+      for (const line of lines) {
+        if (!capturing && line.match(new RegExp(`export type ${typeName}\\b`))) {
+          capturing = true
+        }
+        if (capturing) {
+          result.push(line)
+          depth += (line.match(/\{/g) ?? []).length
+          depth -= (line.match(/\}/g) ?? []).length
+          if (depth <= 0 && result.length > 1) break
+        }
+      }
+      return result.join('\n').trim()
+    }
+
+    if (node) {
+      const typeDef = parseNodeType(node)
+      if (!typeDef) return { content: [{ type: 'text', text: `Type "${node}" not found in backend/types.ts` }] }
+      const webAudio = WEB_AUDIO_MAP[node] ?? 'unknown'
+      return { content: [{ type: 'text', text: `# ${node}\n\n**Web Audio equivalent:** \`${webAudio}\`\n\n\`\`\`ts\n${typeDef}\n\`\`\`` }] }
+    }
+
+    // List all BackendNode types
+    const typeNames = [...content.matchAll(/^export type (Backend\w+)/gm)].map((m) => m[1])
+
+    const sections = typeNames.map((name) => {
+      const webAudio = WEB_AUDIO_MAP[name] ?? 'see types.ts'
+      const def = parseNodeType(name)
+      // Extract method names only for summary
+      const methods = (def.match(/readonly (\w+):/g) ?? []).map((m) => m.replace('readonly ', '').replace(':', ''))
+      return `**${name}** → \`${webAudio}\`\n  Methods: ${methods.join(', ') || 'none'}`
+    })
+
+    const also = ['OscillatorType', 'NoiseType', 'FilterType', 'OversampleType']
+      .filter((t) => content.includes(`export type ${t}`))
+      .map((t) => `- \`${t}\``)
+
+    const out = [
+      '# Backend Node Types — @score/core',
+      '',
+      'All Web Audio API access goes through these types. Never import Web Audio directly.',
+      '',
+      sections.join('\n\n'),
+      also.length > 0 ? `\n## Value Types\n${also.join('\n')}` : '',
+      '',
+      `Use \`backend_nodes({ node: "BackendGainNode" })\` for full type definition.`,
+    ].filter((s) => s !== undefined)
+
+    return { content: [{ type: 'text', text: out.join('\n') }] }
+  },
+}
+
+// ─── Tool: component_catalog ──────────────────────────────────────────
+
+const CATALOG_PACKAGES = [
+  { pkg: 'components',  dir: join(SCORE_ROOT, 'packages', 'components', 'src'),  kind: 'instrument' },
+  { pkg: 'effects',     dir: join(SCORE_ROOT, 'packages', 'effects', 'src'),      kind: 'effect' },
+  { pkg: 'mixer',       dir: join(SCORE_ROOT, 'packages', 'mixer', 'src'),        kind: 'mixer' },
+  { pkg: 'modulation',  dir: join(SCORE_ROOT, 'packages', 'modulation', 'src'),   kind: 'modulation' },
+]
+
+const componentCatalog = {
+  name: 'component_catalog',
+  description: 'List all AudioComponents in the Score framework — instruments, effects, mixer nodes, and modulation sources. Shows factory name, Props type, and which package to import from.',
+  inputSchema: {
+    kind: z.enum(['all', 'instrument', 'effect', 'mixer', 'modulation'])
+      .optional().default('all')
+      .describe('Filter by component kind.'),
+    search: z.string().optional()
+      .describe('Search by component name substring.'),
+  },
+  handler: async ({ kind, search }) => {
+    const results = []
+
+    for (const { pkg, dir, kind: componentKind } of CATALOG_PACKAGES) {
+      if (kind !== 'all' && kind !== componentKind) continue
+      if (!existsSync(dir)) continue
+
+      const files = readdirSync(dir)
+        .filter((f) => f.endsWith('.ts') && f !== 'index.ts' && f !== 'chain.ts')
+        .sort()
+
+      for (const file of files) {
+        const name = file.replace('.ts', '')
+        if (search && !name.includes(search.toLowerCase())) continue
+
+        const content = readFile(join(dir, file))
+        if (!content) continue
+
+        const factoryMatch = content.match(/export const (create\w+)/)
+        const factory = factoryMatch?.[1]
+        if (!factory) continue
+
+        const propsMatch = content.match(/export type (\w+Props)/)
+        const propsType = propsMatch?.[1]
+
+        // Get first @example line if available
+        const exampleMatch = content.match(/@example\s*\n\s*\*\s*```[^\n]*\n\s*\*\s*([^\n]+)/)
+        const example = exampleMatch?.[1]?.replace(/^\*\s*/, '').trim()
+
+        results.push({ name, kind: componentKind, pkg, factory, propsType, example })
+      }
+    }
+
+    if (results.length === 0) {
+      return { content: [{ type: 'text', text: `No components found${search ? ` matching "${search}"` : ''}.` }] }
+    }
+
+    // Group by kind
+    const grouped = {}
+    for (const r of results) {
+      if (!grouped[r.kind]) grouped[r.kind] = []
+      grouped[r.kind].push(r)
+    }
+
+    const sections = Object.entries(grouped).map(([k, items]) => {
+      const lines = items.map((r) => {
+        const props = r.propsType ? ` — props: \`${r.propsType}\`` : ''
+        const ex = r.example ? `\n    Example: \`${r.example}\`` : ''
+        return `  - **\`${r.factory}\`** (@score/${r.pkg})${props}${ex}`
+      })
+      return `### ${k}\n${lines.join('\n')}`
+    })
+
+    const importHint = `Import pattern: \`import { createDelay } from '@score/effects'\`\n`
+      + `Use \`effect_catalog\` for effect details, \`signal_flow\` for routing.`
+
+    return { content: [{ type: 'text', text: `# AudioComponent Catalog\n\n${importHint}\n\n${sections.join('\n\n')}` }] }
+  },
+}
+
+// ─── Server ──────────────────────────────────────────────────────────
+
+const tools = [effectCatalog, signalFlow, backendNodes, componentCatalog]
+
+const createServer = () => {
+  const server = new McpServer({
+    name: 'score-audio',
+    version: '0.1.0',
+  })
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.inputSchema, tool.handler)
+  }
+
+  return server
+}
+
+const main = async () => {
+  const server = createServer()
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}
+
+main().catch((err) => {
+  process.stderr.write(`score-audio MCP error: ${err}\n`)
+  process.exit(1)
+})

--- a/mcp-servers/score-audio/index.js
+++ b/mcp-servers/score-audio/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // score-audio MCP — Audio domain intelligence for AI-assisted composition and debugging
-// Tools: effect_catalog, signal_flow, backend_nodes, component_catalog
+// Tools: effect_catalog, signal_flow, backend_nodes, component_catalog, instrument_source
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -419,9 +419,80 @@ const componentCatalog = {
   },
 }
 
+// ─── Tool: instrument_source ──────────────────────────────────────────
+
+const ALL_SOURCE_PACKAGES = [
+  { pkg: 'components',  dir: join(SCORE_ROOT, 'packages', 'components', 'src'),  kind: 'instrument' },
+  { pkg: 'effects',     dir: join(SCORE_ROOT, 'packages', 'effects', 'src'),      kind: 'effect' },
+  { pkg: 'mixer',       dir: join(SCORE_ROOT, 'packages', 'mixer', 'src'),        kind: 'mixer' },
+  { pkg: 'modulation',  dir: join(SCORE_ROOT, 'packages', 'modulation', 'src'),   kind: 'modulation' },
+  { pkg: 'musical',     dir: join(SCORE_ROOT, 'packages', 'musical', 'src'),      kind: 'musical' },
+  { pkg: 'math',        dir: join(SCORE_ROOT, 'packages', 'math', 'src'),         kind: 'math' },
+  { pkg: 'pattern',     dir: join(SCORE_ROOT, 'packages', 'pattern', 'src'),      kind: 'pattern' },
+]
+
+const instrumentSource = {
+  name: 'instrument_source',
+  description: 'Read the full TypeScript source of any instrument, effect, or audio module. Use this to understand exactly how a component is implemented before writing a new one — see the oscillator setup, filter routing, envelope scheduling, and factory function pattern.',
+  inputSchema: {
+    name: z.string()
+      .describe('File name without extension (e.g. "kick", "synth", "delay", "lfo", "describe"). Case-insensitive.'),
+    package: z.string().optional()
+      .describe('Package to search in (e.g. "components", "effects", "modulation", "musical", "math"). Omit to search all.'),
+  },
+  handler: async ({ name, package: pkgFilter }) => {
+    const target = name.toLowerCase().replace(/\.ts$/, '')
+
+    const candidates = []
+
+    for (const { pkg, dir, kind } of ALL_SOURCE_PACKAGES) {
+      if (pkgFilter && pkg !== pkgFilter) continue
+      if (!existsSync(dir)) continue
+
+      const files = readdirSync(dir).filter((f) => f.endsWith('.ts'))
+      for (const file of files) {
+        const base = file.replace('.ts', '').toLowerCase()
+        if (base === target || base.includes(target)) {
+          candidates.push({ pkg, kind, file, path: join(dir, file) })
+        }
+      }
+    }
+
+    if (candidates.length === 0) {
+      // Build list of all available names
+      const available = []
+      for (const { pkg, dir } of ALL_SOURCE_PACKAGES) {
+        if (!existsSync(dir)) continue
+        readdirSync(dir)
+          .filter((f) => f.endsWith('.ts') && f !== 'index.ts')
+          .forEach((f) => available.push(`${f.replace('.ts', '')} (@score/${pkg})`))
+      }
+      return { content: [{ type: 'text', text: `"${name}" not found.\n\nAvailable:\n${available.map((a) => `  - ${a}`).join('\n')}` }] }
+    }
+
+    if (candidates.length === 1) {
+      const { pkg, kind, file, path } = candidates[0]
+      const content = readFile(path)
+      return { content: [{ type: 'text', text: `# @score/${pkg}/${file} (${kind})\n\n\`\`\`ts\n${content}\n\`\`\`` }] }
+    }
+
+    // Multiple matches — show list and ask to narrow
+    if (candidates.length <= 3) {
+      const parts = candidates.map(({ pkg, kind, file, path }) => {
+        const content = readFile(path)
+        return `# @score/${pkg}/${file} (${kind})\n\n\`\`\`ts\n${content}\n\`\`\``
+      })
+      return { content: [{ type: 'text', text: parts.join('\n\n---\n\n') }] }
+    }
+
+    const list = candidates.map(({ pkg, file }) => `  - ${file} (@score/${pkg})`).join('\n')
+    return { content: [{ type: 'text', text: `Multiple matches for "${name}":\n${list}\n\nNarrow with the \`package\` param.` }] }
+  },
+}
+
 // ─── Server ──────────────────────────────────────────────────────────
 
-const tools = [effectCatalog, signalFlow, backendNodes, componentCatalog]
+const tools = [effectCatalog, signalFlow, backendNodes, componentCatalog, instrumentSource]
 
 const createServer = () => {
   const server = new McpServer({

--- a/mcp-servers/score-audio/package-lock.json
+++ b/mcp-servers/score-audio/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "score-audio-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "score-audio-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-servers/score-audio/package.json
+++ b/mcp-servers/score-audio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "score-audio-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "build": "npx esbuild index.js --bundle --platform=node --format=esm --outfile=dist/index.js",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.24.0"
+  }
+}


### PR DESCRIPTION
## Summary

- New `score-audio` MCP server at `mcp-servers/score-audio/`
- 5 tools: `effect_catalog`, `signal_flow`, `backend_nodes`, `component_catalog`, `instrument_source`
- Audio domain intelligence for AI-assisted composition and debugging
- Reads `@score/effects`, `@score/components`, `@score/core` source at runtime

## Test plan

- [ ] Start server: `node mcp-servers/score-audio/index.js`
- [ ] Add to `claude_desktop_config.json` and restart Claude Desktop
- [ ] Verify tools show up: `effect_catalog`, `signal_flow`, `backend_nodes`, `component_catalog`, `instrument_source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)