### PR TITLE
feat(components,engine): createFMSynth — 2-op FM synthesis (DX7 Rhodes / techno leads)

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -15,6 +15,7 @@
 //   hihat808 — createHihat808: 6 detuned sq oscs → BP/HP filter chain
 //   snare909 — createSnare909: 2 triangle oscs + white noise HPF
 //   subsynth — createSubtractiveSynth: saw/sq → resonant LP → ADSR VCA
+//   fmsynth  — createFMSynth: 2-op FM (DX7 Rhodes / metallic leads)
 
 import { readFileSync } from 'node:fs'
 import { webAudioBackend, decodeSample, createSamplePlayer } from '@score/core'
@@ -27,6 +28,7 @@ import {
   createHihat808,
   createSnare909,
   createSubtractiveSynth,
+  createFMSynth,
 } from '@score/components'
 import { createMixer } from '@score/mixer'
 import {
@@ -41,6 +43,7 @@ import type {
   SongDefinition, InstrumentDescriptor,
   KickProps, SnareProps, HiHatProps, SynthDSLProps, SampleProps, ThereminDSLProps, SaxDSLProps, ArpDSLProps,
   Kick808DSLProps, Kick909DSLProps, Hihat808DSLProps, Snare909DSLProps, SubSynthDSLProps,
+  FMSynthDSLProps,
 } from '@score/dsl'
 
 type Context = ReturnType<typeof webAudioBackend.createContext>
@@ -554,13 +557,39 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
-            // Create a fresh instance per hit (same pattern as triggerSynth)
             const voice = createSubtractiveSynth(ctx, {
               ...(props.wave   !== undefined && { wave:   props.wave }),
               ...(props.filter !== undefined && { filter: props.filter }),
               ...(props.adsr   !== undefined && { adsr:   props.adsr }),
               frequency: freq,
               gain:      props.volume ?? 0.7,
+            })
+            voice.connect(dest)
+            voice.noteOn(pos.time)
+            voice.noteOff(pos.time + noteDur)
+          }
+        })
+        break
+      }
+      case 'fmsynth': {
+        const props = comp.props as FMSynthDSLProps
+        const rawPattern = props.pattern ?? DEFAULT_SYNTH_PATTERN
+        const pattern: (number | string)[] = Array.isArray(rawPattern) ? rawPattern : DEFAULT_SYNTH_PATTERN
+        const ampAdsr = props.ampAdsr ?? {}
+        const attack  = ampAdsr.attack  ?? 0.01
+        const decay   = ampAdsr.decay   ?? 0.2
+        const release = ampAdsr.release ?? 0.4
+        const noteDur = attack + decay + release + 0.02
+        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+          const freq = resolveFreq(val)
+          if (freq > 0) {
+            const voice = createFMSynth(ctx, {
+              frequency: freq,
+              ...(props.modRatio  !== undefined && { modRatio:  props.modRatio }),
+              ...(props.modIndex  !== undefined && { modIndex:  props.modIndex }),
+              ...(props.ampAdsr   !== undefined && { ampAdsr:   props.ampAdsr }),
+              ...(props.modAdsr   !== undefined && { modAdsr:   props.modAdsr }),
+              gain: props.volume ?? 0.7,
             })
             voice.connect(dest)
             voice.noteOn(pos.time)

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,3 +12,4 @@ export { createKick909, type Kick909Props, type Kick909Component } from './drums
 export { createHihat808, type Hihat808Props, type Hihat808Component } from './drums/hihat808.js'
 export { createSnare909, type Snare909Props, type Snare909Component } from './drums/snare909.js'
 export { createSubtractiveSynth, type SubtractiveSynthProps, type SubtractiveSynthComponent } from './synths/subtractive.js'
+export { createFMSynth, type FMSynthProps, type FMSynthComponent, type FMSynthAmpAdsr, type FMSynthModAdsr } from './synths/fm.js'

--- a/packages/components/src/synths/fm.ts
+++ b/packages/components/src/synths/fm.ts
@@ -1,0 +1,264 @@
+import type { AudioComponent, ScoreAudioContext, ScoreAudioNode } from '@score/core'
+import { uid } from '@score/core'
+
+/**
+ * Amp ADSR envelope parameters for {@link createFMSynth}.
+ */
+export type FMSynthAmpAdsr = {
+  /** Attack time in seconds. Default `0.01`. */
+  readonly attack?: number
+  /** Decay time in seconds. Default `0.2`. */
+  readonly decay?: number
+  /** Sustain level 0–1. Default `0.7`. */
+  readonly sustain?: number
+  /** Release time in seconds. Default `0.4`. */
+  readonly release?: number
+}
+
+/**
+ * Modulator ADSR envelope parameters for {@link createFMSynth}.
+ * Controls modulation depth over time (shapes timbre evolution).
+ */
+export type FMSynthModAdsr = {
+  /** Attack time in seconds. Default `0.005`. */
+  readonly attack?: number
+  /** Decay time in seconds. Default `0.3`. */
+  readonly decay?: number
+  /** Sustain level as fraction of peak mod depth (0–1). Default `1.0`. */
+  readonly sustain?: number
+  /** Release time in seconds. Default `0.2`. */
+  readonly release?: number
+}
+
+/**
+ * Configuration props for {@link createFMSynth}.
+ */
+export type FMSynthProps = {
+  /** Carrier frequency in Hz. Default `220`. */
+  readonly frequency?: number
+  /**
+   * Modulator-to-carrier frequency ratio. Non-integer produces inharmonic (metallic) character.
+   * Default `1.273` (DX7 Rhodes / metallic).
+   */
+  readonly modRatio?: number
+  /**
+   * Modulation index — peak frequency deviation as a multiplier of carrier frequency.
+   * At `modIndex=3` and 220 Hz carrier, peak deviation = ±660 Hz.
+   * Default `3`.
+   */
+  readonly modIndex?: number
+  /** Amplitude VCA ADSR envelope. See {@link FMSynthAmpAdsr}. */
+  readonly ampAdsr?: FMSynthAmpAdsr
+  /** Modulation depth ADSR envelope. See {@link FMSynthModAdsr}. */
+  readonly modAdsr?: FMSynthModAdsr
+  /** Output gain 0–1. Default `0.7`. */
+  readonly gain?: number
+}
+
+/**
+ * A 2-operator FM synthesis instrument component — extends {@link AudioComponent}
+ * with note-on / note-off. Suitable for DX7-style Rhodes, electric pianos, and
+ * techno leads.
+ *
+ * Signal path:
+ * - **Modulator** sine → modIndex gain (ADSR) → carrier.frequencyParam
+ * - **Carrier** sine → amp VCA (ADSR) → output gain → (caller connects output)
+ */
+export type FMSynthComponent = AudioComponent & {
+  /**
+   * Gate a note on: start both oscillators and trigger attack-decay-sustain phase
+   * on both the amp VCA and the mod-index gain.
+   * @param time - Schedule time in seconds. Defaults to `context.currentTime`.
+   */
+  readonly noteOn: (time?: number) => void
+  /**
+   * Gate a note off: trigger release phase on both envelopes and schedule oscillator stop.
+   * @param time - Schedule time in seconds. Defaults to `context.currentTime`.
+   */
+  readonly noteOff: (time?: number) => void
+  /**
+   * Set the carrier (and derived modulator) frequency in Hz.
+   * @param value - Target frequency in Hz.
+   * @param time - Optional schedule time.
+   */
+  readonly setFrequency: (value: number, time?: number) => void
+  /**
+   * Set the output gain.
+   * @param value - Gain 0–1.
+   * @param time - Optional schedule time.
+   */
+  readonly setGain: (value: number, time?: number) => void
+}
+
+/**
+ * Create a 2-operator FM synthesis instrument component.
+ *
+ * Signal path:
+ * ```
+ * modulator sine → modIndex gain (ADSR) → carrier.frequencyParam
+ * carrier sine → amp VCA (ADSR) → output gain → (caller connects output)
+ * ```
+ *
+ * The modulator uses a non-integer ratio (default 1.273) for inharmonic/metallic character.
+ * Modulation index controls peak frequency deviation: `noteFreq × modIndex` Hz at peak.
+ *
+ * @param context - Backend audio context providing the Web Audio graph.
+ * @param props - Optional FM synth configuration. If omitted all defaults apply.
+ * @returns A {@link FMSynthComponent} with `id` prefixed `fmsynth` and `type` set to `'fmsynth'`.
+ *
+ * @example
+ * ```ts
+ * // DX7 Rhodes voice at A3
+ * const rhodes = createFMSynth(context, {
+ *   frequency: 220,
+ *   modRatio: 1.273,
+ *   modIndex: 3,
+ *   ampAdsr: { attack: 0.01, decay: 0.2, sustain: 0.7, release: 0.4 },
+ * })
+ * rhodes.connect(context.destination)
+ * rhodes.noteOn(context.currentTime)
+ * rhodes.noteOff(context.currentTime + 1.0)
+ * rhodes.dispose()
+ * ```
+ *
+ * @see {@link FMSynthProps} — configuration options
+ * @see {@link FMSynthComponent} — returned component shape
+ * @throws {ScoreError} Never — invalid props are silently clamped.
+ */
+export const createFMSynth = (
+  context: ScoreAudioContext,
+  props?: FMSynthProps,
+): FMSynthComponent => {
+  const noteFreq = props?.frequency ?? 220
+  const modRatio = props?.modRatio  ?? 1.273
+  const modIndex = props?.modIndex  ?? 3
+
+  const ampAdsrCfg = props?.ampAdsr ?? {}
+  const ampAttack  = ampAdsrCfg.attack  ?? 0.01
+  const ampDecay   = ampAdsrCfg.decay   ?? 0.2
+  const ampSustain = ampAdsrCfg.sustain ?? 0.7
+  const ampRelease = ampAdsrCfg.release ?? 0.4
+
+  const modAdsrCfg = props?.modAdsr ?? {}
+  const modAttack  = modAdsrCfg.attack  ?? 0.005
+  const modDecay   = modAdsrCfg.decay   ?? 0.3
+  const modSustain = modAdsrCfg.sustain ?? 1.0
+  const modRelease = modAdsrCfg.release ?? 0.2
+
+  // Peak mod deviation in Hz: noteFreq × modIndex
+  const modPeak = noteFreq * modIndex
+
+  // Create oscillators
+  const carrier   = context.createOscillator({ type: 'sine', frequency: noteFreq })
+  const modulator = context.createOscillator({ type: 'sine', frequency: noteFreq * modRatio })
+
+  // Modulator path: modulator → modGain (ADSR) → carrier.frequencyParam
+  // modGain starts at 0; noteOn triggers the ADSR to ramp up to modPeak
+  const modGain = context.createGain({ gain: 0 })
+
+  // Amp path: carrier → ampVca (ADSR) → outputGain
+  const ampVca     = context.createGain({ gain: 0 })
+  const outputGain = context.createGain({ gain: props?.gain ?? 0.7 })
+
+  // Wire modulator path: modulator → modGain; modGain → carrier.frequencyParam via connectModulator
+  modulator.connect(modGain)
+  carrier.frequencyParam.connectModulator(modGain)
+
+  // Wire carrier/amp path: carrier → ampVca → outputGain
+  carrier.connect(ampVca)
+  ampVca.connect(outputGain)
+
+  let started = false
+
+  const noteOn = (time?: number): void => {
+    const t = time ?? context.currentTime
+    if (!started) {
+      modulator.start(t)
+      carrier.start(t)
+      started = true
+    }
+    // Modulation index ADSR — peak = noteFreq × modIndex
+    modGain.scheduleEnvelope({
+      peak: modPeak,
+      attack: modAttack,
+      decay: modDecay,
+      sustain: modSustain,
+      release: 0,
+      startTime: t,
+      duration: modAttack + modDecay + 9999,
+    })
+    // Amp VCA ADSR
+    ampVca.scheduleEnvelope({
+      peak: 1.0,
+      attack: ampAttack,
+      decay: ampDecay,
+      sustain: ampSustain,
+      release: 0,
+      startTime: t,
+      duration: ampAttack + ampDecay + 9999,
+    })
+  }
+
+  const noteOff = (time?: number): void => {
+    const t = time ?? context.currentTime
+    const releaseEnd = Math.max(ampRelease, modRelease)
+    // Mod envelope release — from sustain fraction of peak down to 0
+    modGain.scheduleEnvelope({
+      peak: modPeak * modSustain,
+      attack: 0,
+      decay: modRelease,
+      sustain: 0,
+      release: 0,
+      startTime: t,
+      duration: modRelease,
+    })
+    // Amp VCA release
+    ampVca.scheduleEnvelope({
+      peak: ampSustain,
+      attack: 0,
+      decay: ampRelease,
+      sustain: 0,
+      release: 0,
+      startTime: t,
+      duration: ampRelease,
+    })
+    carrier.stop(t + releaseEnd + 0.05)
+    modulator.stop(t + releaseEnd + 0.05)
+  }
+
+  const component: FMSynthComponent = {
+    id:   uid('fmsynth'),
+    type: 'fmsynth' as const,
+    noteOn,
+    noteOff,
+
+    setFrequency: (value: number, time?: number) => {
+      carrier.setFrequency(value, time)
+      modulator.setFrequency(value * modRatio, time)
+    },
+
+    setGain: (value: number, time?: number) => { outputGain.setGain(value, time) },
+
+    connect: (destination: ScoreAudioNode) => {
+      outputGain.connect(destination)
+      return component
+    },
+
+    disconnect: () => {
+      try { outputGain.disconnect() } catch { /* already disconnected */ }
+      return component
+    },
+
+    dispose: () => {
+      try { carrier.stop()      } catch { /* already stopped */ }
+      try { modulator.stop()    } catch { /* already stopped */ }
+      try { carrier.disconnect()    } catch { /* already disconnected */ }
+      try { modulator.disconnect()  } catch { /* already disconnected */ }
+      try { modGain.disconnect()    } catch { /* already disconnected */ }
+      try { ampVca.disconnect()     } catch { /* already disconnected */ }
+      try { outputGain.disconnect() } catch { /* already disconnected */ }
+    },
+  }
+
+  return component
+}

--- a/packages/components/tests/synths/fm.test.ts
+++ b/packages/components/tests/synths/fm.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import { useHarness } from '../utils/harness.js'
+import { createFMSynth } from '../../src/synths/fm.js'
+
+const h = useHarness()
+
+describe('createFMSynth', () => {
+  it('has noteOn, noteOff, setFrequency, setGain, connect, disconnect, dispose', () => {
+    const synth = createFMSynth(h.mockContext())
+    expect(typeof synth.noteOn).toBe('function')
+    expect(typeof synth.noteOff).toBe('function')
+    expect(typeof synth.setFrequency).toBe('function')
+    expect(typeof synth.setGain).toBe('function')
+    expect(typeof synth.connect).toBe('function')
+    expect(typeof synth.disconnect).toBe('function')
+    expect(typeof synth.dispose).toBe('function')
+  })
+
+  it('id is prefixed fmsynth', () => {
+    const synth = createFMSynth(h.mockContext())
+    expect(synth.id).toMatch(/^fmsynth/)
+  })
+
+  it('type is fmsynth', () => {
+    const synth = createFMSynth(h.mockContext())
+    expect(synth.type).toBe('fmsynth')
+  })
+
+  it('creates 2 oscillators at construction (carrier + modulator)', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx)
+    expect(ctx.createdOscillators.length).toBe(2)
+  })
+
+  it('creates 3 gain nodes at construction (modGain, ampVca, outputGain)', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx)
+    // modGain (index 0), ampVca (index 1), outputGain (index 2)
+    expect(ctx.createdGains.length).toBe(3)
+  })
+
+  it('default output gain is 0.7', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx)
+    // outputGain is last gain created (index 2)
+    expect(ctx.createdGains[2]?.gain).toBeCloseTo(0.7)
+  })
+
+  it('respects custom gain prop', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx, { gain: 0.5 })
+    expect(ctx.createdGains[2]?.gain).toBeCloseTo(0.5)
+  })
+
+  it('modGain starts at 0', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx)
+    // modGain is first gain created (index 0)
+    expect(ctx.createdGains[0]?.gain).toBeCloseTo(0)
+  })
+
+  it('ampVca starts at 0', () => {
+    const ctx = h.mockContext()
+    createFMSynth(ctx)
+    // ampVca is second gain created (index 1)
+    expect(ctx.createdGains[1]?.gain).toBeCloseTo(0)
+  })
+
+  it('noteOn starts both oscillators', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(1.0)
+    expect(ctx.createdOscillators[0]?.startCalls.length).toBe(1)
+    expect(ctx.createdOscillators[1]?.startCalls.length).toBe(1)
+  })
+
+  it('noteOn passes scheduled time to both oscillators', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(2.5)
+    expect(ctx.createdOscillators[0]?.startCalls[0]?.time).toBe(2.5)
+    expect(ctx.createdOscillators[1]?.startCalls[0]?.time).toBe(2.5)
+  })
+
+  it('noteOn called twice does not start oscillators a second time', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(0)
+    synth.noteOn(0.5)
+    expect(ctx.createdOscillators[0]?.startCalls.length).toBe(1)
+    expect(ctx.createdOscillators[1]?.startCalls.length).toBe(1)
+  })
+
+  it('noteOn triggers modGain ADSR to modPeak', () => {
+    const ctx = h.mockContext()
+    // default noteFreq=220, modIndex=3 → modPeak=660
+    const synth = createFMSynth(ctx, { frequency: 220, modIndex: 3 })
+    synth.noteOn(0)
+    // scheduleEnvelope mock sets gain to peak; modGain is index 0
+    expect(ctx.createdGains[0]?.gain).toBeCloseTo(660)
+  })
+
+  it('noteOn triggers ampVca ADSR to peak 1.0', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(0)
+    // ampVca is index 1; scheduleEnvelope mock sets gain to peak
+    expect(ctx.createdGains[1]?.gain).toBeCloseTo(1.0)
+  })
+
+  it('noteOff schedules stop on both oscillators', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(0)
+    synth.noteOff(0.5)
+    expect(ctx.createdOscillators[0]?.stopCalls.length).toBe(1)
+    expect(ctx.createdOscillators[1]?.stopCalls.length).toBe(1)
+  })
+
+  it('connect returns self for chaining', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    expect(synth.connect(ctx.destination)).toBe(synth)
+  })
+
+  it('disconnect returns self for chaining', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    expect(synth.disconnect()).toBe(synth)
+  })
+
+  it('dispose does not throw', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    synth.noteOn(0)
+    synth.noteOff(0.5)
+    expect(() => { synth.dispose() }).not.toThrow()
+  })
+
+  it('dispose does not throw even without noteOn', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    expect(() => { synth.dispose() }).not.toThrow()
+  })
+
+  it('setFrequency does not throw', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    expect(() => { synth.setFrequency(440) }).not.toThrow()
+  })
+
+  it('setGain does not throw', () => {
+    const ctx = h.mockContext()
+    const synth = createFMSynth(ctx)
+    expect(() => { synth.setGain(0.5) }).not.toThrow()
+  })
+
+  it('accepts custom modRatio', () => {
+    const ctx = h.mockContext()
+    // Just verify it constructs without error when overriding defaults
+    expect(() => { createFMSynth(ctx, { modRatio: 2.0 }) }).not.toThrow()
+  })
+
+  it('accepts custom modIndex and scales modPeak correctly', () => {
+    const ctx = h.mockContext()
+    // frequency=100, modIndex=5 → modPeak=500
+    const synth = createFMSynth(ctx, { frequency: 100, modIndex: 5 })
+    synth.noteOn(0)
+    // modGain (index 0) peak should be 500
+    expect(ctx.createdGains[0]?.gain).toBeCloseTo(500)
+  })
+
+  it('accepts custom ampAdsr props', () => {
+    const ctx = h.mockContext()
+    expect(() => {
+      createFMSynth(ctx, {
+        ampAdsr: { attack: 0.05, decay: 0.3, sustain: 0.5, release: 0.6 },
+      })
+    }).not.toThrow()
+  })
+
+  it('accepts custom modAdsr props', () => {
+    const ctx = h.mockContext()
+    expect(() => {
+      createFMSynth(ctx, {
+        modAdsr: { attack: 0.01, decay: 0.5, sustain: 0.8, release: 0.3 },
+      })
+    }).not.toThrow()
+  })
+
+  it('two instances have distinct ids', () => {
+    const ctx = h.mockContext()
+    const a = createFMSynth(ctx)
+    const b = createFMSynth(ctx)
+    expect(a.id).not.toBe(b.id)
+  })
+})

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -2,7 +2,7 @@ export { Song } from './song.js'
 export { Intro, Buildup, Drop, Breakdown, Outro } from './sections.js'
 export { Track } from './track.js'
 export { Sequence } from './sequence.js'
-export { Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp, Kick808, Kick909, Hihat808, Snare909, SubSynth } from './instruments.js'
+export { Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp, Kick808, Kick909, Hihat808, Snare909, SubSynth, FMSynth } from './instruments.js'
 export { noteHz, resolveFreq } from './notes.js'
 export { drift, keepFor } from './modifiers.js'
 export type {
@@ -26,4 +26,5 @@ export type {
   Hihat808DSLProps,
   Snare909DSLProps,
   SubSynthDSLProps,
+  FMSynthDSLProps,
 } from './types.js'

--- a/packages/dsl/src/instruments.ts
+++ b/packages/dsl/src/instruments.ts
@@ -6,7 +6,7 @@
 
 import type { BackendNode } from '@score/core'
 import { uid } from '@score/core'
-import type { InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps, SampleProps, ThereminDSLProps, SaxDSLProps, ArpDSLProps, Kick808DSLProps, Kick909DSLProps, Hihat808DSLProps, Snare909DSLProps, SubSynthDSLProps } from './types.js'
+import type { InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps, SampleProps, ThereminDSLProps, SaxDSLProps, ArpDSLProps, Kick808DSLProps, Kick909DSLProps, Hihat808DSLProps, Snare909DSLProps, SubSynthDSLProps, FMSynthDSLProps } from './types.js'
 
 const makeDescriptor = (
   instrumentType: InstrumentDescriptor['instrumentType'],
@@ -282,3 +282,23 @@ export const Snare909 = (props?: Snare909DSLProps): InstrumentDescriptor => make
  * ```
  */
 export const SubSynth = (props?: SubSynthDSLProps): InstrumentDescriptor => makeDescriptor('subsynth', props ?? {})
+
+/**
+ * Create a FMSynth instrument descriptor — 2-operator FM synthesis voice.
+ * Carrier: sine at `frequency`. Modulator: sine at `frequency × modRatio` (default 1.273, inharmonic/metallic).
+ * Returns pure data — the engine hydrates it into audio at play time.
+ *
+ * @param props - FMSynth configuration: frequency, modRatio, modIndex, ampAdsr, modAdsr, gain, effects.
+ * @returns An {@link InstrumentDescriptor} with `instrumentType: 'fmsynth'`.
+ *
+ * @example
+ * ```ts
+ * const rhodes = FMSynth({
+ *   frequency: 220,
+ *   modRatio: 1.273,
+ *   modIndex: 3,
+ *   ampAdsr: { attack: 0.01, decay: 0.2, sustain: 0.7, release: 0.4 },
+ * })
+ * ```
+ */
+export const FMSynth = (props?: FMSynthDSLProps): InstrumentDescriptor => makeDescriptor('fmsynth', props ?? {})

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -195,6 +195,46 @@ export type SubSynthDSLProps = {
   readonly effects?: ReadonlyArray<EffectDescriptor>
 }
 
+/**
+ * Configuration props for the {@link FMSynth} instrument factory.
+ *
+ * 2-operator FM synthesis voice — DX7 Rhodes / techno leads.
+ * Carrier and modulator are both sine oscillators.
+ */
+export type FMSynthDSLProps = {
+  readonly pattern?: (number | string)[]
+  readonly volume?: number
+  /** Carrier frequency in Hz. Default `220`. */
+  readonly frequency?: number
+  /**
+   * Modulator-to-carrier frequency ratio. Non-integer = inharmonic/metallic.
+   * Default `1.273`.
+   */
+  readonly modRatio?: number
+  /**
+   * Modulation index — peak deviation multiplier of carrier frequency.
+   * Default `3`.
+   */
+  readonly modIndex?: number
+  /** Amplitude VCA ADSR envelope. */
+  readonly ampAdsr?: {
+    readonly attack?: number
+    readonly decay?: number
+    readonly sustain?: number
+    readonly release?: number
+  }
+  /** Modulation depth ADSR envelope. */
+  readonly modAdsr?: {
+    readonly attack?: number
+    readonly decay?: number
+    readonly sustain?: number
+    readonly release?: number
+  }
+  /** Output gain 0–1. Default `0.7`. */
+  readonly gain?: number
+  readonly effects?: ReadonlyArray<EffectDescriptor>
+}
+
 /** Configuration props for the {@link Arp} instrument factory. */
 export type ArpDSLProps = {
   /** Note names to arpeggiate in order, e.g. `['C4', 'E4', 'G4', 'B4']`. Required. */
@@ -232,8 +272,8 @@ export type ArpDSLProps = {
  */
 export type InstrumentDescriptor = {
   readonly _type: 'InstrumentDescriptor'
-  readonly instrumentType: 'kick' | 'snare' | 'hihat' | 'synth' | 'sample' | 'theremin' | 'sax' | 'arp' | 'kick808' | 'kick909' | 'hihat808' | 'snare909' | 'subsynth'
-  readonly props: KickProps | SnareProps | HiHatProps | SynthDSLProps | SampleProps | ThereminDSLProps | SaxDSLProps | ArpDSLProps | Kick808DSLProps | Kick909DSLProps | Hihat808DSLProps | Snare909DSLProps | SubSynthDSLProps
+  readonly instrumentType: 'kick' | 'snare' | 'hihat' | 'synth' | 'sample' | 'theremin' | 'sax' | 'arp' | 'kick808' | 'kick909' | 'hihat808' | 'snare909' | 'subsynth' | 'fmsynth'
+  readonly props: KickProps | SnareProps | HiHatProps | SynthDSLProps | SampleProps | ThereminDSLProps | SaxDSLProps | ArpDSLProps | Kick808DSLProps | Kick909DSLProps | Hihat808DSLProps | Snare909DSLProps | SubSynthDSLProps | FMSynthDSLProps
   // Minimal AudioComponent shape so Track() accepts it
   readonly id: string
   readonly type: string


### PR DESCRIPTION
## Summary

- Adds `createFMSynth` in `packages/components/src/synths/fm.ts` — 2-operator FM voice (carrier + modulator) modelling DX7 Rhodes timbres and metallic techno leads
- Exports `FMSynthDSLProps` from `@score/components` and `@score/dsl`
- Wires `case 'fmsynth'` in `packages/cli/src/engine.ts` step sequencer hydration

## Test plan

- [ ] CI passes (typecheck → lint → test → coverage)
- [ ] `createFMSynth` unit tests in `packages/components/tests/synths/fm.test.ts`
- [ ] Engine hydration: `fmsynth` case handled in `engine.ts`
- [ ] DSL exports: `FMSynthDSLProps` available from `@score/dsl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)