### PR TITLE
feat(gui): t220 — import-hiding toggle (Monaco fold stub)

### DIFF
--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -146,6 +146,8 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   const [fftBins,     setFftBins]     = useState<readonly number[]>([])
   const [logEntries,  setLogEntries]  = useState<ReadonlyArray<LogEntry>>([])
   const [pianoNotes,  setPianoNotes]  = useState<ReadonlyArray<PianoRollNote>>([])
+  // t220 — import visibility toggle (stub: fold/unfold in Monaco; auto-inject deferred for DSL chain API)
+  const [importsVisible, setImportsVisible] = useState(true)
   // Set to true when the user clicks play before eval — song:update handler will
   // fire transport:play once the eval succeeds (eval-then-play flow).
   const autoPlayRef   = useRef(false)
@@ -500,6 +502,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
                 onEval={onEval}
                 decorations={editorDecorations}
                 stepBadges={stepBadges}
+                importsVisible={importsVisible}
               />
             </div>
           </div>
@@ -541,6 +544,8 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
             <PanelToggle label="Mixer"   active={panels.mixer}      onClick={() => { togglePanel('mixer') }}      />
             <PanelToggle label="Console" active={panels.console}    onClick={() => { togglePanel('console') }}    />
             <PanelToggle label="Ref"     active={panels.reference}  onClick={() => { togglePanel('reference') }}  />
+            {/* t220 — import visibility toggle */}
+            <PanelToggle label="Imports" active={importsVisible}    onClick={() => { setImportsVisible(v => !v) }} />
           </div>
 
           {/* Floating panels */}

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -42,6 +42,13 @@ type Props = {
    * as a `STEP/TOTAL` pill. Updated on every engine:step tick.
    */
   readonly stepBadges?:  ReadonlyArray<StepBadge>
+  /**
+   * t220 — Whether import lines are visible in the editor.
+   * When `false`, the leading import block is folded (collapsed) in Monaco.
+   * Defaults to `true` (imports visible).
+   * Auto-inject of real imports on fold is deferred until the DSL chain API lands.
+   */
+  readonly importsVisible?: boolean
 }
 
 // ── Score DSL Token Provider ───────────────────────────────────────────────────
@@ -198,7 +205,7 @@ const injectDecorationCss = (): void => {
  * />
  * ```
  */
-export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadges }: Props) => {
+export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true }: Props) => {
   const editorRef       = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
   const decorationsRef  = useRef<string[]>([])
   const stepBadgesRef   = useRef<string[]>([])
@@ -248,6 +255,19 @@ export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadg
 
     stepBadgesRef.current = ed.deltaDecorations(stepBadgesRef.current, newBadges)
   }, [stepBadges])
+
+  // t220 — fold / unfold the leading import block when importsVisible changes
+  useEffect(() => {
+    const ed = editorRef.current
+    if (!ed) return
+    if (importsVisible) {
+      // Unfold line 1 (import block)
+      ed.trigger('t220', 'editor.unfold', { selectionLines: [1] })
+    } else {
+      // Fold line 1 — collapses the contiguous import block at the top
+      ed.trigger('t220', 'editor.fold', { selectionLines: [1] })
+    }
+  }, [importsVisible])
 
   const handleMount: OnMount = useCallback((editor, monaco) => {
     editorRef.current  = editor

--- a/packages/gui/tests/CodeEditorPanel.test.tsx
+++ b/packages/gui/tests/CodeEditorPanel.test.tsx
@@ -64,3 +64,26 @@ describe('CodeEditorPanel — EditorDecoration type', () => {
     )).not.toThrow()
   })
 })
+
+// ── t220 — importsVisible prop ─────────────────────────────────────────────────
+
+describe('CodeEditorPanel — importsVisible (t220)', () => {
+  it('renders without throwing when importsVisible is true', () => {
+    expect(() => render(
+      <CodeEditorPanel value="import { Song } from '@score/dsl'\nexport default Song({ bpm: 128, tracks: [] })" onChange={vi.fn()} onEval={vi.fn()} importsVisible={true} />,
+    )).not.toThrow()
+  })
+
+  it('renders without throwing when importsVisible is false', () => {
+    expect(() => render(
+      <CodeEditorPanel value="import { Song } from '@score/dsl'\nexport default Song({ bpm: 128, tracks: [] })" onChange={vi.fn()} onEval={vi.fn()} importsVisible={false} />,
+    )).not.toThrow()
+  })
+
+  it('defaults importsVisible to true (no prop = imports shown)', () => {
+    // No importsVisible prop — should render normally without throwing
+    expect(() => render(
+      <CodeEditorPanel value="import { Song } from '@score/dsl'\nexport default Song({ bpm: 128, tracks: [] })" onChange={vi.fn()} onEval={vi.fn()} />,
+    )).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `importsVisible` prop to `CodeEditorPanel` — when `false`, triggers Monaco fold action on line 1 to collapse the leading import block
- Adds `Imports` toggle button in the panel toolbar in `LiveCode`
- Auto-inject of real imports on fold is deferred until the fluent DSL chain API lands (a single `@score/dsl` import makes this trivial)
- 188 GUI tests passing

## Test plan

- [ ] CI passes
- [ ] Toggle `Imports` button folds/unfolds the import block in the editor
- [ ] Import fold is visual only — saved file always contains real imports
- [ ] `importsVisible` prop renders without throwing (3 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)