### PR TITLE
feat(dsl): melodic factories, genre presets, groove templates

### DIFF
--- a/packages/dsl/src/genre.ts
+++ b/packages/dsl/src/genre.ts
@@ -1,0 +1,334 @@
+// genre.ts — EDM genre presets + name registry for @score/dsl
+//
+// GenreDescriptor carries BPM range, default meter, key, swing, and short-name
+// registry. defineGenre() lets users define custom genre presets.
+//
+// The name registry maps short percussion aliases to instrument type strings.
+// defineGenre() can override registry keys for genre context (e.g. hardstyle
+// remaps 'bd' → 'kick-hard'). Used by the mini-notation parser (future).
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * BPM range descriptor — default, min, and max for a genre.
+ */
+export type GenreBpm = {
+  readonly default: number
+  readonly min: number
+  readonly max: number
+}
+
+/**
+ * Short-name registry — maps percussion/instrument aliases to instrument type strings.
+ * Used by the mini-notation parser and instrument factories to resolve short names.
+ */
+export type NameRegistry = Record<string, string>
+
+/**
+ * Descriptor produced by {@link defineGenre} — carries all genre defaults.
+ * Pass to `Song(128, [...]).genre(Techno)` to apply BPM range, meter, and swing.
+ */
+export type GenreDescriptor = {
+  readonly _type: 'GenreDescriptor'
+  /** Genre display name, e.g. `'Techno'`. */
+  readonly name: string
+  readonly bpm: GenreBpm
+  /** Default time signature, e.g. `'4/4'`. */
+  readonly meter: string
+  /** Default key/mode, e.g. `'Am'`. `'any'` means no preferred key. */
+  readonly key: string
+  /** Swing amount 0–1. `0` = straight. */
+  readonly swing: number
+  /** Short-name registry overrides for this genre context. */
+  readonly registry: NameRegistry
+}
+
+// ── Default name registry ─────────────────────────────────────────────────────
+//
+// Instrument aliases used by mini-notation and name-resolution helpers.
+// All values are kebab-case instrument type strings (matches engine registry).
+
+/**
+ * Default short-name registry — global aliases covering all major percussion and
+ * instrument types. `defineGenre()` overrides specific keys for genre context.
+ */
+export const DEFAULT_REGISTRY: NameRegistry = {
+  // Kick drums
+  'bd':     'kick-808',
+  'kick':   'kick-808',
+  'bd2':    'kick-909',
+  'hs':     'kick-hard',
+  'gb':     'kick-hardcore',
+  // Snares / claps
+  'sd':     'snare-909',
+  'snare':  'snare-909',
+  'cp':     'clap',
+  'clap':   'clap',
+  // Hi-hats
+  'hh':     'hi-hat-808',
+  'hat':    'hi-hat-808',
+  'oh':     'hi-hat-808',   // engine uses props.open to differentiate
+  // Percussion
+  'cb':     'cowbell808',
+  'rim':    'rimshot',
+  'cg':     'conga',
+  'tom':    'tom',
+  'sh':     'shaker',
+  'tb2':    'tambourine',
+  'wb':     'woodblock',
+  'bn':     'bongo',
+  'cr':     'crash',
+  'rd':     'ride',
+  // Bass / melodic
+  'tb':     'bass-303',
+  'acid':   'bass-303',
+  'rb':     'reese-bass',
+  'wob':    'wobble-bass',
+  'sub':    'synth',
+  'fm':     'fm-synth',
+  'juno':   'sub-synth',
+  'pad':    'pad',
+  'ss':     'supersaw',
+  'rh':     'rhodes',
+  'org':    'hammond',
+  'arp':    'arp',
+  'sax':    'sax',
+  'piano':  'wavetable',
+  // Sample
+  'smp':    'sample',
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+/**
+ * Define a reusable genre preset.
+ *
+ * Returns a {@link GenreDescriptor} that carries BPM range, meter, key, swing,
+ * and optional name registry overrides. Pass to `Song(...).genre(preset)` to
+ * apply genre defaults to the composition.
+ *
+ * @param desc - Genre configuration. `name` and `bpm.default` are required.
+ * @returns A frozen {@link GenreDescriptor}.
+ *
+ * @example
+ * ```ts
+ * // Define a custom genre preset
+ * const MyGenre = defineGenre({
+ *   name: 'My Genre',
+ *   bpm: { default: 132, min: 128, max: 140 },
+ *   meter: '4/4',
+ *   key: 'Cm',
+ *   swing: 0,
+ * })
+ *
+ * export default Song(132, [...]).genre(MyGenre)
+ * ```
+ *
+ * @see {@link Techno}, {@link House}, {@link DeepHouse} — built-in presets
+ */
+export const defineGenre = (desc: {
+  readonly name: string
+  readonly bpm: GenreBpm
+  readonly meter?: string
+  readonly key?: string
+  readonly swing?: number
+  readonly registry?: NameRegistry
+}): GenreDescriptor => ({
+  _type: 'GenreDescriptor',
+  name: desc.name,
+  bpm: desc.bpm,
+  meter: desc.meter ?? '4/4',
+  key: desc.key ?? 'any',
+  swing: desc.swing ?? 0,
+  registry: { ...DEFAULT_REGISTRY, ...(desc.registry ?? {}) },
+})
+
+// ── Built-in genre presets ────────────────────────────────────────────────────
+
+/**
+ * Techno — driving 4/4, dark, industrial. Kick909, Snare909, Hihat808.
+ * BPM range: 130–150 bpm, default 138.
+ */
+export const Techno = defineGenre({
+  name: 'Techno',
+  bpm: { default: 138, min: 130, max: 150 },
+  key: 'Am',
+  swing: 0,
+})
+
+/**
+ * House — 4/4 four-on-the-floor, Chicago roots. Kick808, clap on 2/4.
+ * BPM range: 120–132, default 128.
+ */
+export const House = defineGenre({
+  name: 'House',
+  bpm: { default: 128, min: 120, max: 132 },
+  key: 'Am',
+  swing: 0,
+})
+
+/**
+ * Deep House — slower, darker house with Rhodes and sub bass.
+ * BPM range: 118–125, default 122.
+ */
+export const DeepHouse = defineGenre({
+  name: 'Deep House',
+  bpm: { default: 122, min: 118, max: 125 },
+  key: 'Fm',
+  swing: 0.02,
+})
+
+/**
+ * Drum & Bass — fast breakbeat, Reese bass, heavy sub.
+ * BPM range: 160–180, default 174.
+ */
+export const DnB = defineGenre({
+  name: 'Drum & Bass',
+  bpm: { default: 174, min: 160, max: 180 },
+  key: 'Dm',
+  swing: 0,
+})
+
+/**
+ * Dubstep — half-time feel, wobble bass, heavy sub.
+ * BPM range: 136–142, default 140.
+ */
+export const Dubstep = defineGenre({
+  name: 'Dubstep',
+  bpm: { default: 140, min: 136, max: 142 },
+  key: 'Gm',
+  swing: 0,
+})
+
+/**
+ * Hardstyle — reverse-bass kick, distorted body, festival anthems.
+ * BPM range: 145–160, default 150.
+ * Registry: `bd` → `kick-hard`.
+ */
+export const Hardstyle = defineGenre({
+  name: 'Hardstyle',
+  bpm: { default: 150, min: 145, max: 160 },
+  key: 'Am',
+  swing: 0,
+  registry: { bd: 'kick-hard', kick: 'kick-hard' },
+})
+
+/**
+ * Trance / Progressive — supersaw leads, arpeggios, big builds.
+ * BPM range: 130–145, default 138.
+ */
+export const Trance = defineGenre({
+  name: 'Trance',
+  bpm: { default: 138, min: 130, max: 145 },
+  key: 'Am',
+  swing: 0,
+  registry: { ss: 'supersaw', pad: 'supersaw' },
+})
+
+/**
+ * Future Bass — chords + supersaw stabs, wobble, half-time elements.
+ * BPM range: 140–160, default 150.
+ */
+export const FutureBass = defineGenre({
+  name: 'Future Bass',
+  bpm: { default: 150, min: 140, max: 160 },
+  key: 'Em',
+  swing: 0,
+  registry: { ss: 'supersaw' },
+})
+
+/**
+ * Trap (EDM) — 808 sub bass, hi-hat rolls, half-time snare.
+ * BPM range: 130–150, default 140.
+ * Registry: `bd` → `kick-808` (808 sub doubles as kick).
+ */
+export const Trap = defineGenre({
+  name: 'Trap',
+  bpm: { default: 140, min: 130, max: 150 },
+  key: 'Cm',
+  swing: 0.02,
+  registry: { bd: 'kick-808' },
+})
+
+/**
+ * Psytrance — fast squelchy FM bass, driving 145 bpm.
+ * BPM range: 142–148, default 145.
+ */
+export const Psytrance = defineGenre({
+  name: 'Psytrance',
+  bpm: { default: 145, min: 142, max: 148 },
+  key: 'Am',
+  swing: 0,
+  registry: { fm: 'fm-synth', tb: 'bass-303' },
+})
+
+/**
+ * IDM / Glitch — experimental, irregular rhythms, complex polyrhythm.
+ * BPM range: 90–160, default 120.
+ */
+export const IDM = defineGenre({
+  name: 'IDM',
+  bpm: { default: 120, min: 90, max: 160 },
+  key: 'any',
+  swing: 0,
+})
+
+/**
+ * Ambient / Dark Ambient — slow, drone, long pads, vast spaces.
+ * BPM range: 60–100, default 90.
+ */
+export const Ambient = defineGenre({
+  name: 'Ambient',
+  bpm: { default: 90, min: 60, max: 100 },
+  key: 'any',
+  swing: 0,
+  registry: { pad: 'pad', drone: 'pad' },
+})
+
+/**
+ * Synthwave / Retrowave — supersaw leads, gated reverb drums, arpeggios.
+ * BPM range: 95–115, default 100.
+ */
+export const Synthwave = defineGenre({
+  name: 'Synthwave',
+  bpm: { default: 100, min: 95, max: 115 },
+  key: 'Am',
+  swing: 0,
+  registry: { ss: 'supersaw', arp: 'arp' },
+})
+
+/**
+ * Lo-fi Hip Hop — dusty samples, vinyl noise, lazy swing.
+ * BPM range: 70–90, default 80.
+ */
+export const LoFi = defineGenre({
+  name: 'Lo-fi Hip Hop',
+  bpm: { default: 80, min: 70, max: 90 },
+  key: 'any',
+  swing: 0.06,
+  registry: { smp: 'sample' },
+})
+
+/**
+ * Minimal Techno — sparse clicks, subtle acid, hypnotic repetition.
+ * BPM range: 128–135, default 130.
+ */
+export const MinimalTechno = defineGenre({
+  name: 'Minimal Techno',
+  bpm: { default: 130, min: 128, max: 135 },
+  key: 'Am',
+  swing: 0,
+  registry: { tb: 'bass-303' },
+})
+
+/**
+ * Acid House — TB-303 squelch, four-on-the-floor, Chicago 1987.
+ * BPM range: 120–130, default 125.
+ */
+export const AcidHouse = defineGenre({
+  name: 'Acid House',
+  bpm: { default: 125, min: 120, max: 130 },
+  key: 'Am',
+  swing: 0,
+  registry: { tb: 'bass-303', acid: 'bass-303' },
+})

--- a/packages/dsl/src/groove.ts
+++ b/packages/dsl/src/groove.ts
@@ -1,0 +1,133 @@
+// groove.ts — Groove descriptor factory + built-in groove templates for @score/dsl
+//
+// GrooveDescriptor carries timing offsets and velocity curves across 16 steps.
+// The engine applies offsets (in seconds) and velocity multipliers at play time.
+// All values are pure data — no AudioContext.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Groove descriptor — per-step timing offsets and velocity multipliers.
+ *
+ * `offsets` are in seconds, applied additively to each step's schedule time.
+ * `velocities` are multipliers on step amplitude (0.5 = half velocity, 1.5 = accent).
+ * Both arrays must be 16 elements (one per step in a standard bar).
+ *
+ * The engine reads this from `SongDescriptor._groove` and applies it to every
+ * part on every step tick.
+ */
+export type GrooveDescriptor = {
+  readonly _type: 'GrooveDescriptor'
+  /** Display name, e.g. `'Shuffle'`. */
+  readonly name: string
+  /** Per-step timing offsets in seconds. 16 values. Positive = late, negative = early. */
+  readonly offsets: readonly number[]
+  /** Per-step velocity multipliers. 16 values. `1.0` = no change. */
+  readonly velocities: readonly number[]
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+/**
+ * Define a custom groove template.
+ *
+ * `offsets` and `velocities` are padded/truncated to 16 steps.
+ * Omitting either fills with zeros (offsets) or ones (velocities).
+ *
+ * @param desc - Groove configuration.
+ * @returns A frozen {@link GrooveDescriptor}.
+ *
+ * @example
+ * ```ts
+ * // Custom reggae offbeat pocket — slightly late on even steps
+ * const GrooveReggae = defineGroove({
+ *   name: 'Reggae',
+ *   offsets: Array.from({ length: 16 }, (_, i) => i % 2 === 0 ? 0 : 0.015),
+ * })
+ *
+ * export default Song(80, [...]).groove(GrooveReggae)
+ * ```
+ *
+ * @see {@link GrooveShuffle}, {@link GrooveSwing16}, {@link GrooveHipHop}
+ */
+export const defineGroove = (desc: {
+  readonly name: string
+  readonly offsets?: readonly number[]
+  readonly velocities?: readonly number[]
+}): GrooveDescriptor => {
+  const pad16 = (arr: readonly number[] | undefined, fill: number): readonly number[] => {
+    const src = arr ?? []
+    return Array.from({ length: 16 }, (_, i) => src[i] ?? fill)
+  }
+
+  return {
+    _type: 'GrooveDescriptor',
+    name: desc.name,
+    offsets: pad16(desc.offsets, 0),
+    velocities: pad16(desc.velocities, 1.0),
+  }
+}
+
+// ── Built-in grooves ──────────────────────────────────────────────────────────
+
+/**
+ * Straight groove — all steps on the grid, equal velocity.
+ * Equivalent to no groove at all. Use as a reset or default.
+ */
+export const GrooveStraight = defineGroove({
+  name: 'Straight',
+})
+
+/**
+ * Shuffle groove — odd 16th-note steps are pushed ~30 ms late.
+ * Creates a classic swing/shuffle feel on hi-hats and snares.
+ * Offset: 0, +0.030s alternating across all 16 steps.
+ */
+export const GrooveShuffle = defineGroove({
+  name: 'Shuffle',
+  offsets: Array.from({ length: 16 }, (_, i) => i % 2 === 0 ? 0 : 0.030),
+  velocities: Array.from({ length: 16 }, (_, i) => i % 2 === 0 ? 1.0 : 0.85),
+})
+
+/**
+ * 16th-note swing groove — alternating 16ths pushed forward.
+ * Lighter than GrooveShuffle (~20 ms), tighter feel. Good for house and funk.
+ */
+export const GrooveSwing16 = defineGroove({
+  name: 'Swing 16th',
+  offsets: Array.from({ length: 16 }, (_, i) => i % 2 === 0 ? 0 : 0.020),
+  velocities: Array.from({ length: 16 }, (_, i) => i % 2 === 0 ? 1.0 : 0.9),
+})
+
+/**
+ * Hip-hop laid-back groove — snare/backbeat slightly late and softer.
+ * Steps 4, 5, 12, 13 (around beats 2 and 4) pushed 20–35 ms late.
+ * Creates the relaxed behind-the-beat feel of classic boom-bap.
+ */
+export const GrooveHipHop = defineGroove({
+  name: 'Hip-Hop',
+  offsets:    [0, 0, 0, 0,  0.020, 0.035, 0, 0,  0, 0, 0, 0,  0.020, 0.035, 0, 0],
+  velocities: [1.1, 0.8, 0.9, 0.7,  0.95, 0.8, 0.7, 0.85,  1.0, 0.75, 0.85, 0.7,  0.9, 0.8, 0.75, 0.85],
+})
+
+/**
+ * Latin groove — clave-influenced timing with accented downbeats.
+ * Steps 0, 3, 6, 9, 12 accented (Son clave pattern feel).
+ * Off-beats pushed slightly late for a flowing sway.
+ */
+export const GrooveLatin = defineGroove({
+  name: 'Latin',
+  offsets:    [0, 0.010, 0, 0,  0.010, 0, 0.015, 0,  0, 0.010, 0, 0,  0.010, 0, 0.015, 0],
+  velocities: [1.2, 0.7, 0.85, 1.0,  0.7, 0.9, 1.1, 0.75,  1.0, 0.7, 0.85, 0.9,  0.7, 0.85, 1.1, 0.75],
+})
+
+/**
+ * MPC-style groove — slightly quantised with subtle velocity humanization.
+ * Mimics the natural imprecision of an MPC drum machine with pads.
+ * All offsets ≤ 8 ms, velocity variation ±15%.
+ */
+export const GrooveMPC = defineGroove({
+  name: 'MPC',
+  offsets:    [0, 0.002, 0.005, 0.001,  0.003, 0.007, 0.002, 0.004,  0.001, 0.006, 0.003, 0.002,  0.005, 0.003, 0.008, 0.001],
+  velocities: [1.05, 0.9, 0.95, 0.85,  1.0, 0.88, 0.92, 0.87,  1.02, 0.86, 0.93, 0.89,  0.97, 0.91, 0.88, 0.94],
+})

--- a/packages/dsl/src/melodic.ts
+++ b/packages/dsl/src/melodic.ts
@@ -1,0 +1,347 @@
+// melodic.ts — Melodic instrument factories for @score/dsl
+//
+// All factories return ChainablePart via createPart().
+// Instrument-specific chain extras (cutoff, ratio, etc.) are added via object
+// spread on the base part — each returns a new ChainablePart.
+//
+// Stubs (createPart only) are marked — engine has a fallback for unknown types.
+// Real @score/components implementations for stubs come in a follow-up PR.
+
+import { createPart } from './chain.js'
+import type { ChainablePart } from './chain.js'
+
+// ── Synth ─────────────────────────────────────────────────────────────────────
+
+/**
+ * General-purpose oscillator synth — oscillator + ADSR envelope + optional filter.
+ *
+ * @param wave - Oscillator wave type. Default `'sawtooth'`.
+ * @param pitch - Optional starting pitch, e.g. `'C3'`.
+ * @returns A `ChainablePart` for `'synth'`.
+ *
+ * @example
+ * ```ts
+ * // Pad chord with reverb
+ * Synth('sine', 'C3').notes(['C3','E3','G3']).reverb(0.4).volume(0.5)
+ * ```
+ *
+ * @see {@link SubSynth} — analogue subtractive voice
+ * @see {@link FMSynth} — 2-operator FM voice
+ */
+export const Synth = (
+  wave: 'sine' | 'square' | 'sawtooth' | 'triangle' = 'sawtooth',
+  pitch?: string,
+): ChainablePart =>
+  createPart({
+    instrumentType: 'synth',
+    props: { wave },
+    ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+  })
+
+// ── SubSynth ──────────────────────────────────────────────────────────────────
+
+/** Extended ChainablePart with SubSynth-specific chain methods. */
+export type SubSynthPart = ChainablePart & {
+  /** Number of detuned oscillators (unison stack). `1` = mono, `2` = dual, `4` = quad. Default `1`. */
+  readonly unison: (n: 1 | 2 | 4) => SubSynthPart
+  /** Detune spread in cents across unison oscillators. Default `8`. */
+  readonly detune: (cents: number) => SubSynthPart
+}
+
+const makeSubSynth = (base: ChainablePart): SubSynthPart => ({
+  ...base,
+  unison: (n) => makeSubSynth(createPart({ ...base, props: { ...base.props, unison: n } })),
+  detune: (cents) => makeSubSynth(createPart({ ...base, props: { ...base.props, detune: cents } })),
+})
+
+/**
+ * Analogue subtractive synth voice — detuned oscillators → resonant LP filter → ADSR VCA.
+ * Inspired by the Juno-60 and Minimoog. Excellent for bass lines, leads, and pads.
+ *
+ * @param pitch - Optional starting pitch, e.g. `'C2'`.
+ * @returns A {@link SubSynthPart} with `.unison()` and `.detune()` extras.
+ *
+ * @example
+ * ```ts
+ * // Deep house bass — dual oscillator, filter sweep
+ * SubSynth('C2').unison(2).detune(8).filter(600, 1.2).wobble(0.5)
+ * ```
+ *
+ * @see {@link Synth} — simpler oscillator voice
+ * @see {@link Bass303} — 303-style acid bass
+ */
+export const SubSynth = (pitch?: string): SubSynthPart =>
+  makeSubSynth(
+    createPart({
+      instrumentType: 'sub-synth',
+      props: {},
+      ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+    }),
+  )
+
+// ── FMSynth ───────────────────────────────────────────────────────────────────
+
+/** Extended ChainablePart with FMSynth-specific chain methods. */
+export type FMSynthPart = ChainablePart & {
+  /** Modulator-to-carrier frequency ratio. Non-integer = inharmonic/metallic. Default `1.273`. */
+  readonly ratio: (n: number) => FMSynthPart
+  /** Modulation index — peak deviation multiplier of carrier frequency. Default `3`. */
+  readonly modIndex: (n: number) => FMSynthPart
+  /** Feedback amount 0–1 (carrier feeds back to modulator). Default `0`. */
+  readonly feedback: (n: number) => FMSynthPart
+}
+
+const makeFMSynth = (base: ChainablePart): FMSynthPart => ({
+  ...base,
+  ratio: (n) => makeFMSynth(createPart({ ...base, props: { ...base.props, modRatio: n } })),
+  modIndex: (n) => makeFMSynth(createPart({ ...base, props: { ...base.props, modIndex: n } })),
+  feedback: (n) => makeFMSynth(createPart({ ...base, props: { ...base.props, feedback: n } })),
+})
+
+/**
+ * 2-operator FM synthesis voice — DX7 Rhodes / metallic leads / electric piano.
+ * Carrier and modulator are both sine oscillators.
+ *
+ * @param pitch - Optional starting pitch, e.g. `'A3'`.
+ * @returns An {@link FMSynthPart} with `.ratio()`, `.modIndex()`, `.feedback()` extras.
+ *
+ * @example
+ * ```ts
+ * // DX7 Rhodes voicing at A3 — classic deep house chord
+ * FMSynth('A3').ratio(1.273).modIndex(3).reverb(0.3).volume(0.6)
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Metallic FM lead — inharmonic ratio, high modulation index
+ * FMSynth('C4').ratio(3.5).modIndex(6).delay(0.375, 0.4)
+ * ```
+ *
+ * @see {@link SubSynth} — analogue subtractive alternative
+ * @see {@link Synth} — simpler wavetable voice
+ */
+export const FMSynth = (pitch?: string): FMSynthPart =>
+  makeFMSynth(
+    createPart({
+      instrumentType: 'fm-synth',
+      props: {},
+      ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+    }),
+  )
+
+// ── Bass303 ───────────────────────────────────────────────────────────────────
+
+/** Extended ChainablePart with Bass303-specific chain methods. */
+export type Bass303Part = ChainablePart & {
+  /** Filter cutoff frequency in Hz. Default `400`. */
+  readonly cutoff: (freq: number) => Bass303Part
+  /** Filter resonance Q. Default `0.8`. Increases to self-oscillation at high values. */
+  readonly resonance: (q: number) => Bass303Part
+  /** Accent steps — step indices where velocity is boosted and filter opens fully. */
+  readonly accent: (steps: number[]) => Bass303Part
+  /** Slide steps — step indices with portamento (glide) to next note. */
+  readonly slide: (steps: number[]) => Bass303Part
+}
+
+const makeBass303 = (base: ChainablePart): Bass303Part => ({
+  ...base,
+  cutoff: (freq) => makeBass303(createPart({ ...base, props: { ...base.props, cutoff: freq } })),
+  resonance: (q) => makeBass303(createPart({ ...base, props: { ...base.props, resonance: q } })),
+  accent: (steps) => makeBass303(createPart({ ...base, props: { ...base.props, accentSteps: steps } })),
+  slide: (steps) => makeBass303(createPart({ ...base, props: { ...base.props, slideSteps: steps } })),
+})
+
+/**
+ * Roland TB-303-style acid bass — sawtooth/square oscillator + resonant filter with envelope.
+ * The defining voice of acid house, acid techno, and trance. Glide and accent are essential.
+ *
+ * @param pitch - Optional starting pitch, e.g. `'C2'`.
+ * @returns A {@link Bass303Part} with `.cutoff()`, `.resonance()`, `.accent()`, `.slide()` extras.
+ *
+ * @example
+ * ```ts
+ * // Classic acid bassline — open filter + resonance + accent on downbeats
+ * Bass303('C2').cutoff(600).resonance(2.0).accent([0, 4, 8]).wobble(0.5)
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Slide phrase across a scale
+ * Bass303('C2').notes(['C2','D2','F2','G2']).slide([1,3]).cutoff(500).resonance(1.5)
+ * ```
+ *
+ * @see {@link SubSynth} — broader analogue voice
+ */
+export const Bass303 = (pitch?: string): Bass303Part =>
+  makeBass303(
+    createPart({
+      instrumentType: 'bass-303',
+      props: {},
+      ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+    }),
+  )
+
+// ── Arp ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Arpeggiator — cycles through `notes` in sequence, up/down/pingpong/random.
+ * Each step triggers a note from the sequence at the current synth voice.
+ *
+ * @param notes - Ordered note names or MIDI pitch numbers to arpeggiate, e.g. `['C3','E3','G3']`.
+ * @returns A `ChainablePart` for `'arp'`.
+ *
+ * @example
+ * ```ts
+ * // Classic trance arp — up mode, triangle wave
+ * Arp(['C4','E4','G4','B4']).euclidean(8, 16).volume(0.5).delay(0.375, 0.3)
+ * ```
+ *
+ * @see {@link Synth} — underlying oscillator voice
+ * @see {@link Bass303} — monophonic acid bassline alternative
+ */
+export const Arp = (notes: (string | number)[]): ChainablePart =>
+  createPart({
+    instrumentType: 'arp',
+    props: { notes },
+    _notes: notes,
+  })
+
+// ── Sample ────────────────────────────────────────────────────────────────────
+
+/**
+ * Sample playback — load and trigger an audio file on each pattern hit.
+ *
+ * @param path - Absolute or relative path to the audio file (`.wav`, `.mp3`, `.ogg`).
+ * @returns A `ChainablePart` for `'sample'`.
+ *
+ * @example
+ * ```ts
+ * // One-shot clap on beats 2 and 4
+ * Sample('./samples/clap.wav').hits(4, 12).volume(0.7)
+ * ```
+ *
+ * @see {@link Arp} — pitched sequence without sample files
+ */
+export const Sample = (path: string): ChainablePart =>
+  createPart({
+    instrumentType: 'sample',
+    props: { path },
+  })
+
+// ── Theremin ──────────────────────────────────────────────────────────────────
+
+/**
+ * Theremin — continuous pitch/volume control, sine oscillator with LFO vibrato.
+ * Plays continuously; use `.note()` to set pitch and `.volume()` for amplitude.
+ *
+ * @param pitch - Optional starting pitch, e.g. `'A4'`.
+ * @returns A `ChainablePart` for `'theremin'`.
+ *
+ * @example
+ * ```ts
+ * Theremin('A4').vibrato(5, 8).volume(0.4)
+ * ```
+ */
+export const Theremin = (pitch?: string): ChainablePart =>
+  createPart({
+    instrumentType: 'theremin',
+    props: {},
+    ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+  })
+
+// ── Sax ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Saxophone — sawtooth oscillator through bandpass filter with ADSR envelope.
+ * Breathy, reedy character. Use for jazz, house, or melodic leads.
+ *
+ * @param pitch - Optional starting pitch, e.g. `'A4'`.
+ * @returns A `ChainablePart` for `'sax'`.
+ *
+ * @example
+ * ```ts
+ * Sax('A4').notes(['A4','B4','C5','D5']).dur(0.35).reverb(0.2)
+ * ```
+ */
+export const Sax = (pitch?: string): ChainablePart =>
+  createPart({
+    instrumentType: 'sax',
+    props: {},
+    ...( pitch !== undefined ? { _notes: [pitch] } : {}),
+  })
+
+// ── Stubs — real @score/components implementations pending ────────────────────
+// Engine falls back to Synth('sine') for all unknown instrumentType values.
+// These stubs are named anchors for the engine registry and future components.
+
+/** Soft pad voice — long attack, sustained, gentle filter. @stub */
+export const Pad = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'pad', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Plucked string envelope — fast attack, fast decay. @stub */
+export const Pluck = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'pluck', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Short stab voice — percussive attack, no sustain. @stub */
+export const Stab = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'stab', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Fender Rhodes electric piano — FM voice with tine character. @stub */
+export const Rhodes = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'rhodes', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Wurlitzer electric piano — reedy, slightly overdriven. @stub */
+export const Wurlitzer = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'wurlitzer', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Hammond B3-style tonewheel organ. @stub */
+export const Hammond = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'hammond', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Hohner Clavinet — percussive clavichord, used in funk. @stub */
+export const Clavinet = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'clavinet', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** DX7-style FM lead — bright, cutting, metallic. @stub */
+export const DX7Lead = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'dx7-lead', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Wavetable synth — cycle through waveform tables. @stub */
+export const WavetableSynth = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'wavetable', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Supersaw — N detuned sawtooth oscillators (trance, big room, synthwave). @stub */
+export const SuperSaw = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'supersaw', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Karplus-Strong plucked string synthesis. @stub */
+export const KarplusSynth = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'karplus', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Electric guitar — Karplus with pick model. @stub */
+export const Guitar = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'guitar', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Acoustic guitar — Karplus with body resonance. @stub */
+export const AcousticGuitar = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'acoustic-guitar', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Bass guitar — Karplus with low-frequency body. @stub */
+export const BassGuitar = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'bass-guitar', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Trumpet — bright brass with mute options. @stub */
+export const Trumpet = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'trumpet', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Trombone — warm, sliding brass. @stub */
+export const Trombone = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'trombone', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** French horn — rich, mellow brass. @stub */
+export const FrenchHorn = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'french-horn', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })
+
+/** Flugelhorn — darker, softer trumpet variant. @stub */
+export const Flugelhorn = (pitch?: string): ChainablePart =>
+  createPart({ instrumentType: 'flugelhorn', props: {}, ...( pitch !== undefined ? { _notes: [pitch] } : {}) })

--- a/packages/dsl/tests/instruments.test.ts
+++ b/packages/dsl/tests/instruments.test.ts
@@ -1,49 +1,120 @@
 import { describe, it, expect } from 'vitest'
-import { Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp } from '../src/instruments.js'
+import { Kick, Snare, HiHat } from '../src/instruments.js'
+import { Synth, SubSynth, FMSynth, Bass303, Arp, Sample, Theremin, Sax } from '../src/melodic.js'
 
 describe('Arp', () => {
-  it('returns an InstrumentDescriptor with instrumentType arp', () => {
-    const arp = Arp({ notes: ['C4', 'E4', 'G4'] })
-    expect(arp._type).toBe('InstrumentDescriptor')
+  it('returns a ChainablePart with instrumentType arp', () => {
+    const arp = Arp(['C4', 'E4', 'G4'])
+    expect(arp._type).toBe('ChainablePart')
     expect(arp.instrumentType).toBe('arp')
   })
 
-  it('stores notes in props', () => {
-    const arp = Arp({ notes: ['A3', 'C4', 'E4'] })
+  it('stores notes in _notes and props', () => {
+    const arp = Arp(['A3', 'C4', 'E4'])
+    expect(arp._notes).toEqual(['A3', 'C4', 'E4'])
     const props = arp.props as { notes: string[] }
     expect(props.notes).toEqual(['A3', 'C4', 'E4'])
   })
 
-  it('stores optional mode, wave, gain in props', () => {
-    const arp = Arp({ notes: ['C4'], mode: 'down', wave: 'sawtooth', gain: 0.5 })
-    const props = arp.props as { mode: string; wave: string; gain: number }
-    expect(props.mode).toBe('down')
-    expect(props.wave).toBe('sawtooth')
-    expect(props.gain).toBe(0.5)
-  })
-
   it('has a unique id per instance', () => {
-    const a = Arp({ notes: ['C4'] })
-    const b = Arp({ notes: ['C4'] })
+    const a = Arp(['C4'])
+    const b = Arp(['C4'])
     expect(a.id).not.toBe(b.id)
   })
 
   it('has no-op connect/disconnect/dispose', () => {
-    const arp = Arp({ notes: ['C4'] })
+    const arp = Arp(['C4'])
     expect(() => { arp.connect({} as never) }).not.toThrow()
     expect(() => { arp.disconnect() }).not.toThrow()
     expect(() => { arp.dispose() }).not.toThrow()
   })
 
-  it('stores envelope in props', () => {
-    const env = { attack: 0.01, decay: 0.1, sustain: 0.6, release: 0.05 }
-    const arp = Arp({ notes: ['C4'], envelope: env })
-    const props = arp.props as { envelope: typeof env }
-    expect(props.envelope).toEqual(env)
+  it('chain methods work — notes via .notes()', () => {
+    const arp = Arp(['C4']).notes(['C4', 'E4', 'G4']).volume(0.5)
+    expect(arp._notes).toEqual(['C4', 'E4', 'G4'])
+    expect(arp._volume).toBe(0.5)
   })
 })
 
-describe('existing instrument factories still work after type extension', () => {
+describe('melodic factories return ChainablePart', () => {
+  it('Synth returns synth descriptor', () => {
+    const s = Synth()
+    expect(s._type).toBe('ChainablePart')
+    expect(s.instrumentType).toBe('synth')
+  })
+
+  it('Synth accepts wave and pitch', () => {
+    const s = Synth('square', 'C3')
+    expect(s.props).toMatchObject({ wave: 'square' })
+    expect(s._notes).toEqual(['C3'])
+  })
+
+  it('SubSynth returns sub-synth descriptor with unison/detune extras', () => {
+    const s = SubSynth('C2')
+    expect(s.instrumentType).toBe('sub-synth')
+    expect(s._notes).toEqual(['C2'])
+    expect(typeof s.unison).toBe('function')
+    expect(typeof s.detune).toBe('function')
+  })
+
+  it('SubSynth.unison() and .detune() store in props', () => {
+    const s = SubSynth().unison(2).detune(12)
+    expect((s.props).unison).toBe(2)
+    expect((s.props).detune).toBe(12)
+  })
+
+  it('FMSynth returns fm-synth descriptor with ratio/modIndex/feedback extras', () => {
+    const s = FMSynth('A3')
+    expect(s.instrumentType).toBe('fm-synth')
+    expect(typeof s.ratio).toBe('function')
+    expect(typeof s.modIndex).toBe('function')
+    expect(typeof s.feedback).toBe('function')
+  })
+
+  it('FMSynth.ratio().modIndex() chain stores in props', () => {
+    const s = FMSynth().ratio(1.273).modIndex(3).feedback(0.2)
+    expect((s.props).modRatio).toBe(1.273)
+    expect((s.props).modIndex).toBe(3)
+    expect((s.props).feedback).toBe(0.2)
+  })
+
+  it('Bass303 returns bass-303 descriptor with cutoff/resonance/accent/slide extras', () => {
+    const b = Bass303('C2')
+    expect(b.instrumentType).toBe('bass-303')
+    expect(typeof b.cutoff).toBe('function')
+    expect(typeof b.resonance).toBe('function')
+    expect(typeof b.accent).toBe('function')
+    expect(typeof b.slide).toBe('function')
+  })
+
+  it('Bass303 chain stores in props', () => {
+    const b = Bass303().cutoff(600).resonance(2.0).accent([0, 4]).slide([1])
+    const p = b.props
+    expect(p.cutoff).toBe(600)
+    expect(p.resonance).toBe(2.0)
+    expect(p.accentSteps).toEqual([0, 4])
+    expect(p.slideSteps).toEqual([1])
+  })
+
+  it('Sample returns sample descriptor', () => {
+    const s = Sample('./kick.wav')
+    expect(s._type).toBe('ChainablePart')
+    expect(s.instrumentType).toBe('sample')
+    expect((s.props).path).toBe('./kick.wav')
+  })
+
+  it('Theremin returns theremin descriptor', () => {
+    expect(Theremin().instrumentType).toBe('theremin')
+    expect(Theremin('A4')._notes).toEqual(['A4'])
+  })
+
+  it('Sax returns sax descriptor', () => {
+    expect(Sax().instrumentType).toBe('sax')
+    expect(Sax('A4')._notes).toEqual(['A4'])
+  })
+})
+
+describe('percussion factories return InstrumentDescriptor', () => {
   it('Kick returns kick descriptor', () => {
     expect(Kick().instrumentType).toBe('kick')
   })
@@ -54,21 +125,5 @@ describe('existing instrument factories still work after type extension', () => 
 
   it('HiHat returns hihat descriptor', () => {
     expect(HiHat().instrumentType).toBe('hihat')
-  })
-
-  it('Synth returns synth descriptor', () => {
-    expect(Synth().instrumentType).toBe('synth')
-  })
-
-  it('Sample returns sample descriptor', () => {
-    expect(Sample({ path: './kick.wav' }).instrumentType).toBe('sample')
-  })
-
-  it('Theremin returns theremin descriptor', () => {
-    expect(Theremin().instrumentType).toBe('theremin')
-  })
-
-  it('Sax returns sax descriptor', () => {
-    expect(Sax().instrumentType).toBe('sax')
   })
 })


### PR DESCRIPTION
## Summary
- Adds melodic instrument factories (Bass303, Pad, Pluck, Synth variants, FMSynth DSL wrappers) via chain API
- Adds genre preset system for style-aware defaults
- Adds groove template library for swing/humanize patterns
- Fixes CLI engine-effects.test.ts to use updated Song API

## Test plan
- [ ] pnpm test passes
- [ ] pnpm typecheck passes
- [ ] Melodic factories return ChainablePart with correct instrumentType
- [ ] Genre presets apply expected defaults
- [ ] Groove templates apply correct timing offsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)