### PR TITLE
docs: dual license, CLA, and contributing guide

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,45 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to Score.
+
+By submitting a pull request, issue, or any other contribution to this
+repository, you agree to the following terms:
+
+## 1. Grant of Copyright License
+
+You grant Bree Yard a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute your
+contributions and derivative works thereof, under any license — including
+commercial licenses.
+
+## 2. Grant of Patent License
+
+If your contribution includes any patented material, you grant Bree Yard a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent license
+to make, use, sell, offer for sale, import, and otherwise transfer the
+contribution.
+
+## 3. Original Work
+
+You represent that each of your contributions is your original creation and
+that you have the legal right to grant the above licenses. If your employer
+has rights to intellectual property you create, you represent that you have
+received permission to make the contribution on behalf of that employer.
+
+## 4. No Obligation
+
+You understand that the decision to include your contribution in the project
+rests entirely with the project maintainer and that this agreement does not
+obligate the maintainer to include your contribution.
+
+## 5. Acknowledgement
+
+By opening a pull request against this repository, you acknowledge that you
+have read, understood, and agree to be bound by the terms of this Contributor
+License Agreement.
+
+---
+
+*This CLA is based on the Apache Individual Contributor License Agreement v2.0
+and adapted for this project.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Score
+
+Thank you for contributing to Score.
+
+## Contributor License Agreement
+
+**All contributors must agree to the [Contributor License Agreement](CLA.md)
+before their pull request can be merged.**
+
+By opening a pull request, you automatically agree to the CLA terms. No
+separate signature is required — your PR submission is your agreement.
+
+## Code Standards
+
+All contributions must follow the project thesis:
+
+- Zero `let` — `const` everywhere
+- Zero `class` — factory functions only
+- Pure functions by default
+- Append-only state — new versions, not mutations
+- IO and hardware boundaries annotated explicitly with `// BOUNDARY — [reason]`
+
+Contributions that do not follow these standards will receive a change request.
+
+## Pull Request Process
+
+1. Fork the repository and create your branch from `dev`
+2. Write tests for any new functionality
+3. Ensure all existing tests pass (`pnpm test`)
+4. Add TSDoc comments to all public exports
+5. Open your PR against `dev` (not `main`)
+6. A maintainer will review and merge
+
+## Reporting Issues
+
+Open an issue on GitHub. For security issues, email bree@breeyard.com directly.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+same terms as the project. See [LICENSE](LICENSE) and [CLA.md](CLA.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+Copyright (c) 2024–present Bree Yard. All rights reserved.
+
+────────────────────────────────────────────────────────────────────────────
+NON-COMMERCIAL LICENSE (MIT)
+────────────────────────────────────────────────────────────────────────────
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to use,
+copy, modify, merge, publish, distribute, and/or sublicense the Software
+solely for non-commercial purposes, subject to the following conditions:
+
+  1. The above copyright notice and this permission notice shall be included
+     in all copies or substantial portions of the Software.
+
+  2. "Non-commercial" means personal, educational, research, or open-source
+     use where no revenue is directly or indirectly generated from the
+     Software or any product or service that incorporates the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+────────────────────────────────────────────────────────────────────────────
+COMMERCIAL LICENSE
+────────────────────────────────────────────────────────────────────────────
+
+Commercial use of this Software — including but not limited to use by record
+labels, music publishers, studios, streaming platforms, or any entity that
+incorporates the Software into a revenue-generating product or service —
+requires a separate commercial license.
+
+To request a commercial license, contact: bree@breeyard.com
+
+Unauthorised commercial use is a violation of copyright law.

--- a/LICENSE
+++ b/LICENSE
@@ -12,9 +12,11 @@ solely for non-commercial purposes, subject to the following conditions:
   1. The above copyright notice and this permission notice shall be included
      in all copies or substantial portions of the Software.
 
-  2. "Non-commercial" means personal, educational, research, or open-source
-     use where no revenue is directly or indirectly generated from the
-     Software or any product or service that incorporates the Software.
+  2. "Non-commercial" means personal, educational, research, open-source,
+     or artistic use. This explicitly includes artists, musicians, and
+     producers who use the Software to create, perform, distribute, or
+     commercially release music or other creative works — the music you
+     make with Score is yours, and you may profit from it freely.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -28,10 +30,14 @@ THE SOFTWARE.
 COMMERCIAL LICENSE
 ────────────────────────────────────────────────────────────────────────────
 
-Commercial use of this Software — including but not limited to use by record
-labels, music publishers, studios, streaming platforms, or any entity that
-incorporates the Software into a revenue-generating product or service —
-requires a separate commercial license.
+Commercial use of the Software *as software* — meaning embedding, bundling,
+or distributing Score as part of a revenue-generating software product or
+service (including but not limited to DAW plugins, SaaS platforms, streaming
+infrastructure, or tools sold to end users) — requires a separate commercial
+license.
+
+Using Score to create, produce, perform, or release music does not require a
+commercial license, regardless of whether that music generates revenue.
 
 To request a commercial license, contact: bree@breeyard.com
 


### PR DESCRIPTION
## Summary

- **LICENSE**: Dual license — non-commercial MIT (free for artists, open source, personal, educational use) + commercial license on request for software products (DAW plugins, SaaS, streaming infra). Artists making and profiting from music with Score need no commercial license.
- **CLA.md**: Contributor License Agreement — by opening a PR, contributors grant Bree Yard perpetual right to sublicense contributions commercially. Required before any PR can be merged.
- **CONTRIBUTING.md**: CLA acknowledgement, thesis code standards, PR process.

## Why now

External contributor PR #20 is open. Without a CLA in place, contributors retain full copyright on their contributions, blocking any commercial licensing of the project.

## Test plan

- [ ] Review LICENSE terms — especially artist exemption language
- [ ] Review CLA terms
- [ ] Merge before PR #20 is merged so CLA applies retroactively as a condition of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)