### PR TITLE
feat(cli,core): Phase 10 — score list, score export, offline WAV renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,7 @@ sounds/**/*
 
 # Claude Code local state
 .claude/
+
+# Local only — not ready to publish
+THESIS.md
 mcp-servers/score-codebase/node_modules/

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,149 @@
+// score export — render a song to a WAV file.
+// Uses OfflineAudioContext to schedule all note events upfront,
+// then encodes the result as 16-bit PCM WAV.
+//
+// Usage:
+//   score export <song.js>                      → <song>.wav (same directory)
+//   score export <song.js> --out ./render.wav   → specified output path
+//   score export <song.js> --bars 16            → render exactly 16 bars
+
+import { resolve, dirname, basename, extname } from 'node:path'
+import { existsSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { ScoreError } from '@score/core'
+import type { SongDefinition } from '@score/dsl'
+import { validateSongFile } from '../validator/SongValidator.js'
+import { validateSongExport } from '../validator/SongExportValidator.js'
+import { renderSong, encodeWav } from '../renderer.js'
+
+const GREEN  = '\x1b[32m'
+const CYAN   = '\x1b[36m'
+const YELLOW = '\x1b[33m'
+const RESET  = '\x1b[0m'
+
+const log  = (msg: string): void => { console.log(`${GREEN}Score:${RESET} ${msg}`) }
+const warn = (msg: string): void => { console.log(`${YELLOW}Score:${RESET} ${msg}`) }
+
+const loadSong = async (resolved: string, trust: boolean): Promise<SongDefinition> => {
+  if (!trust) validateSongFile(resolved)
+
+  const url = pathToFileURL(resolved).href
+  const mod = await import(url) as Record<string, unknown>
+  const raw: unknown = mod['default']
+  if (!raw || typeof raw !== 'object') {
+    throw ScoreError('Song file must have a default export', {
+      received: typeof raw,
+      fix: 'Add: export default Song({ bpm: 140, tracks: [...] })',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  validateSongExport(raw)
+  const song = raw as SongDefinition
+  if (!song.bpm || song.bpm <= 0) {
+    throw ScoreError('Song must have a valid bpm', {
+      received: song.bpm,
+      fix: 'Song({ bpm: 140, ... }) — bpm must be a positive number',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+  return song
+}
+
+/**
+ * Render a song file to a WAV file on disk.
+ *
+ * @param args - CLI arguments. Expects a file path as the first non-flag argument.
+ *   - `--out <path>` / `-o <path>` — output file path. Defaults to `<song>.wav` in the same directory.
+ *   - `--bars <n>` / `-b <n>` — number of bars to render. Defaults to arrangement length or 8.
+ *   - `--sr <n>` — sample rate in Hz. Defaults to `44100`.
+ *   - `--trust` / `-t` — skip static analysis of the song file.
+ *
+ * @example
+ * ```
+ * score export my-track.js
+ * score export my-track.js --out ./renders/my-track.wav --bars 32
+ * ```
+ *
+ * @throws `ScoreError` if the file is missing or the song is invalid.
+ */
+export const exportSong = async (args: string[]): Promise<void> => {
+  const trust    = args.includes('--trust') || args.includes('-t')
+  const filePath = args.find(a => !a.startsWith('-'))
+
+  if (!filePath) {
+    throw ScoreError('No song file specified', {
+      received: undefined,
+      fix: 'Usage: score export <song.js>',
+      docs: 'https://score.dev/docs/cli/export',
+    })
+  }
+
+  const resolved = resolve(process.cwd(), filePath.replace(/\\/g, '/'))
+  if (!existsSync(resolved)) {
+    throw ScoreError(`Song file not found: ${filePath}`, {
+      received: resolved,
+      fix: 'Check the file path and try again',
+      docs: 'https://score.dev/docs/cli/export',
+    })
+  }
+
+  // Parse --out / -o
+  const outFlagIdx = args.findIndex(a => a === '--out' || a === '-o')
+  const outArg     = outFlagIdx !== -1 ? args[outFlagIdx + 1] : undefined
+  const defaultOut = resolve(
+    dirname(resolved),
+    `${basename(filePath, extname(filePath))}.wav`,
+  )
+  const outPath = outArg ? resolve(process.cwd(), outArg.replace(/\\/g, '/')) : defaultOut
+
+  // Parse --bars / -b
+  const barsFlagIdx = args.findIndex(a => a === '--bars' || a === '-b')
+  const barsArg     = barsFlagIdx !== -1 ? args[barsFlagIdx + 1] : undefined
+  const bars        = barsArg !== undefined ? parseInt(barsArg, 10) : undefined
+  if (bars !== undefined && (isNaN(bars) || bars <= 0)) {
+    throw ScoreError('--bars must be a positive integer', {
+      received: barsArg,
+      fix: 'score export song.js --bars 16',
+      docs: 'https://score.dev/docs/cli/export',
+    })
+  }
+
+  // Parse --sr
+  const srFlagIdx = args.findIndex(a => a === '--sr')
+  const srArg     = srFlagIdx !== -1 ? args[srFlagIdx + 1] : undefined
+  const sampleRate = srArg !== undefined ? parseInt(srArg, 10) : 44100
+  if (isNaN(sampleRate) || sampleRate <= 0) {
+    throw ScoreError('--sr must be a positive integer', {
+      received: srArg,
+      fix: 'score export song.js --sr 44100',
+      docs: 'https://score.dev/docs/cli/export',
+    })
+  }
+
+  log(`Loading ${CYAN}${filePath}${RESET}...`)
+  const song = await loadSong(resolved, trust)
+
+  const arrangementBars = song.arrangement.reduce((sum, s) => sum + s.bars, 0)
+  const totalBars = bars ?? (arrangementBars > 0 ? arrangementBars : 8)
+  const stepSec   = 60 / song.bpm / 4
+  const durationSec = totalBars * 16 * stepSec
+  const mins = Math.floor(durationSec / 60)
+  const secs  = Math.round(durationSec % 60)
+
+  log(`Rendering ${String(totalBars)} bars (~${String(mins)}:${String(secs).padStart(2, '0')}) at ${String(sampleRate)} Hz...`)
+
+  if (song.tracks.some(t => {
+    const d = 'instrumentType' in t ? t : t.component
+    return 'instrumentType' in d && (d.instrumentType === 'theremin' || d.instrumentType === 'sax')
+  })) {
+    warn('Theremin and Sax are continuous instruments and will not be included in the export.')
+  }
+
+  const buffer = await renderSong(song, { bars: totalBars, sampleRate })
+  const wav    = encodeWav(buffer)
+
+  writeFileSync(outPath, wav)
+
+  const sizeMb = (wav.length / 1024 / 1024).toFixed(1)
+  log(`Exported → ${CYAN}${outPath}${RESET} (${sizeMb} MB)`)
+}

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,0 +1,129 @@
+// score list — display metadata and track info for a song file.
+// Loads the song without starting audio. Prints bpm, key, genre,
+// arrangement, and per-track details in a readable format.
+
+import { resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { ScoreError } from '@score/core'
+import type { SongDefinition, InstrumentDescriptor } from '@score/dsl'
+import { validateSongFile } from '../validator/SongValidator.js'
+import { validateSongExport } from '../validator/SongExportValidator.js'
+import { isInstrumentDescriptor } from '../engine.js'
+
+const CYAN  = '\x1b[36m'
+const GREEN = '\x1b[32m'
+const DIM   = '\x1b[2m'
+const RESET = '\x1b[0m'
+const BOLD  = '\x1b[1m'
+
+const header = (msg: string): void => { console.log(`\n${BOLD}${msg}${RESET}`) }
+const row    = (label: string, value: string): void => {
+  console.log(`  ${DIM}${label.padEnd(14)}${RESET}${value}`)
+}
+
+/**
+ * Display metadata and structure of a song file without starting audio playback.
+ *
+ * @param args - CLI arguments. Expects a file path as the first non-flag argument.
+ *   Flags: `--trust` / `-t` skip static analysis of the song file.
+ *
+ * @example
+ * ```
+ * score list my-track.js
+ * score list my-track.js --trust
+ * ```
+ */
+export const list = async (args: string[]): Promise<void> => {
+  const trust    = args.includes('--trust') || args.includes('-t')
+  const filePath = args.find(a => !a.startsWith('-'))
+
+  if (!filePath) {
+    throw ScoreError('No song file specified', {
+      received: undefined,
+      fix: 'Usage: score list <song.js>',
+      docs: 'https://score.dev/docs/cli/list',
+    })
+  }
+
+  const resolved = resolve(process.cwd(), filePath.replace(/\\/g, '/'))
+  if (!existsSync(resolved)) {
+    throw ScoreError(`Song file not found: ${filePath}`, {
+      received: resolved,
+      fix: 'Check the file path and try again',
+      docs: 'https://score.dev/docs/cli/list',
+    })
+  }
+
+  if (!trust) validateSongFile(resolved)
+
+  const url = pathToFileURL(resolved).href
+  const mod = await import(url) as Record<string, unknown>
+  const raw: unknown = mod['default']
+  if (!raw || typeof raw !== 'object') {
+    throw ScoreError('Song file must have a default export', {
+      received: typeof raw,
+      fix: 'Add: export default Song({ bpm: 140, tracks: [...] })',
+      docs: 'https://score.dev/docs/dsl/song',
+    })
+  }
+
+  validateSongExport(raw)
+  const song = raw as SongDefinition
+
+  // ── Summary ──────────────────────────────────────────────────────────────
+  header(`${GREEN}Score${RESET} — ${CYAN}${filePath}${RESET}`)
+  row('BPM',   String(song.bpm))
+  row('Key',   song.key   ?? '—')
+  row('Genre', song.genre ?? '—')
+  row('Tracks', String(song.tracks.length))
+
+  // ── Arrangement ───────────────────────────────────────────────────────────
+  if (song.arrangement.length > 0) {
+    const totalBars = song.arrangement.reduce((sum, s) => sum + s.bars, 0)
+    const barsPerSec = song.bpm / 4
+    const totalSec = totalBars / barsPerSec
+    const mins = Math.floor(totalSec / 60)
+    const secs = Math.round(totalSec % 60)
+    row('Arrangement', `${String(totalBars)} bars (~${String(mins)}:${String(secs).padStart(2, '0')})`)
+
+    header('Arrangement')
+    song.arrangement.forEach(section => {
+      const trackNames = section.tracks
+        .map(t => isInstrumentDescriptor(t) ? t : t.component)
+        .filter(isInstrumentDescriptor)
+        .map((d: InstrumentDescriptor) => d.instrumentType)
+        .join(', ')
+      console.log(`  ${DIM}${section.sectionType.padEnd(10)}${RESET}${String(section.bars).padEnd(4)} bars  ${DIM}[${trackNames}]${RESET}`)
+    })
+  }
+
+  // ── Tracks ────────────────────────────────────────────────────────────────
+  header('Tracks')
+  song.tracks.forEach((track, i) => {
+    const desc: InstrumentDescriptor | null = isInstrumentDescriptor(track)
+      ? track
+      : (isInstrumentDescriptor(track.component) ? track.component : null)
+    if (!desc) return
+
+    const props = desc.props as Record<string, unknown>
+    const extras: string[] = []
+
+    if (typeof props['wave']   === 'string') extras.push(`wave:${props['wave']}`)
+    if (typeof props['volume'] === 'number') extras.push(`vol:${String(props['volume'])}`)
+    if (typeof props['gain']   === 'number') extras.push(`gain:${String(props['gain'])}`)
+    if (typeof props['note']   === 'string') extras.push(`note:${props['note']}`)
+    if (Array.isArray(props['notes']))       extras.push(`notes:[${(props['notes'] as string[]).join(',')}]`)
+    if (typeof props['path']   === 'string') extras.push(`path:${props['path']}`)
+
+    const effects = Array.isArray(props['effects']) ? props['effects'] as unknown[] : []
+    const fxStr = effects.length > 0
+      ? ` ${DIM}+${String(effects.length)} fx${RESET}`
+      : ''
+
+    const extrasStr = extras.length > 0 ? `  ${DIM}${extras.join('  ')}${RESET}` : ''
+    console.log(`  ${String(i + 1).padStart(2)}.  ${CYAN}${desc.instrumentType.padEnd(10)}${RESET}${extrasStr}${fxStr}`)
+  })
+
+  console.log('')
+}

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -65,7 +65,7 @@ const buildEffectsChain = (
 
 // ── Type guard ────────────────────────────────────────────────────────────────
 
-const isInstrumentDescriptor = (comp: unknown): comp is InstrumentDescriptor => {
+export const isInstrumentDescriptor = (comp: unknown): comp is InstrumentDescriptor => {
   if (typeof comp !== 'object' || comp === null) return false
   return (comp as { _type?: unknown })._type === 'InstrumentDescriptor'
 }
@@ -78,8 +78,9 @@ const DEFAULT_HIHAT_PATTERN = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
 const DEFAULT_SYNTH_PATTERN = [1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
 
 // ── Instrument trigger functions ──────────────────────────────────────────────
+// Exported for use by the offline renderer (renderer.ts).
 
-const triggerKick = (ctx: Context, time: number, props: KickProps, dest: GainNode): void => {
+export const triggerKick = (ctx: Context, time: number, props: KickProps, dest: GainNode): void => {
   const freq = props.synth?.frequency ?? 80
   const drop = props.synth?.pitchDrop ?? 0.1
   const gain = props.volume ?? 0.85
@@ -92,7 +93,7 @@ const triggerKick = (ctx: Context, time: number, props: KickProps, dest: GainNod
   osc.stop(time + drop + 0.15)
 }
 
-const triggerSnare = (ctx: Context, time: number, props: SnareProps, dest: GainNode): void => {
+export const triggerSnare = (ctx: Context, time: number, props: SnareProps, dest: GainNode): void => {
   const gain = props.volume ?? 0.5
   const body  = ctx.createOscillator({ type: 'sine', frequency: 185 })
   const bGain = ctx.createGain({ gain: gain * 0.7 })
@@ -111,7 +112,7 @@ const triggerSnare = (ctx: Context, time: number, props: SnareProps, dest: GainN
   noise.stop(time + 0.12)
 }
 
-const triggerHiHat = (ctx: Context, time: number, props: HiHatProps, dest: GainNode): void => {
+export const triggerHiHat = (ctx: Context, time: number, props: HiHatProps, dest: GainNode): void => {
   const gain = props.volume ?? 0.25
   const dur  = props.open ? 0.3 : 0.06
   const noise  = ctx.createNoise({ type: 'white' })
@@ -124,7 +125,7 @@ const triggerHiHat = (ctx: Context, time: number, props: HiHatProps, dest: GainN
   noise.stop(time + dur)
 }
 
-const triggerSynth = (
+export const triggerSynth = (
   ctx: Context,
   time: number,
   props: SynthDSLProps,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,8 @@ import { play } from './commands/play.js'
 import { repl } from './commands/repl.js'
 import { newSong } from './commands/new.js'
 import { doctor } from './commands/doctor.js'
+import { list } from './commands/list.js'
+import { exportSong } from './commands/export.js'
 
 const [,, command, ...args] = process.argv
 
@@ -18,6 +20,8 @@ const commands: Record<string, (args: string[]) => Promise<void> | void> = {
   repl:   args => repl(args),
   new:    args => { newSong(args); },
   doctor: args => { doctor(args); },
+  list:   args => list(args),
+  export: args => exportSong(args),
 }
 
 const handler = commands[command ?? '']
@@ -25,12 +29,15 @@ if (!handler) {
   console.log('Score — EDM audio framework')
   console.log('')
   console.log('Usage:')
-  console.log('  score play <song.js>         Play a song file')
-  console.log('  score play <song.js> --watch Live reload on file save')
-  console.log('  score repl [song.js]         Interactive live coding REPL')
-  console.log('  score new song <name>        Create a new song from template')
-  console.log('  score doctor                 Check system requirements')
-  console.log('  score --version              Show version')
+  console.log('  score play <song.js>              Play a song file')
+  console.log('  score play <song.js> --watch      Live reload on file save')
+  console.log('  score repl [song.js]              Interactive live coding REPL')
+  console.log('  score list <song.js>              Show song info and track list')
+  console.log('  score export <song.js>            Render song to WAV')
+  console.log('  score export <song.js> --bars 16  Render specified number of bars')
+  console.log('  score new song <name>             Create a new song from template')
+  console.log('  score doctor                      Check system requirements')
+  console.log('  score --version                   Show version')
   process.exit(0)
 }
 

--- a/packages/cli/src/renderer.ts
+++ b/packages/cli/src/renderer.ts
@@ -1,0 +1,283 @@
+// Offline renderer — renders a SongDefinition to a raw audio buffer.
+//
+// Uses OfflineAudioContext to schedule all notes upfront and render without
+// a real-time audio device. Instruments supported: kick, snare, hihat, synth, arp.
+// Theremin and sax (continuous, non-pattern) are skipped in offline mode.
+//
+// HARDWARE BOUNDARY: offline rendering is inherently time-sequential;
+// the step loop here is a controlled boundary exception, not DSL-layer state.
+
+import { readFileSync } from 'node:fs'
+import { createOfflineContext } from '@score/core'
+import { decodeSample, createSamplePlayer } from '@score/core'
+import { createMixer } from '@score/mixer'
+import { resolveFreq } from '@score/dsl'
+import type {
+  SongDefinition, InstrumentDescriptor,
+  KickProps, SnareProps, HiHatProps, SynthDSLProps, SampleProps, ArpDSLProps,
+} from '@score/dsl'
+import {
+  isInstrumentDescriptor,
+  triggerKick, triggerSnare, triggerHiHat, triggerSynth,
+} from './engine.js'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const STEPS_PER_BAR = 16
+const LEAD_TIME     = 0.01  // small offset so first event doesn't clip at t=0
+const TAIL_SEC      = 0.5   // render a little past the last note for release tails
+
+// ── Pattern evaluation ────────────────────────────────────────────────────────
+
+const evalPattern = <T>(
+  pattern: T[] | ((step: number, bar: number) => T),
+  step: number,
+  bar: number,
+): T => {
+  if (Array.isArray(pattern)) return pattern[step % pattern.length] as T
+  return pattern(step, bar)
+}
+
+// ── Arrangement — active track set per bar ────────────────────────────────────
+
+const buildArrangementMap = (song: SongDefinition): Map<number, Set<string>> | null => {
+  if (song.arrangement.length === 0) return null
+
+  const result = new Map<number, Set<string>>()
+  let cursor = 0
+  for (const section of song.arrangement) {
+    for (let b = 0; b < section.bars; b++) {
+      const activeIds = new Set(
+        section.tracks
+          .map(t => isInstrumentDescriptor(t) ? t : t.component)
+          .filter(isInstrumentDescriptor)
+          .map((d: InstrumentDescriptor) => d.id),
+      )
+      result.set(cursor + b, activeIds)
+    }
+    cursor += section.bars
+  }
+  return result
+}
+
+// ── WAV encoder ───────────────────────────────────────────────────────────────
+
+/**
+ * Encode a rendered audio buffer as a 16-bit PCM WAV binary.
+ *
+ * @param rendered    - Rendered buffer from `startRendering`.
+ * @returns `Buffer` containing a valid WAV file.
+ */
+export const encodeWav = (rendered: {
+  length: number
+  sampleRate: number
+  numberOfChannels: number
+  getChannelData: (channel: number) => Float32Array
+}): Buffer => {
+  const channels    = rendered.numberOfChannels
+  const sampleRate  = rendered.sampleRate
+  const numSamples  = rendered.length
+  const bitsPerSample = 16
+  const blockAlign  = channels * Math.ceil(bitsPerSample / 8)
+  const byteRate    = sampleRate * blockAlign
+  const dataSize    = numSamples * blockAlign
+
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + dataSize, 4)
+  header.write('WAVE', 8)
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20)          // PCM format
+  header.writeUInt16LE(channels, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(byteRate, 28)
+  header.writeUInt16LE(blockAlign, 32)
+  header.writeUInt16LE(bitsPerSample, 34)
+  header.write('data', 36)
+  header.writeUInt32LE(dataSize, 40)
+
+  const pcm = Buffer.alloc(dataSize)
+  const channelData = Array.from({ length: channels }, (_: unknown, c: number) =>
+    rendered.getChannelData(c),
+  )
+  for (let i = 0; i < numSamples; i++) {
+    for (let c = 0; c < channels; c++) {
+      const sample   = Math.max(-1, Math.min(1, channelData[c]?.[i] ?? 0))
+      const intSample = Math.round(sample * 32767)
+      pcm.writeInt16LE(intSample, (i * channels + c) * 2)
+    }
+  }
+
+  return Buffer.concat([header, pcm])
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+export type RenderOptions = {
+  /** Override total bars to render. Default: arrangement length, or 8 if no arrangement. */
+  readonly bars?: number
+  /** Output sample rate. Default: 44100. */
+  readonly sampleRate?: number
+  /** Output channel count. Default: 2. */
+  readonly channels?: number
+}
+
+/**
+ * Render a {@link SongDefinition} to an audio buffer using offline processing.
+ *
+ * All note events are scheduled upfront into an {@link OfflineAudioContext},
+ * then rendered to a buffer synchronously. Supported instrument types:
+ * `kick`, `snare`, `hihat`, `synth`, `arp`, `sample`.
+ * Theremin and Sax (continuous, non-pattern) are not rendered offline.
+ *
+ * @param song    - Compiled song descriptor.
+ * @param options - Render configuration.
+ * @returns Rendered audio buffer ready for WAV encoding via {@link encodeWav}.
+ *
+ * @example
+ * ```ts
+ * const song = await loadSong('./my-track.js')
+ * const buffer = await renderSong(song, { bars: 8 })
+ * const wav = encodeWav(buffer)
+ * writeFileSync('./my-track.wav', wav)
+ * ```
+ */
+export const renderSong = async (
+  song: SongDefinition,
+  options: RenderOptions = {},
+): Promise<{
+  length: number
+  sampleRate: number
+  numberOfChannels: number
+  getChannelData: (channel: number) => Float32Array
+}> => {
+  const sampleRate = options.sampleRate ?? 44100
+  const channels   = options.channels   ?? 2
+
+  const arrangementBars = song.arrangement.reduce((sum, s) => sum + s.bars, 0)
+  const totalBars  = options.bars ?? (arrangementBars > 0 ? arrangementBars : 8)
+  const stepSec    = 60 / song.bpm / 4  // 16th note duration
+  const totalSteps = totalBars * STEPS_PER_BAR
+  const durationSec = totalSteps * stepSec + TAIL_SEC
+  const length     = Math.ceil(durationSec * sampleRate)
+
+  const ctx = createOfflineContext({ length, sampleRate, numberOfChannels: channels })
+  const mixer = createMixer(ctx, { masterVolume: 0.85 })
+
+  const descriptors = song.tracks
+    .map(t => isInstrumentDescriptor(t) ? t : t.component)
+    .filter(isInstrumentDescriptor)
+
+  // Pre-decode sample buffers before scheduling
+  type RenderedBuffer = Awaited<ReturnType<typeof decodeSample>>
+  const sampleBuffers = new Map<string, RenderedBuffer>()
+  await Promise.all(
+    descriptors
+      .filter(d => d.instrumentType === 'sample')
+      .map(async (d) => {
+        const props = d.props as SampleProps
+        const raw = readFileSync(props.path)
+        const arrayBuffer = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength)
+        sampleBuffers.set(d.id, await decodeSample(ctx, arrayBuffer))
+      }),
+  )
+
+  // Per-track channel inputs
+  type GainNode = ReturnType<typeof ctx.createGain>
+  const channelInputs: GainNode[] = descriptors.map(comp => {
+    const channel = mixer.addChannel({ name: comp.instrumentType, effects: [] })
+    return channel.input as unknown as GainNode
+  })
+
+  // Build arrangement map for mute logic
+  const arrangementMap = buildArrangementMap(song)
+
+  const isTrackActive = (descriptor: InstrumentDescriptor, bar: number): boolean => {
+    if (!arrangementMap) return true
+    const activeIds = arrangementMap.get(bar % totalBars)
+    return activeIds ? activeIds.has(descriptor.id) : true
+  }
+
+  // Schedule all steps upfront — hardware boundary (sequential time loop)
+  for (let absStep = 0; absStep < totalSteps; absStep++) {
+    const bar     = Math.floor(absStep / STEPS_PER_BAR)
+    const barStep = absStep % STEPS_PER_BAR
+    const time    = absStep * stepSec + LEAD_TIME
+
+    descriptors.forEach((desc, i) => {
+      const dest = channelInputs[i]
+      if (!dest) return
+      if (!isTrackActive(desc, bar)) return
+
+      switch (desc.instrumentType) {
+        case 'kick': {
+          const props = desc.props as KickProps
+          const pattern = props.pattern ?? [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
+          const hit = evalPattern(pattern, barStep, bar)
+          if (hit) triggerKick(ctx, time, props, dest)
+          break
+        }
+        case 'snare': {
+          const props = desc.props as SnareProps
+          const pattern = props.pattern ?? [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
+          const hit = evalPattern(pattern, barStep, bar)
+          if (hit) triggerSnare(ctx, time, props, dest)
+          break
+        }
+        case 'hihat': {
+          const props = desc.props as HiHatProps
+          const pattern = props.pattern ?? [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+          const hit = evalPattern(pattern, barStep, bar)
+          if (hit) triggerHiHat(ctx, time, props, dest)
+          break
+        }
+        case 'synth': {
+          const props = desc.props as SynthDSLProps
+          const rawPattern = props.pattern ?? props.sequence ?? [1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+          const pattern: (number | string)[] = Array.isArray(rawPattern) ? rawPattern : []
+          const val = evalPattern(pattern, barStep, bar)
+          const freq = resolveFreq(val)
+          if (freq > 0) triggerSynth(ctx, time, props, freq, dest)
+          break
+        }
+        case 'arp': {
+          const props = desc.props as ArpDSLProps
+          const notes = props.notes
+          if (notes.length === 0) break
+          const noteIdx = absStep % notes.length
+          const note = notes[noteIdx] ?? notes[0] ?? 'C4'
+          const freq = resolveFreq(note)
+          if (freq > 0) triggerSynth(ctx, time, {
+            wave: props.wave ?? 'triangle',
+            gain: props.gain ?? 0.3,
+            envelope: props.envelope,
+          } as SynthDSLProps, freq, dest)
+          break
+        }
+        case 'sample': {
+          const props = desc.props as SampleProps
+          const buf = sampleBuffers.get(desc.id)
+          if (!buf) break
+          const pattern = props.pattern ?? [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+          const hit = evalPattern(pattern, barStep, bar)
+          if (hit) {
+            const player = createSamplePlayer(ctx, buf, {
+              loop: props.loop ?? false,
+              playbackRate: props.rate ?? 1.0,
+              gain: props.volume ?? 1.0,
+            })
+            player.connect(dest)
+            player.start(time)
+          }
+          break
+        }
+        // theremin and sax are continuous instruments — not rendered offline
+        default:
+          break
+      }
+    })
+  }
+
+  return ctx.startRendering()
+}

--- a/packages/cli/tests/export.test.ts
+++ b/packages/cli/tests/export.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { writeFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const writeTempSong = (content: string): string => {
+  const dir = join(tmpdir(), 'score-cli-export-tests')
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, `export-song-${String(Date.now())}.mjs`)
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+const outPath = (name: string): string => {
+  const dir = join(tmpdir(), 'score-cli-export-tests')
+  mkdirSync(dir, { recursive: true })
+  return join(dir, name)
+}
+
+const MINIMAL_SONG = `
+import { Song, Kick } from '@score/dsl'
+export default Song({ bpm: 128, tracks: [Kick()] })
+`
+
+// ── unit tests for encodeWav ──────────────────────────────────────────────────
+
+describe('encodeWav', () => {
+  it('produces a valid RIFF WAV header', async () => {
+    const { encodeWav } = await import('../src/renderer.js')
+    const numSamples = 4410  // 0.1s at 44100 Hz
+    const channelData = new Float32Array(numSamples).fill(0.5)
+    const buf = encodeWav({
+      length:          numSamples,
+      sampleRate:      44100,
+      numberOfChannels: 1,
+      getChannelData:  () => channelData,
+    })
+    // RIFF header magic bytes
+    expect(buf.toString('ascii', 0, 4)).toBe('RIFF')
+    expect(buf.toString('ascii', 8, 12)).toBe('WAVE')
+    expect(buf.toString('ascii', 12, 16)).toBe('fmt ')
+    expect(buf.toString('ascii', 36, 40)).toBe('data')
+  })
+
+  it('encodes correct file size for 1 channel', async () => {
+    const { encodeWav } = await import('../src/renderer.js')
+    const numSamples = 100
+    const channelData = new Float32Array(numSamples)
+    const buf = encodeWav({
+      length:          numSamples,
+      sampleRate:      44100,
+      numberOfChannels: 1,
+      getChannelData:  () => channelData,
+    })
+    // 44 bytes header + numSamples * 1 channel * 2 bytes per sample
+    expect(buf.length).toBe(44 + numSamples * 2)
+  })
+
+  it('encodes correct file size for 2 channels', async () => {
+    const { encodeWav } = await import('../src/renderer.js')
+    const numSamples = 100
+    const channelData = new Float32Array(numSamples)
+    const buf = encodeWav({
+      length:          numSamples,
+      sampleRate:      44100,
+      numberOfChannels: 2,
+      getChannelData:  () => channelData,
+    })
+    // 44 bytes header + numSamples * 2 channels * 2 bytes per sample
+    expect(buf.length).toBe(44 + numSamples * 4)
+  })
+
+  it('clips samples to [-1, 1] range', async () => {
+    const { encodeWav } = await import('../src/renderer.js')
+    // Channels: one above +1, one below -1
+    const channelData = new Float32Array([2.0, -2.0])
+    const buf = encodeWav({
+      length:          2,
+      sampleRate:      44100,
+      numberOfChannels: 1,
+      getChannelData:  () => channelData,
+    })
+    // PCM data starts at byte 44
+    const s0 = buf.readInt16LE(44)
+    const s1 = buf.readInt16LE(46)
+    expect(s0).toBe(32767)   // clipped to +1 → max int16
+    expect(s1).toBe(-32767)  // clipped to -1 → min int16 (round)
+  })
+})
+
+// ── export command ────────────────────────────────────────────────────────────
+
+describe('export command', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws ScoreError when no file arg given', async () => {
+    const { exportSong } = await import('../src/commands/export.js')
+    await expect(exportSong([])).rejects.toThrow()
+  })
+
+  it('throws ScoreError when file does not exist', async () => {
+    const { exportSong } = await import('../src/commands/export.js')
+    await expect(exportSong(['/nonexistent/song.js'])).rejects.toThrow()
+  })
+
+  it('throws ScoreError when --bars is not a valid integer', async () => {
+    const { exportSong } = await import('../src/commands/export.js')
+    const path = writeTempSong(MINIMAL_SONG)
+    await expect(exportSong([path, '--bars', 'abc', '--trust'])).rejects.toThrow()
+  })
+
+  it('renders a minimal song and writes a WAV file', async () => {
+    const { exportSong } = await import('../src/commands/export.js')
+    const songPath = writeTempSong(MINIMAL_SONG)
+    const wav = outPath(`minimal-${String(Date.now())}.wav`)
+    await exportSong([songPath, '--out', wav, '--bars', '1', '--trust'])
+    expect(existsSync(wav)).toBe(true)
+    // Must be a valid RIFF WAV
+    const { readFileSync } = await import('node:fs')
+    const data = readFileSync(wav)
+    expect(data.toString('ascii', 0, 4)).toBe('RIFF')
+    expect(data.toString('ascii', 8, 12)).toBe('WAVE')
+    if (existsSync(wav)) unlinkSync(wav)
+  }, 30000)  // offline render can take a few seconds
+
+  it('defaults output path to <song>.wav', async () => {
+    const { exportSong } = await import('../src/commands/export.js')
+    const dir = join(tmpdir(), 'score-cli-export-tests')
+    mkdirSync(dir, { recursive: true })
+    const songName = `default-out-${String(Date.now())}`
+    const songPath = join(dir, `${songName}.mjs`)
+    writeFileSync(songPath, MINIMAL_SONG, 'utf-8')
+    const expectedWav = join(dir, `${songName}.wav`)
+    await exportSong([songPath, '--bars', '1', '--trust'])
+    expect(existsSync(expectedWav)).toBe(true)
+    if (existsSync(expectedWav)) unlinkSync(expectedWav)
+  }, 30000)
+})

--- a/packages/cli/tests/list.test.ts
+++ b/packages/cli/tests/list.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const writeTempSong = (content: string): string => {
+  const dir = join(tmpdir(), 'score-cli-list-tests')
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, `list-song-${String(Date.now())}.mjs`)
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+const MINIMAL_SONG = `
+import { Song, Kick } from '@score/dsl'
+export default Song({ bpm: 128, tracks: [Kick()] })
+`
+
+const FULL_SONG = `
+import { Song, Kick, Snare, HiHat, Synth, Intro, Drop } from '@score/dsl'
+const kick  = Kick({ pattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0] })
+const snare = Snare()
+const hihat = HiHat()
+const bass  = Synth({ wave: 'sawtooth', gain: 0.3 })
+export default Song({
+  bpm: 140,
+  key: 'Am',
+  genre: 'techno',
+  tracks: [kick, snare, hihat, bass],
+  arrangement: [
+    Intro(4,  [kick, bass]),
+    Drop(16,  [kick, snare, hihat, bass]),
+  ],
+})
+`
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('list command', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws ScoreError when no file arg given', async () => {
+    const { list } = await import('../src/commands/list.js')
+    await expect(list([])).rejects.toThrow()
+  })
+
+  it('throws ScoreError when file does not exist', async () => {
+    const { list } = await import('../src/commands/list.js')
+    await expect(list(['/nonexistent/path/song.js'])).rejects.toThrow()
+  })
+
+  it('prints bpm and track count for a minimal song', async () => {
+    const { list } = await import('../src/commands/list.js')
+    const path = writeTempSong(MINIMAL_SONG)
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      output.push(args.join(' '))
+    })
+    await list([path, '--trust'])
+    const combined = output.join('\n')
+    expect(combined).toContain('128')
+    expect(combined.toLowerCase()).toContain('kick')
+  })
+
+  it('prints key and genre when present', async () => {
+    const { list } = await import('../src/commands/list.js')
+    const path = writeTempSong(FULL_SONG)
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      output.push(args.join(' '))
+    })
+    await list([path, '--trust'])
+    const combined = output.join('\n')
+    expect(combined).toContain('140')
+    expect(combined).toContain('Am')
+    expect(combined).toContain('techno')
+  })
+
+  it('prints arrangement sections when present', async () => {
+    const { list } = await import('../src/commands/list.js')
+    const path = writeTempSong(FULL_SONG)
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      output.push(args.join(' '))
+    })
+    await list([path, '--trust'])
+    const combined = output.join('\n')
+    expect(combined).toContain('20')   // total bars: Intro(4) + Drop(16)
+    expect(combined.toLowerCase()).toContain('intro')
+    expect(combined.toLowerCase()).toContain('drop')
+  })
+
+  it('lists all four tracks', async () => {
+    const { list } = await import('../src/commands/list.js')
+    const path = writeTempSong(FULL_SONG)
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      output.push(args.join(' '))
+    })
+    await list([path, '--trust'])
+    const combined = output.join('\n')
+    expect(combined.toLowerCase()).toContain('kick')
+    expect(combined.toLowerCase()).toContain('snare')
+    expect(combined.toLowerCase()).toContain('hihat')
+    expect(combined.toLowerCase()).toContain('synth')
+  })
+
+  it('-t flag accepted as alias for --trust', async () => {
+    const { list } = await import('../src/commands/list.js')
+    const path = writeTempSong(MINIMAL_SONG)
+    await expect(list([path, '-t'])).resolves.not.toThrow()
+  })
+})

--- a/packages/core/src/backend/index.ts
+++ b/packages/core/src/backend/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js'
-export { webAudioBackend } from './web-audio.js'
+export { webAudioBackend, createOfflineContext } from './web-audio.js'
+export type { RenderableBackendContext } from './web-audio.js'

--- a/packages/core/src/backend/web-audio.ts
+++ b/packages/core/src/backend/web-audio.ts
@@ -401,6 +401,64 @@ const createBackendContext = (ctx: BaseAudioContext): BackendContext => {
     },
   }
 }
+// --- Renderable context (offline) ---
+
+/**
+ * A {@link BackendContext} that supports offline rendering.
+ * Created via {@link createOfflineContext} — use it to render a song to an audio buffer
+ * without a real-time audio device.
+ */
+export type RenderableBackendContext = BackendContext & {
+  /**
+   * Render all scheduled audio and return the resulting buffer.
+   * Call this after scheduling all note events.
+   */
+  readonly startRendering: () => Promise<{
+    readonly length: number
+    readonly sampleRate: number
+    readonly numberOfChannels: number
+    readonly getChannelData: (channel: number) => Float32Array
+  }>
+}
+
+/**
+ * Create an offline {@link RenderableBackendContext} for WAV rendering.
+ *
+ * @param options - Offline render configuration.
+ *   - `length` — total number of samples to render.
+ *   - `sampleRate` — sample rate in Hz. Defaults to `44100`.
+ *   - `numberOfChannels` — channel count. Defaults to `2`.
+ * @returns A backend context with `startRendering()` for offline render.
+ *
+ * @example
+ * ```ts
+ * const ctx = createOfflineContext({ length: 44100 * 10, sampleRate: 44100 })
+ * // schedule audio events...
+ * const buffer = await ctx.startRendering()
+ * ```
+ */
+export const createOfflineContext = (options: {
+  length: number
+  sampleRate?: number
+  numberOfChannels?: number
+}): RenderableBackendContext => {
+  const sampleRate = options.sampleRate ?? 44100
+  const raw = new OfflineAudioContext(
+    options.numberOfChannels ?? 2,
+    options.length,
+    sampleRate,
+  )
+  return {
+    ...createBackendContext(raw),
+    startRendering: () => raw.startRendering() as Promise<{
+      readonly length: number
+      readonly sampleRate: number
+      readonly numberOfChannels: number
+      readonly getChannelData: (channel: number) => Float32Array
+    }>,
+  }
+}
+
 // --- Web Audio BackendProvider ---
 
 export const webAudioBackend: BackendProvider = {


### PR DESCRIPTION
## Summary

- **`score list <song.js>`** — display song metadata: bpm, key, genre, tracks, arrangement with bar count and duration estimate
- **`score export <song.js>`** — render song to 16-bit PCM WAV using `OfflineAudioContext`. Flags: `--bars N`, `--out <path>`, `--sr <hz>`, `--trust`
- **`@score/core`** — `createOfflineContext()` + `RenderableBackendContext` type that wraps `OfflineAudioContext` and exposes `startRendering()`
- **`renderer.ts`** — offline renderer: schedules all steps upfront as a pre-computed time loop (hardware boundary), respects arrangement mute logic. Supports: kick, snare, hihat, synth, arp, sample. Theremin/Sax skipped (continuous instruments).
- **`encodeWav()`** — minimal 16-bit PCM WAV encoder (no external dep)
- **`score list`** / **`score export`** wired into `index.ts` help text
- Stacked on `feature/phase-9-completion` (Phase 9 — Arp, humanize, drift, keepFor)

## Test plan

- [ ] `encodeWav` unit tests — WAV header magic bytes, size calculation (1ch + 2ch), sample clipping to ±32767
- [ ] `score export` integration test — renders 1 bar of a minimal song to a real WAV file on disk, verifies RIFF header
- [ ] `score export` error tests — no file, file not found, invalid `--bars`
- [ ] `score list` tests — bpm/track display, key/genre display, arrangement sections, all four track types
- [ ] Full test suite: all 1133 tests pass across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)