### PR TITLE
docs(adr): ADRs 015–025 — full app roadmap gap coverage

### DIFF
--- a/docs/adr/015-gui-three-tier-progressive-disclosure.md
+++ b/docs/adr/015-gui-three-tier-progressive-disclosure.md
@@ -1,0 +1,61 @@
+# ADR 015 — GUI Three-Tier Progressive Disclosure
+
+**Date:** 2026-03-23
+**Status:** Accepted
+**Deciders:** Project owner
+
+---
+
+## Context
+
+The fluent chain API (ADR 014) exposes 40+ methods per instrument. Showing all controls simultaneously in Score Studio would produce an interface indistinguishable from a traditional DAW — too dense for beginners and inconsistent with the code-first philosophy. At the same time, power users expect full access without round-tripping to the code editor for every tweak.
+
+---
+
+## Decision
+
+Score Studio uses a **three-tier control system** per track.
+
+**Tier 1 — Quick Strip** (always visible in the mixer row):
+- Volume knob
+- Pattern density badge (step count indicator, clickable)
+- Instrument-characteristic control — one control per family:
+  - Kick → Tune, Snare → Snappy, Bass303 → Filter cutoff, Pad → Reverb
+- Reverb knob
+- Mute toggle
+
+**Tier 2 — Instrument Panel** (shown when track row ▼ is clicked):
+Grouped into four sections (~12–15 controls total):
+- **Rhythm** — pattern punchcard, density, swing
+- **Timbre** — oscillator, filter, instrument-specific character params
+- **Space** — reverb wet, room size, delay, pan
+- **Dynamic** — volume, compressor threshold, sidechain
+
+**Tier 3 — Full Chain** (shown via ⋯ button):
+- All 40+ chain methods rendered as individual widgets
+- Deferred to post-Friday milestone; panel is a stub for now
+
+Every control in every tier calls `patchChainMethod()`, which writes the corresponding chain method back to the song file. Tier does not affect what code is generated — only how many controls are visible at once.
+
+---
+
+## Consequences
+
+**Positive:**
+- Beginners can make a track with 5 controls; no cognitive overload
+- Power users access the full chain without switching to the code editor
+- `patchChainMethod()` is the single write path — tiers share codegen logic
+- Tier 2 groups map directly to ADR 014 chain method categories
+
+**Negative:**
+- Tier 1 characteristic control is instrument-specific — requires a per-family registry
+- Tier 3 is intentionally deferred, leaving a gap for early testers
+- Three tiers add UI surface area and require explicit expand/collapse state management
+
+---
+
+## Alternatives Considered
+
+- **Single flat panel** — all controls always visible. Rejected: overwhelming for non-developers.
+- **Two tiers only** (quick strip + full panel) — simpler, but loses the progressive ramp for intermediate users.
+- **Code editor only** — no GUI controls. Rejected: testers who are musicians, not coders, need GUI entry points.

--- a/docs/adr/016-project-file-format-autosave.md
+++ b/docs/adr/016-project-file-format-autosave.md
@@ -1,0 +1,67 @@
+# ADR 016 — Project File Format and Autosave
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Score needs a project format that is git-diffable, human-readable, and simple enough that "open a project" means opening a folder. Binary formats (Ableton `.als`, Logic `.logicx`) are opaque and not diffable. The song file is already the source of truth — the project format must reflect that without adding overhead.
+
+---
+
+## Decision
+
+A Score project is a **directory**, not a single file.
+
+```
+my-project/
+  song.ts          # the song — source of truth
+  samples/         # gitignored; symlinked or downloaded at open time
+  assets/          # waveforms, analysis data, cached renders
+  score.json       # machine-generated project metadata
+```
+
+`score.json` schema:
+
+```json
+{
+  "name": "my-project",
+  "bpm": 128,
+  "created": "2026-03-23T00:00:00Z",
+  "lastOpened": "2026-03-23T12:00:00Z",
+  "samplePaths": ["samples/kick.wav"]
+}
+```
+
+`score.json` is **never hand-edited**. It exists only for the GUI's recent-files list and sample path resolution.
+
+**Autosave:** every eval cycle (Ctrl+Enter) writes the current editor content to `song.ts`. Score Studio maintains a 20-entry in-memory undo buffer (ADR 017). There is no background autosave timer — eval is the save trigger.
+
+**File > Save As** copies the entire project directory.
+**File > Open** shows a directory picker; a valid project must contain `song.ts`.
+
+---
+
+## Consequences
+
+**Positive:**
+- `git diff my-project/song.ts` works — projects are fully version-controllable
+- `score.json` never clutters diffs with audio data
+- "Save" is a no-op concept — the file is always current after eval
+- Directory structure is self-documenting
+
+**Negative:**
+- `samples/` must be re-resolved on every machine — no bundled audio (by design, ADR rules)
+- "File > Open" as a directory picker is unfamiliar to users expecting a single file
+- `score.json` will drift if a user hand-edits `song.ts` outside Score Studio
+
+---
+
+## Alternatives Considered
+
+- **Single `.score` file** (zip archive of song.ts + metadata) — diffable only with zip-aware git tooling. Rejected: unnecessary complexity.
+- **Background autosave timer** — writes every N seconds regardless of eval. Rejected: creates saves that don't correspond to any eval'd state, corrupting the undo buffer relationship.
+- **No `score.json`** — store metadata in song.ts comments. Rejected: pollutes the music-authoring surface with tooling metadata.

--- a/docs/adr/017-undo-redo-architecture.md
+++ b/docs/adr/017-undo-redo-architecture.md
@@ -1,0 +1,65 @@
+# ADR 017 — Undo/Redo Architecture
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Score Studio writes GUI interactions back to the song file as chain method calls via `codePatcher` (ADR 014). Undo must reverse both the code change and the live audio state simultaneously. Traditional undo systems use a command pattern (Command, CommandHistory classes) — this is incompatible with Score's zero-class, functional constraint (ADR 001).
+
+---
+
+## Decision
+
+Score Studio uses an **immutable code-string history** for undo/redo.
+
+The undo buffer is a plain array of code strings — the raw editor content at each saved point:
+
+```ts
+const undoStack: string[] = []
+const redoStack: string[] = []
+```
+
+**On every `codePatcher` call:**
+1. Push the pre-change code string onto `undoStack`
+2. Clear `redoStack`
+3. Apply the patch, set editor content, trigger eval
+
+**Ctrl+Z (undo):**
+1. Pop from `undoStack` → push current code onto `redoStack`
+2. Set editor content to popped string
+3. Trigger eval — audio state is restored as a side effect
+
+**Ctrl+Shift+Z (redo):** symmetric pop from `redoStack`.
+
+Maximum stack depth: **50 entries**. Oldest entries are dropped when the limit is reached.
+
+Re-eval on undo is acceptable because eval completes in < 50ms and is the existing hot-swap path (ADR 007). There is no separate "undo audio" logic — restoring the code string and re-evaluating achieves both in one step.
+
+**Anti-decision:** Do NOT implement a command pattern with `Command` or `CommandHistory` constructs. This would introduce classes and mutable object state — both forbidden by ADR 001.
+
+---
+
+## Consequences
+
+**Positive:**
+- No command-pattern infrastructure; zero classes required
+- Code and audio state are always in sync after undo — single re-eval achieves both
+- The undo buffer is inspectable as a plain array — trivially serialisable if needed
+- Consistent with the thesis: code is the source of truth; undoing means restoring prior code
+
+**Negative:**
+- Each undo entry is a full code string — memory cost scales with file size × depth (acceptable for typical song files < 5 KB)
+- Undo granularity is per-`codePatcher` call, not per-character — mid-type undo is not supported
+- Redo stack is cleared on any new edit — standard UX but may surprise users
+
+---
+
+## Alternatives Considered
+
+- **Command pattern** — `Command` objects with `execute`/`undo` methods. Rejected: requires classes; would need per-method inverse logic for 40+ chain methods.
+- **AST-level diffing** — parse song.ts to AST, store AST diffs. Rejected: overkill; adds a parser dependency and defeats the "code string is truth" principle.
+- **Disk-based undo** — write each undo state to a temp file. Rejected: I/O latency; unnecessary when in-memory fits within 50 × 5 KB ≈ 250 KB.

--- a/docs/adr/018-export-formats-render-pipeline.md
+++ b/docs/adr/018-export-formats-render-pipeline.md
@@ -1,0 +1,61 @@
+# ADR 018 — Export Formats and Render Pipeline
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Testers need to share their tracks externally. SoundCloud, Spotify, and other platforms require MP3; industry remix workflow requires stems; Ableton/FL Studio import requires MIDI. WAV alone is insufficient. The render pipeline must stay client-side — no server should touch a user's audio.
+
+---
+
+## Decision
+
+Score supports **four export formats**:
+
+| Format | Mechanism | Notes |
+|---|---|---|
+| **WAV** | `OfflineAudioContext` offline render | Primary format; lossless |
+| **MP3** | lamejs WASM, post-render in a Worker | Client-side; no server |
+| **Stems** | `OfflineAudioContext`, solo each track in turn | One WAV per instrument variable |
+| **MIDI** | Pattern array extraction; no audio render | Pure data; no `OfflineAudioContext` needed |
+
+**CLI:** `score export --format wav|mp3|stems|midi [--bitrate 320] [--output ./out/]`
+
+**GUI:** File > Export dialog with:
+- Format picker (WAV / MP3 / Stems / MIDI)
+- MP3 bitrate selector (128 / 192 / 320 kbps)
+- Output path / filename field
+- Progress bar (render duration / song duration)
+
+**Stems naming:** instrument variable names from the song file (e.g. `kick.wav`, `bass303.wav`). The eval sandbox exports a track registry alongside the `Song` default export.
+
+**MP3 encoding** runs in a `Worker` after the WAV buffer is produced. The main thread receives a progress event stream. This keeps the GUI responsive during long renders.
+
+**MIDI export** walks each track's pattern array and note sequence to emit Note On/Off events at the correct BPM-relative tick positions. Output is a standard `.mid` file (MIDI 1.0, single track per instrument).
+
+---
+
+## Consequences
+
+**Positive:**
+- All rendering is client-side — no server dependency, no privacy risk
+- WAV is always the render primitive; MP3/Stems are post-processing passes
+- Stems enable professional remix workflow from day one
+- MIDI bridges Score to every other DAW
+
+**Negative:**
+- lamejs WASM adds ~200 KB to the bundle
+- Stems render time scales linearly with track count (one full render per track)
+- MIDI export requires instrument metadata (note, duration) that not all instruments currently expose
+
+---
+
+## Alternatives Considered
+
+- **Server-side FFmpeg for MP3** — simpler implementation. Rejected: requires a server, adds latency, raises privacy concerns for unpublished music.
+- **OGG Vorbis instead of MP3** — open format, better quality at bitrate. Rejected: platform compatibility (iOS, some social platforms) still requires MP3.
+- **Single mixed stem only** — no per-track stems. Rejected: stems are the industry standard handoff format; omitting them would limit professional use.

--- a/docs/adr/019-distribution-strategy.md
+++ b/docs/adr/019-distribution-strategy.md
@@ -1,0 +1,66 @@
+# ADR 019 — Distribution Strategy
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Score must be installable by two distinct audiences: developers (comfortable with npm and the terminal) and musician testers (who may not know what npm is). A single distribution channel serves neither well. The project also needs a clear versioning contract so CLI and Studio never drift out of sync.
+
+---
+
+## Decision
+
+Three distribution channels:
+
+**1. npm global (developers / CI)**
+```
+npm install -g @score/cli
+```
+CLI only. Provides `score play`, `score export`, `score doctor`, etc. No GUI.
+
+**2. Electron installer (musicians / general users)**
+Built via `electron-forge make`:
+- Windows: NSIS `.exe` installer
+- macOS: `.dmg`
+- Linux: `.AppImage`
+
+This is the **primary distribution path**. Bundles the CLI and Score Studio together.
+
+**3. Homebrew tap (macOS first-class)**
+```
+brew install bwyard/tap/score
+```
+Installs CLI + opens Score Studio. Targets macOS developers who prefer Homebrew over npm globals.
+
+**Auto-update:** `electron-updater` with GitHub Releases as the update server. Update check on every Studio launch; user prompted, never forced.
+
+**Versioning:** semantic versioning. CLI and Studio always ship at the same version number — a single release cuts both the npm package and the Electron installer. The npm scope is `@score/*` internally; packages are published under `@bwyard/*`.
+
+**Dev / beta channel:** `npm install -g @score/cli@beta` and a separate GitHub Release pre-release tag for the installer.
+
+---
+
+## Consequences
+
+**Positive:**
+- Musicians install the `.exe`/`.dmg` — no npm required
+- Developers install via npm or Homebrew — no GUI overhead if unwanted
+- Single version number prevents CLI/Studio mismatch bugs
+- GitHub Releases is free and already needed for the repo
+
+**Negative:**
+- Three channels require three build/publish jobs in CI
+- Homebrew tap requires a separate tap repo (`bwyard/homebrew-tap`)
+- Code-signing (macOS notarization, Windows Authenticode) is required for installer trust — cost and setup overhead
+
+---
+
+## Alternatives Considered
+
+- **npm only** — simplest. Rejected: musicians cannot install npm packages without developer tooling.
+- **Web app (browser-based Score Studio)** — no install required. Rejected: Web Audio API limitations for professional latency, no local file system access without workarounds.
+- **Single channel (installer only)** — no npm package. Rejected: CI pipelines and developer workflows need headless CLI access.

--- a/docs/adr/020-song-file-versioning-migration.md
+++ b/docs/adr/020-song-file-versioning-migration.md
@@ -1,0 +1,70 @@
+# ADR 020 — Song File Versioning and Migration
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+The Score DSL will evolve. Method renames, factory signature changes, and removed helpers are inevitable as the API matures. Without a migration system, every DSL change breaks every existing song file — a user who wrote tracks six months ago cannot open them in a newer Score Studio without manual editing.
+
+---
+
+## Decision
+
+Song files declare their DSL version via a header comment:
+
+```ts
+// @score-version 1.0
+import { Song, Kick, Bass303 } from '@score/dsl'
+// ...
+```
+
+The CLI and Score Studio read this header before eval. If the version is behind the current DSL version, a **migration chain** runs first.
+
+**Migration functions** are pure functions of signature `(code: string) => string`. They live in `@score/dsl/src/migrations/` and are named `v1_0_to_v1_1.ts`. Each function applies the minimal string transformation required for that version step (regex replacement, AST rewrite, or simple find-replace).
+
+The migration chain composes all required steps in sequence:
+
+```ts
+const migrate = (code: string, from: string, to: string): string =>
+  migrationChain
+    .filter(m => m.from >= from && m.to <= to)
+    .reduce((acc, m) => m.fn(acc), code)
+```
+
+**Rules:**
+- Breaking DSL changes (renamed methods, removed factories) MUST ship with a migration
+- Non-breaking additions (new chain methods, new factories) do NOT need migrations
+- Migrations run in-memory before eval — the file is not written unless the user explicitly saves
+
+**CLI commands:**
+- `score migrate <file>` — apply all pending migrations and write in-place
+- `score migrate --dry-run <file>` — print the migrated code without writing
+
+Score Studio shows a banner when a song file needs migration, with a one-click "Migrate and Save" button.
+
+---
+
+## Consequences
+
+**Positive:**
+- Existing song files survive DSL evolution without manual editing
+- Migrations are pure functions — testable, composable, zero side effects
+- `--dry-run` lets users review changes before committing
+- Breaking changes are forced to ship with their migration — no silent breakage
+
+**Negative:**
+- Migration functions must be maintained alongside every breaking DSL change — adds authoring discipline requirement
+- String-based migrations are fragile for complex restructuring (a full AST rewrite would be safer but is overkill for most changes)
+- Version header must be present — songs without the header are treated as version `1.0` (oldest)
+
+---
+
+## Alternatives Considered
+
+- **No versioning** — require manual migration. Rejected: untenable once testers have accumulated song libraries.
+- **AST-based migration** — parse to AST, transform, re-emit. More robust but requires a full TypeScript parser at runtime. Deferred; adopt if string migrations prove insufficient.
+- **Lockfile approach** — pin DSL version per project (like `package.json`). Rejected: creates dependency management overhead; migrations are simpler for a single-author DSL.

--- a/docs/adr/021-real-time-collaboration.md
+++ b/docs/adr/021-real-time-collaboration.md
@@ -1,0 +1,53 @@
+# ADR 021 — Real-Time Collaboration Architecture
+
+**Date:** 2026-03-23
+**Status:** Proposed (not yet scheduled)
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Live coding performance with multiple simultaneous coders is a key differentiator for Score — each performer edits the shared song in real time, and the audience hears the result evolve. This capability is post-v1 but requires an architectural slot before the network layer is frozen, so that early decisions (IPC bridge, eval sandbox) do not inadvertently close off the collaboration path.
+
+---
+
+## Decision
+
+Score collaboration uses a **shared-document model over WebRTC**.
+
+Each participant holds a full local copy of the song code. Changes are broadcast as **operational transforms (OT)** on the code string — the same model used by collaborative text editors (Google Docs, CodeMirror collab). Audio is not streamed; each participant runs the song locally from their own synced code copy.
+
+**Session setup:**
+- The session host runs `score collab host` (CLI) or clicks "Start Collab" in Score Studio
+- A WebRTC data channel is established; a human-readable session code is generated
+- Participants join via `score collab join <code>` or the GUI join dialog
+
+**Sync payload:** code string diffs (OT operations), not audio. Latency tolerance is the same as a text editor — 100–300 ms round trip is acceptable.
+
+**Package:** a dedicated `@score/collab` package wraps the WebRTC signaling, OT engine, and connection management. It is a pure add-on — `@score/core`, `@score/dsl`, and `@score/gui` have no collab dependencies.
+
+**Eval trigger:** each participant's eval runs locally on receipt of the merged code string. There is no "master" audio source — all participants hear their own local render.
+
+---
+
+## Consequences
+
+**Positive:**
+- No audio streaming required — bandwidth is minimal (text diffs only)
+- OT is a well-understood algorithm with existing TypeScript implementations
+- `@score/collab` is opt-in — non-collab installs are unaffected
+- Live coding performance is a genuine differentiator in the DAW market
+
+**Negative:**
+- OT merge conflicts on simultaneous edits to the same line require conflict resolution policy
+- Participants may hear slight divergence if their local audio backends differ
+- WebRTC signaling requires a lightweight relay server (STUN/TURN) for NAT traversal — not fully peer-to-peer
+
+---
+
+## Alternatives Considered
+
+- **CRDTs instead of OT** — conflict-free replicated data types are simpler to implement correctly. Worth revisiting at implementation time; OT is selected here for familiarity.
+- **Audio streaming (JamKazam model)** — stream the mixed audio to all participants. Rejected: latency and bandwidth requirements are an order of magnitude higher than code sync.
+- **Central server with shared state** — server holds the canonical code string. Rejected: introduces server dependency and single point of failure; WebRTC peer model is more resilient for live performance.

--- a/docs/adr/022-score-registry.md
+++ b/docs/adr/022-score-registry.md
@@ -1,0 +1,62 @@
+# ADR 022 — Score Registry (Song and Instrument Sharing)
+
+**Date:** 2026-03-23
+**Status:** Proposed (not yet scheduled)
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Community is core to a DAW platform's longevity. Artists sharing patterns, instruments, and songs builds the ecosystem and drives adoption. The registry must stay true to Score's core principle — code is music — which means no binary hosting, no proprietary formats, and no lock-in.
+
+---
+
+## Decision
+
+**Score Registry** is a public index of published songs and instruments hosted at `registry.score.dev`.
+
+The registry is an **index, not a host**. Every entry points to a git repository (GitHub or GitLab). The registry stores: name, author, description, tags, repo URL, entry file path, and Score DSL version. No binaries or audio files are stored in the registry.
+
+**CLI commands:**
+
+```
+score publish song ./song.ts --name "Midnight Acid" --tags techno,acid
+score publish instrument ./instruments/bass303.ts --name "TB-303 Acid"
+score install midnight-acid
+score search --tags techno
+```
+
+`score install <name>`:
+1. Looks up the registry entry
+2. Clones the repo (shallow) into `~/.score/instruments/` or `~/.score/songs/`
+3. Makes the instrument available in the local eval sandbox
+
+**Authentication:** GitHub OAuth — no separate Score account needed. Publish rights are tied to the authenticated GitHub identity.
+
+**No bundled audio:** `samples/` directories in installed repos are gitignored by the registry fetch. The registry enforces the same no-bundled-audio rule as the core project.
+
+**Versioning:** registry entries track the DSL version at publish time. `score install` checks compatibility and warns if a migration will be needed.
+
+---
+
+## Consequences
+
+**Positive:**
+- Authors retain full ownership — their music lives in their repos, not Score's servers
+- "Code is music" principle is preserved end-to-end — instruments are TypeScript, not patches
+- GitHub OAuth removes the need to build auth infrastructure
+- Community instruments are automatically versioned via git history
+
+**Negative:**
+- Registry depends on third-party git hosts — if a repo is deleted, the registry entry breaks
+- `score install` requires git on the user's machine — an additional dependency
+- Curation / abuse prevention (malicious instrument code) requires a moderation policy
+
+---
+
+## Alternatives Considered
+
+- **npm as the registry** — publish instruments as `@score-community/bass303`. Consistent with existing tooling. Deferred: npm is developer-centric; a domain-specific registry is more discoverable for musicians.
+- **Binary / patch hosting (VST marketplace model)** — host compiled instruments. Rejected: incompatible with "code is music"; creates a binary dependency chain.
+- **No public registry** — share via GitHub links only. Rejected: discoverability is the core value proposition; a searchable index is essential.

--- a/docs/adr/023-keyboard-shortcuts-system.md
+++ b/docs/adr/023-keyboard-shortcuts-system.md
@@ -1,0 +1,67 @@
+# ADR 023 — Keyboard Shortcuts System
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Score Studio has 40+ interactive surfaces — mixer rows, the code editor, transport controls, export dialog, settings panel. Without a centralised shortcut system, keybindings scatter across components, conflict silently, and become impossible to document or customise. Power users expect full keyboard control; new users need a discoverable reference.
+
+---
+
+## Decision
+
+Score Studio uses a **centralised shortcut registry** — a plain object constant:
+
+```ts
+const SHORTCUTS: Record<ShortcutId, ShortcutDef> = { ... }
+
+type ShortcutDef = {
+  keys: string[]        // e.g. ['Ctrl', 'Enter']
+  description: string   // shown in the reference panel
+  action: string        // dispatch identifier, NOT a function reference
+}
+```
+
+The `action` field is a string identifier dispatched via the IPC bridge or a context reducer — never a direct function reference. This separates key-binding from behaviour and enables user overrides without touching component code.
+
+**Built-in bindings:**
+
+| Shortcut | Action | Description |
+|---|---|---|
+| Space | `transport.toggle` | Play / Stop |
+| Ctrl+Enter | `eval.run` | Evaluate song file |
+| Ctrl+Z | `history.undo` | Undo |
+| Ctrl+Shift+Z | `history.redo` | Redo |
+| Ctrl+S | `file.save` | Save |
+| Escape | `panel.closeAll` | Close open panels |
+| 1–4 | `mode.switch` | Switch view mode |
+
+**User customisation:** overrides are stored in `score.json` under `"shortcuts": { "eval.run": ["Ctrl", "Shift", "Enter"] }`. Overrides merge with the registry at startup.
+
+A `KeyboardShortcutsPanel` component (? icon or keyboard icon in toolbar) renders the full reference, grouped by category. The MCP server can read `SHORTCUTS` for documentation generation — this satisfies the MCP tool discoverability goal noted in project memory.
+
+---
+
+## Consequences
+
+**Positive:**
+- Single file of truth for all keybindings — no hunting across components
+- Action-string dispatch means shortcuts work from any context (menu, panel, code editor)
+- User customisation requires no code changes — only `score.json` edits
+- MCP-readable registry enables automatic shortcut documentation
+
+**Negative:**
+- Action strings must be kept in sync with the dispatch layer — a typo in an action string fails silently
+- Custom shortcuts stored in `score.json` are per-project, not global — users with multiple projects must set overrides in each (or use `~/.score/config.json`)
+
+---
+
+## Alternatives Considered
+
+- **Per-component keybinding** — each component registers its own shortcuts. Rejected: conflicts are undetectable; no central reference possible.
+- **Function references in registry** — `action: () => evalSong()`. Rejected: prevents serialisation for user overrides; couples registry to runtime context.
+- **Electron globalShortcut API** — system-level shortcuts active even when Score Studio is not focused. Rejected: inappropriate for media keys; Space would intercept other applications.

--- a/docs/adr/024-audio-midi-device-config.md
+++ b/docs/adr/024-audio-midi-device-config.md
@@ -1,0 +1,70 @@
+# ADR 024 — Audio and MIDI Device Configuration
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Artists use audio interfaces (Focusrite Scarlett, SSL 2+, RME Babyface) rather than laptop speakers. The default `AudioContext` picks the OS system default, which is almost always the built-in speakers — wrong for any studio session. MIDI controllers need explicit device binding. Without explicit device configuration, Score is unsuitable for professional use.
+
+---
+
+## Decision
+
+Device configuration is stored in `score.json` under a `"devices"` key:
+
+```json
+{
+  "devices": {
+    "audioOutput": "Focusrite USB Audio",
+    "audioInput":  "Focusrite USB Audio",
+    "midi": ["Arturia KeyStep 37", "Ableton Push 2"]
+  }
+}
+```
+
+**Fallback chain:** project `score.json` → `~/.score/config.json` (global defaults) → OS system default.
+
+**Score Studio Settings panel** (gear icon):
+- Audio output selector — populated via `navigator.mediaDevices.enumerateDevices()` / `AudioContext.sinkId`
+- Audio input selector — for LiveIn / live recording (ADR cross-ref: LiveIn feature)
+- MIDI device checklist — all detected MIDI inputs; checked items are active
+
+Changes write to `score.json` immediately. No restart required — the backend layer creates a new `AudioContext` with the updated `sinkId` on next eval.
+
+**CLI commands:**
+
+```
+score devices                            # list all detected audio + MIDI devices
+score config set audioOutput "Focusrite USB Audio"   # set global default
+score config set audioInput  "Focusrite USB Audio"
+score config get audioOutput             # read current value
+```
+
+`score devices` reads from `navigator.mediaDevices` in the Node web-audio-api polyfill layer (ADR 010).
+
+---
+
+## Consequences
+
+**Positive:**
+- Audio interface selection survives project restarts — stored, not ephemeral
+- `~/.score/config.json` global defaults mean a new project inherits the user's preferred device without reconfiguration
+- MIDI device checklist enables multi-device setups (keyboard + pad controller simultaneously)
+- `score devices` gives CLI users the same device visibility as GUI users
+
+**Negative:**
+- `AudioContext.setSinkId()` is not yet supported in all Electron versions — requires version gating or fallback
+- Device names are OS strings — they can change when the device is reconnected or renamed
+- The Node polyfill layer (node-web-audio-api) has limited MIDI device enumeration support; CLI MIDI listing may be incomplete on some platforms
+
+---
+
+## Alternatives Considered
+
+- **Hard-code to system default** — zero configuration. Rejected: immediately wrong for every studio setup.
+- **Separate device config file** (e.g. `~/.score/devices.json` only) — no per-project override. Rejected: different projects may target different hardware (studio interface vs. laptop speakers for a live set).
+- **Environment variable for audio device** — `SCORE_AUDIO_OUTPUT=...`. Rejected: not discoverable in the GUI; duplicates the config system.

--- a/docs/adr/025-onboarding-first-run.md
+++ b/docs/adr/025-onboarding-first-run.md
@@ -1,0 +1,61 @@
+# ADR 025 — Onboarding and First-Run Experience
+
+**Date:** 2026-03-23
+**Status:** Proposed
+**Deciders:** Project owner
+
+---
+
+## Context
+
+Testers are not all developers. A musician opening Score Studio for the first time has no frame of reference for AudioContext, sinkId, or eval cycles. Without a first-run experience, they will hear silence, have no idea why, and close the app. The onboarding must bridge the gap between "musician installing a new DAW" and "Score user writing their first track" — without condescending or hiding Score's code-first nature.
+
+---
+
+## Decision
+
+**First-run detection:** absence of `~/.score/config.json`. Score Studio shows a 3-step wizard on first launch only.
+
+**Step 1 — Audio device selection:**
+- Dropdown: pick output device (pre-populated from `enumerateDevices()`)
+- "Test" button plays a 440 Hz sine tone through the selected device
+- Selection writes `audioOutput` to `~/.score/config.json`
+
+**Step 2 — Sample pack:**
+- Offers a curated list of free samples (links to freesound.org and looperman)
+- No audio files are bundled with Score (ADR rule) — links open in the system browser
+- User may skip; a notice explains that Score generates synthesis without samples
+
+**Step 3 — Open or create:**
+- "Open tutorial song" — loads `examples/tutorial.ts` from the Score install directory
+- "New song" — creates a new blank project directory (ADR 016)
+- "Skip" — opens Score Studio with no project
+
+**Tutorial song** (`examples/tutorial.ts`): a simple 4-bar techno loop. Every line is commented, explaining the DSL concept it demonstrates. The tutorial is a real song, not a mock — it plays and sounds correct.
+
+**CLI:** `score doctor` doubles as first-run setup. If `~/.score/config.json` is absent or incomplete, it prompts interactively for audio device selection before running diagnostics.
+
+**Re-triggering:** the wizard does not appear on subsequent launches. Settings > Reset Onboarding restores it.
+
+---
+
+## Consequences
+
+**Positive:**
+- Musician testers hear sound within 60 seconds of installing
+- Audio device is configured correctly before the first eval — no silent confusion
+- Tutorial song teaches DSL idioms without a separate documentation step
+- `score doctor` first-run path means CLI users also get guided setup
+
+**Negative:**
+- Wizard adds UI surface that must be maintained as the DSL evolves — tutorial song requires updates on breaking DSL changes
+- Sample pack step is a link-out, not a one-click install — slightly disjointed UX
+- Wizard state (`~/.score/config.json` presence) is a side-channel detection — a misconfigured install could suppress the wizard unexpectedly
+
+---
+
+## Alternatives Considered
+
+- **No onboarding — docs only** — link to a README. Rejected: musicians do not read readmes before opening an app.
+- **Bundled sample pack** — include 50 MB of starter samples. Rejected: violates the no-bundled-audio rule; increases installer size significantly.
+- **Video tutorial instead of wizard** — embed a walkthrough video. Rejected: video goes stale with every DSL change; the tutorial song is self-maintaining.


### PR DESCRIPTION
## Summary
- ADR 015: GUI three-tier progressive disclosure (Quick Strip → Instrument Panel → Full Chain)
- ADR 016: Project file format + autosave
- ADR 017: Undo/redo — immutable code-string history (no command pattern)
- ADR 018: Export formats — WAV/MP3/stems/MIDI
- ADR 019: Distribution — npm global + Electron installer + Homebrew tap
- ADR 020: Song file versioning + migration
- ADR 021: Real-time collaboration via WebRTC OT (not scheduled)
- ADR 022: Score Registry — git-repo-indexed sharing (not scheduled)
- ADR 023: Keyboard shortcuts — centralized registry
- ADR 024: Audio/MIDI device configuration
- ADR 025: Onboarding + first-run wizard

## Test plan
- [ ] Docs only — no code changes, no tests needed
- [ ] Review ADR decisions for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)