### PR TITLE
feat(gui): InstrumentPanel + InstrumentPicker components

### DIFF
--- a/docs/spec/GUI_COMPONENT_STANDARD.md
+++ b/docs/spec/GUI_COMPONENT_STANDARD.md
@@ -1,0 +1,209 @@
+# GUI Component Standard — Score Studio
+
+> Maintained by the Score team. All GUI components in `packages/gui` must follow these standards.
+> These apply to both `src/renderer/` React components and `src/main/` Electron code.
+
+---
+
+## Core Principle
+
+Score Studio follows the same functional philosophy as the audio engine:
+**no classes, no mutation, const + arrow functions only.**
+
+The GUI is a pure function of state. Components receive props, render output, fire callbacks.
+No component owns state it doesn't need — lift state to the minimum common ancestor.
+
+---
+
+## React Component Rules
+
+### 1. Functional components only
+
+```typescript
+// ✓ Correct
+export const MixerStrip = (props: MixerStripProps): JSX.Element => {
+  return <div>...</div>
+}
+
+// ✗ Never use
+export class MixerStrip extends React.Component { ... }
+export const MixerStrip: React.FC<MixerStripProps> = (props) => { ... }  // No React.FC
+```
+
+### 2. Props are always `readonly`
+
+```typescript
+// ✓ Correct — all fields readonly
+export type MixerStripProps = {
+  readonly name:     string
+  readonly volume:   number
+  readonly onVolume: (v: number) => void
+}
+
+// ✗ Avoid mutable props
+export type MixerStripProps = {
+  name: string  // mutable — will not be linted but is wrong by convention
+}
+```
+
+### 3. No React.FC
+
+`React.FC` implicitly adds `children` to props and has other subtle issues.
+Declare props explicitly with a named type and let TypeScript infer the return.
+
+### 4. Named exports only
+
+```typescript
+// ✓ Correct — named export
+export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => { ... }
+export type { InstrumentPanelProps }
+
+// ✗ No default exports from component files
+export default InstrumentPanel  // don't do this
+```
+
+### 5. One component per file
+
+Each `.tsx` file exports one primary component. Supporting sub-components
+(small presentational fragments) may co-exist in the same file but should be
+unexported unless they are independently useful.
+
+---
+
+## Styling Rules
+
+### Inline styles for dynamic values, class names for static layout
+
+Score Studio uses no CSS-in-JS library (no emotion, styled-components, etc.).
+
+```typescript
+// ✓ Dynamic value → inline style
+<div style={{ opacity: muted ? 0.4 : 1, backgroundColor: accent }} />
+
+// ✓ Static layout → inline style object constant or className
+const styles = {
+  strip: { display: 'flex', flexDirection: 'column' as const, width: 56 },
+} as const
+<div style={styles.strip} />
+```
+
+Keep style objects outside the render function (as `const` at module level)
+to avoid object recreation on every render.
+
+---
+
+## Accessibility Rules
+
+Every interactive element must have an accessible name. This is both a usability
+requirement and a testability requirement — tests use `getByRole({ name: })` to find
+interactive elements. If the element has no accessible name, the test can't find it.
+
+```typescript
+// ✓ Accessible mute button
+<button
+  aria-label={`Mute ${trackName}`}
+  aria-pressed={muted}
+  onClick={onMute}
+>
+  M
+</button>
+
+// ✓ Accessible slider
+<label htmlFor={`vol-${trackIndex}`}>Volume</label>
+<input
+  id={`vol-${trackIndex}`}
+  type="range"
+  min={0} max={1} step={0.01}
+  value={volume}
+  onChange={e => onVolume(parseFloat(e.target.value))}
+/>
+
+// ✗ Inaccessible — no name, no label
+<button onClick={onMute}>M</button>
+<input type="range" onChange={...} />
+```
+
+---
+
+## Electron IPC Rules
+
+**Never import directly from `'electron'` in renderer code.** The renderer process
+does not have direct access to the Electron API. All IPC goes through the preload bridge.
+
+```typescript
+// ✓ Correct — use the preload bridge
+window.electron.ipcRenderer.send('transport:play')
+window.electron.ipcRenderer.on('engine:state', handler)
+
+// ✗ Never do this in renderer
+import { ipcRenderer } from 'electron'  // breaks in renderer process
+```
+
+**IPC channels are typed.** All channel names and payloads are defined in
+`packages/gui/src/main/ipc-types.ts`. Never use string literals for channel names
+outside that file — import the type.
+
+---
+
+## State Management Rules
+
+### Lift state minimally
+
+Don't add state to a component unless it owns that state. If two components need
+the same state, lift it to their common ancestor.
+
+### Callbacks, not shared state
+
+Components communicate upward via callbacks (`onVolume`, `onMute`, `onChange`).
+They never reach into sibling or parent components.
+
+### `useEffect` discipline
+
+- One concern per `useEffect`
+- Always include a cleanup function if registering listeners or timers
+- Dependencies array must be complete — no `eslint-disable` for exhaustive-deps
+
+```typescript
+// ✓ Cleanup always provided
+useEffect(() => {
+  const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+  window.addEventListener('keydown', handler)
+  return () => window.removeEventListener('keydown', handler)
+}, [onClose])
+```
+
+---
+
+## File Structure
+
+```
+packages/gui/
+├─ src/
+│  ├─ renderer/
+│  │  ├─ components/
+│  │  │  ├─ shared/         # Reusable components (MixerStrip, InstrumentPanel, etc.)
+│  │  │  └─ <FeatureName>/  # Feature-specific (LiveCode/, SplashScreen/, etc.)
+│  │  └─ lib/               # Pure renderer utilities (codePatcher, getActiveLines)
+│  └─ main/                 # Electron main process
+│     ├─ index.ts           # Main entry + IPC handlers
+│     └─ ipc-types.ts       # Shared IPC channel type definitions
+└─ tests/
+   ├─ setup.ts              # Global test setup (canvas mock, IPC mock)
+   └─ *.test.tsx            # One per component/utility
+```
+
+---
+
+## Component Checklist (before submitting a PR)
+
+- [ ] Functional component, `const` + arrow, no class
+- [ ] Props typed as `readonly` named type (exported)
+- [ ] All interactive elements have accessible names
+- [ ] No direct `import ... from 'electron'` in renderer
+- [ ] Style constants defined outside render
+- [ ] `useEffect` cleanups present for all listeners/timers
+- [ ] Test file exists with: rendering, interactions, props variants, edge cases
+- [ ] Tests use `userEvent` not `fireEvent`
+- [ ] Tests query by role/label/text (not `data-testid` unless necessary)
+- [ ] `pnpm --filter @score/gui test` passes
+- [ ] `pnpm --filter @score/gui typecheck` passes

--- a/docs/spec/GUI_TESTING_STANDARD.md
+++ b/docs/spec/GUI_TESTING_STANDARD.md
@@ -1,0 +1,216 @@
+# GUI Testing Standard — Score Studio
+
+> Maintained by the Score team. Update this document when new patterns are established.
+> All GUI tests must follow these standards. PRs that add components without tests will be rejected.
+
+---
+
+## Philosophy (Kent C. Dodds)
+
+> "The more your tests resemble the way your software is used, the more confidence they give you."
+
+Tests prove the component *works for the user*, not that it *exists as written*.
+Test behavior. Never test implementation details (internal state, CSS classes, refs).
+
+---
+
+## Testing Pyramid
+
+```
+          ┌─────────────┐
+          │     E2E     │  Playwright — full Electron app, critical journeys
+          ├─────────────┤  Phase 15+ (planned)
+          │ Integration │  Multi-component flows, IPC-mocked end-to-end
+          ├─────────────┤
+          │  Component  │  React Testing Library — current primary layer
+          ├─────────────┤
+          │    Unit     │  Pure functions only (codePatcher, math helpers)
+          └─────────────┘
+```
+
+### Unit tests
+- For pure functions only: `codePatcher.ts`, `getActiveLines()`, `noteHz()`, etc.
+- No DOM, no React — just function input/output
+- Fast: all unit tests should complete in <1s total
+
+### Component tests (React Testing Library)
+- One test file per component: `Foo.tsx` → `Foo.test.tsx`
+- Test from the user's perspective: what they see and what they can do
+- Mock only: IPC bridge (`window.electron`), canvas APIs, timers
+
+### Integration tests
+- Multi-component: e.g. LiveCode + MixerStrip + engine IPC all wired
+- Mock the main-process IPC handler, let the renderer flow naturally
+- Test user journeys: "user evals code → mixer strips appear → user drags fader → volume changes"
+
+### E2E tests (Planned — Phase 15+)
+- Framework: [Playwright](https://playwright.dev/) + [electron-playwright-helpers](https://github.com/spaceagetv/electron-playwright-helpers)
+- Target journeys (not implementation):
+  - Eval a song → audio engine boots → bar counter increments
+  - Adjust BPM via slider → BPM in code updates
+  - Export to WAV → file appears on disk
+  - Open a `.score` file → code loads in editor
+- Do NOT test individual component interactions in E2E — those belong in component tests
+
+---
+
+## TDD Workflow (Required for all new components)
+
+```
+1. Write the test file (failing) — describes the contract
+2. Run: pnpm --filter @score/gui test → see RED
+3. Write the minimum component code to pass
+4. Run tests → GREEN
+5. Refactor → tests still GREEN
+```
+
+No new component ships without a passing test file. No exceptions.
+
+---
+
+## Query Priority
+
+Use the highest-confidence query available. In order of preference:
+
+| Priority | Query | When to use |
+|----------|-------|-------------|
+| 1 | `getByRole('button', { name: /mute/i })` | All interactive elements |
+| 2 | `getByLabelText(/volume/i)` | Form inputs with labels |
+| 3 | `getByText(/kick/i)` | Static displayed text |
+| 4 | `getByPlaceholderText` | Inputs with placeholder only |
+| 5 | `getByTestId` | **Last resort only** — non-semantic elements (canvases, custom widgets) |
+
+Never query by className, id, or style. If you can't query without a `data-testid`,
+add an `aria-label` to the element instead.
+
+---
+
+## `userEvent` over `fireEvent`
+
+`fireEvent` fires a single synthetic DOM event. Real users fire a sequence
+(pointerdown → pointerup → click → focus changes). Use `userEvent` for all interactions.
+
+```typescript
+// ✗ Do NOT use
+import { fireEvent } from '@testing-library/react'
+fireEvent.click(button)
+fireEvent.change(input, { target: { value: '0.5' } })
+
+// ✓ Use this
+import userEvent from '@testing-library/user-event'
+const user = userEvent.setup()
+await user.click(button)
+await user.clear(input)
+await user.type(input, '0.5')
+```
+
+Note: `userEvent.setup()` must be called *before* `render()` in v14.
+
+---
+
+## Standard Test Structure
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen }                        from '@testing-library/react'
+import userEvent                                 from '@testing-library/user-event'
+import { MyComponent }                           from '../src/renderer/components/shared/MyComponent.js'
+import type { MyComponentProps }                 from '../src/renderer/components/shared/MyComponent.js'
+
+// ── Default props ─────────────────────────────────────────────────────────────
+
+const defaultProps: MyComponentProps = {
+  // Required props with sensible defaults
+}
+
+// ── Setup helper ─────────────────────────────────────────────────────────────
+
+const setup = (overrides: Partial<MyComponentProps> = {}) => {
+  const user = userEvent.setup()
+  const result = render(<MyComponent {...defaultProps} {...overrides} />)
+  return { user, ...result }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('MyComponent — rendering', () => {
+  it('renders the component name or key content', () => {
+    setup()
+    expect(screen.getByText('Expected Text')).toBeInTheDocument()
+  })
+})
+
+describe('MyComponent — interactions', () => {
+  it('calls onSomething when button clicked', async () => {
+    const onSomething = vi.fn()
+    const { user } = setup({ onSomething })
+    await user.click(screen.getByRole('button', { name: /something/i }))
+    expect(onSomething).toHaveBeenCalledOnce()
+  })
+})
+
+describe('MyComponent — props variants', () => {
+  it('does not crash with minimal props', () => {
+    expect(() => setup()).not.toThrow()
+  })
+})
+```
+
+---
+
+## What NOT to Test
+
+- ✗ CSS class names or inline styles
+- ✗ Internal React state
+- ✗ Whether a component re-renders
+- ✗ Ref values
+- ✗ Implementation details of child components (test those separately)
+- ✗ That a function was called with `new` (never relevant in functional components)
+
+---
+
+## Accessibility Requirements
+
+Every interactive element must have an accessible name. Tests verify this implicitly
+by using `getByRole` with `{ name: }`. If `getByRole` can't find it, the element
+lacks an accessible name — fix the component, not the test.
+
+```typescript
+// ✓ Button with aria-label
+<button aria-label="Mute kick track" onClick={onMute}>M</button>
+
+// ✓ Input with visible label
+<label htmlFor="vol-0">Volume</label>
+<input id="vol-0" type="range" />
+
+// ✓ Input with aria-label (when visible label not feasible)
+<input type="range" aria-label="Volume" />
+```
+
+---
+
+## Mocking Canvas and IPC
+
+```typescript
+// In tests/setup.ts (already configured):
+// - HTMLCanvasElement.getContext() → mock returns null
+// - ResizeObserver → mock stub
+// - window.electron → mock IPC bridge
+
+// To mock IPC in a specific test:
+vi.spyOn(window.electron.ipcRenderer, 'on').mockImplementation(...)
+vi.spyOn(window.electron.ipcRenderer, 'send').mockImplementation(vi.fn())
+```
+
+---
+
+## Coverage Thresholds (enforced in CI)
+
+| Metric | Threshold |
+|--------|-----------|
+| Statements | 90% |
+| Branches | 85% |
+| Functions | 90% |
+| Lines | 90% |
+
+New components must not reduce coverage below these thresholds.

--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -394,7 +394,7 @@ ipcMain.on('engine:eval', (_event, { code }: RendererToMain['engine:eval']) => {
     [key: string]: unknown
   }
 
-  const context: VmContext = vm.createContext({
+  const contextObj: Record<string, unknown> = {
     // DSL — percussion + legacy instruments
     Song, Track, Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp, resolveFreq,
     Kick808, Kick909, Snare909, Hihat808, SubSynth, FMSynth,
@@ -417,7 +417,8 @@ ipcMain.on('engine:eval', (_event, { code }: RendererToMain['engine:eval']) => {
     Math, console,
     // Export capture
     __exports__: null,
-  }) as VmContext
+  }
+  const context = vm.createContext(contextObj) as VmContext
 
   try {
     vm.runInContext(scriptCode, context, { timeout: 5000, filename: 'score-live.vm' })

--- a/packages/gui/src/renderer/components/shared/InstrumentPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPanel.tsx
@@ -1,0 +1,213 @@
+// InstrumentPanel.tsx — Per-track instrument parameter panel.
+//
+// Renders instrument-type-specific controls: labeled range sliders + mute button.
+// Each slider fires onChange(method, value) where method is a chain API method name
+// (e.g. 'volume', 'reverb', 'filter'). The consumer wires onChange to patchChainMethod.
+//
+// No audio, no IPC — pure props in, callbacks out.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Props for {@link InstrumentPanel}. */
+export type InstrumentPanelProps = {
+  /** Zero-based track index — used for unique input IDs. */
+  readonly trackIndex:     number
+  /** DSL instrument type string, e.g. 'kick', 'synth', 'bass303'. */
+  readonly instrumentType: string
+  /** Display name for the track (shown at top of panel). */
+  readonly trackName:      string
+  /** Current parameter values keyed by chain API method name. */
+  readonly params:         Record<string, number | string>
+  /** Whether this track is currently muted. */
+  readonly muted:          boolean
+  /**
+   * Called when a control changes.
+   * @param method - Chain API method name, e.g. `'volume'`, `'reverb'`, `'filter'`.
+   * @param value  - New value (number or string).
+   */
+  readonly onChange:  (method: string, value: number | string) => void
+  /** Called when the mute button is clicked. */
+  readonly onMute:    () => void
+}
+
+// ── Internal control types ────────────────────────────────────────────────────
+
+type SliderControl = {
+  readonly kind:    'slider'
+  readonly label:   string
+  readonly method:  string
+  readonly min:     number
+  readonly max:     number
+  readonly step:    number
+  readonly default: number
+}
+
+type CheckboxControl = {
+  readonly kind:   'checkbox'
+  readonly label:  string
+  readonly method: string
+}
+
+type Control = SliderControl | CheckboxControl
+
+const slider = (
+  label: string, method: string, min: number, max: number, step: number, def: number,
+): SliderControl => ({ kind: 'slider', label, method, min, max, step, default: def })
+
+const checkbox = (label: string, method: string): CheckboxControl =>
+  ({ kind: 'checkbox', label, method })
+
+// ── Control definitions per instrument type ───────────────────────────────────
+
+const FALLBACK_CONTROLS: readonly Control[] = [
+  slider('Volume', 'volume', 0, 1, 0.01, 0.8),
+  slider('Reverb', 'reverb', 0, 1, 0.01, 0),
+]
+
+const CONTROLS: Record<string, readonly Control[]> = {
+  kick:    [slider('Volume', 'volume', 0, 1, 0.01, 0.85), slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Decay', 'decay', 0.1, 2, 0.01, 0.5),  slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  kick808: [slider('Volume', 'volume', 0, 1, 0.01, 0.85), slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Decay', 'decay', 0.1, 2, 0.01, 0.5),  slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  kick909: [slider('Volume', 'volume', 0, 1, 0.01, 0.85), slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Decay', 'decay', 0.1, 2, 0.01, 0.5),  slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  snare:   [slider('Volume', 'volume', 0, 1, 0.01, 0.7),  slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Snappy', 'sustain', 0, 1, 0.01, 0.5), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  snare909:[slider('Volume', 'volume', 0, 1, 0.01, 0.7),  slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Snappy', 'sustain', 0, 1, 0.01, 0.5), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  hihat:   [slider('Volume', 'volume', 0, 1, 0.01, 0.4),  slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Decay', 'decay', 0.1, 2, 0.01, 0.1),  checkbox('Open', 'open')],
+  hihat808:[slider('Volume', 'volume', 0, 1, 0.01, 0.4),  slider('Tune', 'pitch', -24, 24, 1, 0),    slider('Decay', 'decay', 0.1, 2, 0.01, 0.1),  checkbox('Open', 'open')],
+  bass303: [slider('Volume', 'volume', 0, 1, 0.01, 0.8),  slider('Filter', 'filter', 100, 8000, 10, 800), slider('Resonance', 'resonance', 0, 30, 0.1, 0.5), slider('Wobble', 'wobble', 0, 1, 0.01, 0)],
+  synth:   [slider('Volume', 'volume', 0, 1, 0.01, 0.6),  slider('Filter', 'filter', 100, 8000, 10, 2000), slider('Attack', 'attack', 0.01, 2, 0.01, 0.01), slider('Release', 'release', 0.1, 4, 0.01, 0.3), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  subsynth:[slider('Volume', 'volume', 0, 1, 0.01, 0.6),  slider('Filter', 'filter', 100, 8000, 10, 2000), slider('Attack', 'attack', 0.01, 2, 0.01, 0.01), slider('Release', 'release', 0.1, 4, 0.01, 0.3), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  fmsynth: [slider('Volume', 'volume', 0, 1, 0.01, 0.6),  slider('Filter', 'filter', 100, 8000, 10, 2000), slider('Attack', 'attack', 0.01, 2, 0.01, 0.01), slider('Release', 'release', 0.1, 4, 0.01, 0.3), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+  pad:     [slider('Volume', 'volume', 0, 1, 0.01, 0.6),  slider('Filter', 'filter', 100, 8000, 10, 2000), slider('Attack', 'attack', 0.01, 2, 0.01, 0.3),  slider('Release', 'release', 0.1, 4, 0.01, 1.0),  slider('Reverb', 'reverb', 0, 1, 0.01, 0.2)],
+  pluck:   [slider('Volume', 'volume', 0, 1, 0.01, 0.6),  slider('Filter', 'filter', 100, 8000, 10, 2000), slider('Attack', 'attack', 0.01, 2, 0.01, 0.005), slider('Release', 'release', 0.1, 4, 0.01, 0.4), slider('Reverb', 'reverb', 0, 1, 0.01, 0)],
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = {
+  panel: {
+    display: 'flex', flexDirection: 'row' as const, alignItems: 'center',
+    gap: 12, padding: '6px 10px', background: '#111', borderTop: '1px solid #222',
+    minHeight: 48,
+  },
+  nameSection: {
+    display: 'flex', flexDirection: 'column' as const, alignItems: 'flex-start',
+    gap: 4, minWidth: 64,
+  },
+  trackName: {
+    fontSize: 10, color: '#aaa', fontFamily: 'monospace', whiteSpace: 'nowrap' as const,
+    overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 60,
+  },
+  muteBtn: (muted: boolean) => ({
+    width: 28, height: 18, fontSize: 9, fontFamily: 'monospace',
+    background: muted ? '#ffcc00' : '#222', color: muted ? '#000' : '#aaa',
+    border: '1px solid #333', borderRadius: 2, cursor: 'pointer', padding: 0,
+  }),
+  controlsRow: {
+    display: 'flex', flexDirection: 'row' as const, alignItems: 'center',
+    gap: 10, flexWrap: 'wrap' as const,
+  },
+  control: {
+    display: 'flex', flexDirection: 'column' as const, alignItems: 'flex-start', gap: 2,
+  },
+  label: { fontSize: 9, color: '#666', fontFamily: 'monospace', userSelect: 'none' as const },
+  value: { fontSize: 9, color: '#888', fontFamily: 'monospace', minWidth: 32 },
+  slider: {
+    width: 60, height: 16, accentColor: '#4a8fff',
+  },
+  checkboxRow: {
+    display: 'flex', flexDirection: 'row' as const, alignItems: 'center', gap: 4,
+  },
+} as const
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+/**
+ * Per-track instrument parameter panel.
+ *
+ * Renders instrument-type-specific controls: labeled sliders and toggles.
+ * Each control fires `onChange(method, value)` — the consumer wires this
+ * to `patchChainMethod` from `codePatcher.ts` to update the live code.
+ *
+ * @example
+ * ```tsx
+ * <InstrumentPanel
+ *   trackIndex={0}
+ *   instrumentType="kick"
+ *   trackName="Kick"
+ *   params={{}}
+ *   muted={false}
+ *   onChange={(method, value) => patchChainMethod(code, 0, method, value)}
+ *   onMute={() => toggleMute(0)}
+ * />
+ * ```
+ */
+export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => {
+  const { trackIndex, instrumentType, trackName, params, muted, onChange, onMute } = props
+  const controls = CONTROLS[instrumentType] ?? FALLBACK_CONTROLS
+
+  return (
+    <div style={styles.panel} data-testid={`instrument-panel-${trackIndex}`}>
+
+      {/* Track name + mute */}
+      <div style={styles.nameSection}>
+        <span style={styles.trackName}>{trackName}</span>
+        <button
+          style={styles.muteBtn(muted)}
+          aria-label={`Mute ${trackName}`}
+          aria-pressed={muted}
+          onClick={onMute}
+        >
+          {muted ? 'M' : 'm'}
+        </button>
+      </div>
+
+      {/* Controls */}
+      <div style={styles.controlsRow}>
+        {controls.map(ctrl => {
+          const inputId = `panel-${trackIndex}-${ctrl.method}`
+
+          if (ctrl.kind === 'checkbox') {
+            const checked = Boolean(params[ctrl.method] ?? 0)
+            return (
+              <div key={ctrl.method} style={styles.control}>
+                <div style={styles.checkboxRow}>
+                  <input
+                    id={inputId}
+                    type="checkbox"
+                    aria-label={ctrl.label}
+                    checked={checked}
+                    onChange={e => onChange(ctrl.method, e.target.checked ? 1 : 0)}
+                  />
+                  <label htmlFor={inputId} style={styles.label}>{ctrl.label}</label>
+                </div>
+              </div>
+            )
+          }
+
+          const val = typeof params[ctrl.method] === 'number'
+            ? params[ctrl.method] as number
+            : ctrl.default
+
+          return (
+            <div key={ctrl.method} style={styles.control}>
+              <div style={{ display: 'flex', flexDirection: 'row', gap: 4 }}>
+                <label htmlFor={inputId} style={styles.label}>{ctrl.label}</label>
+                <span style={styles.value}>{val.toFixed(ctrl.step < 1 ? 2 : 0)}</span>
+              </div>
+              <input
+                id={inputId}
+                type="range"
+                aria-label={ctrl.label}
+                style={styles.slider}
+                min={ctrl.min}
+                max={ctrl.max}
+                step={ctrl.step}
+                value={val}
+                onChange={e => onChange(ctrl.method, parseFloat(e.target.value))}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/gui/src/renderer/components/shared/InstrumentPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPanel.tsx
@@ -6,6 +6,8 @@
 //
 // No audio, no IPC — pure props in, callbacks out.
 
+import React from 'react'
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /** Props for {@link InstrumentPanel}. */
@@ -140,12 +142,12 @@ const styles = {
  * />
  * ```
  */
-export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => {
+export const InstrumentPanel = (props: InstrumentPanelProps): React.JSX.Element => {
   const { trackIndex, instrumentType, trackName, params, muted, onChange, onMute } = props
   const controls = CONTROLS[instrumentType] ?? FALLBACK_CONTROLS
 
   return (
-    <div style={styles.panel} data-testid={`instrument-panel-${trackIndex}`}>
+    <div style={styles.panel} data-testid={`instrument-panel-${String(trackIndex)}`}>
 
       {/* Track name + mute */}
       <div style={styles.nameSection}>
@@ -163,7 +165,7 @@ export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => {
       {/* Controls */}
       <div style={styles.controlsRow}>
         {controls.map(ctrl => {
-          const inputId = `panel-${trackIndex}-${ctrl.method}`
+          const inputId = `panel-${String(trackIndex)}-${ctrl.method}`
 
           if (ctrl.kind === 'checkbox') {
             const checked = Boolean(params[ctrl.method] ?? 0)
@@ -175,7 +177,7 @@ export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => {
                     type="checkbox"
                     aria-label={ctrl.label}
                     checked={checked}
-                    onChange={e => onChange(ctrl.method, e.target.checked ? 1 : 0)}
+                    onChange={e => { onChange(ctrl.method, e.target.checked ? 1 : 0) }}
                   />
                   <label htmlFor={inputId} style={styles.label}>{ctrl.label}</label>
                 </div>
@@ -202,7 +204,7 @@ export const InstrumentPanel = (props: InstrumentPanelProps): JSX.Element => {
                 max={ctrl.max}
                 step={ctrl.step}
                 value={val}
-                onChange={e => onChange(ctrl.method, parseFloat(e.target.value))}
+                onChange={e => { onChange(ctrl.method, parseFloat(e.target.value)) }}
               />
             </div>
           )

--- a/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
@@ -5,7 +5,7 @@
 //
 // No audio, no IPC — pure props in, callbacks out.
 
-import { useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -98,13 +98,13 @@ const styles = {
  * />
  * ```
  */
-export const InstrumentPicker = (props: InstrumentPickerProps): JSX.Element => {
+export const InstrumentPicker = (props: InstrumentPickerProps): React.JSX.Element => {
   const { onPick, onClose } = props
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
     window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
+    return () => { window.removeEventListener('keydown', handler) }
   }, [onClose])
 
   const renderGroup = (entries: readonly InstrumentEntry[]) => (
@@ -114,7 +114,7 @@ export const InstrumentPicker = (props: InstrumentPickerProps): JSX.Element => {
           key={type}
           style={styles.instrBtn}
           aria-label={label}
-          onClick={() => onPick(type)}
+          onClick={() => { onPick(type) }}
         >
           {label}
         </button>

--- a/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
@@ -1,0 +1,152 @@
+// InstrumentPicker.tsx — Instrument selection modal.
+//
+// Renders a grid of instrument type buttons grouped by category.
+// Clicking a button fires onPick(instrumentType). Escape or close button fires onClose().
+//
+// No audio, no IPC — pure props in, callbacks out.
+
+import { useEffect } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Props for {@link InstrumentPicker}. */
+export type InstrumentPickerProps = {
+  /** Called when the user selects an instrument. @param instrumentType - DSL type string, e.g. `'kick'`. */
+  readonly onPick:  (instrumentType: string) => void
+  /** Called when the picker should be dismissed (Escape key or close button). */
+  readonly onClose: () => void
+}
+
+// ── Instrument catalogue ──────────────────────────────────────────────────────
+
+type InstrumentEntry = { readonly label: string; readonly type: string }
+
+const DRUMS: readonly InstrumentEntry[] = [
+  { label: 'Kick',    type: 'kick'    },
+  { label: 'Snare',   type: 'snare'   },
+  { label: 'HiHat',   type: 'hihat'   },
+  { label: 'Clap',    type: 'clap'    },
+  { label: 'Crash',   type: 'crash'   },
+  { label: 'Ride',    type: 'ride'    },
+]
+
+const MELODIC: readonly InstrumentEntry[] = [
+  { label: 'Bass303', type: 'bass303'  },
+  { label: 'SubSynth',type: 'subsynth' },
+  { label: 'Synth',   type: 'synth'   },
+  { label: 'Pad',     type: 'pad'     },
+  { label: 'Pluck',   type: 'pluck'   },
+  { label: 'FMSynth', type: 'fmsynth' },
+]
+
+const OTHER: readonly InstrumentEntry[] = [
+  { label: 'Sample',  type: 'sample'  },
+  { label: 'Arp',     type: 'arp'     },
+]
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = {
+  overlay: {
+    position: 'fixed' as const, inset: 0,
+    background: 'rgba(0,0,0,0.7)', display: 'flex',
+    alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+  },
+  modal: {
+    background: '#111', border: '1px solid #333', borderRadius: 6,
+    padding: '16px 20px', minWidth: 340, position: 'relative' as const,
+  },
+  header: {
+    display: 'flex', flexDirection: 'row' as const,
+    alignItems: 'center', justifyContent: 'space-between', marginBottom: 14,
+  },
+  title: { fontSize: 12, color: '#ccc', fontFamily: 'monospace', fontWeight: 'bold' as const },
+  closeBtn: {
+    background: 'none', border: '1px solid #444', borderRadius: 2,
+    color: '#888', cursor: 'pointer', fontSize: 11, fontFamily: 'monospace',
+    padding: '2px 8px',
+  },
+  section: { marginBottom: 10 },
+  sectionLabel: {
+    fontSize: 9, color: '#555', fontFamily: 'monospace',
+    textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 6,
+  },
+  grid: {
+    display: 'flex', flexDirection: 'row' as const, flexWrap: 'wrap' as const, gap: 6,
+  },
+  instrBtn: {
+    background: '#1a1a1a', border: '1px solid #333', borderRadius: 3,
+    color: '#aaa', cursor: 'pointer', fontSize: 10, fontFamily: 'monospace',
+    padding: '4px 10px', minWidth: 56,
+  },
+} as const
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+/**
+ * Instrument selection modal.
+ *
+ * Renders a dark modal overlay with a grid of instrument type buttons grouped
+ * by category (Drums, Melodic, Other). Clicking a button fires `onPick(type)`.
+ * Pressing Escape or clicking the close button fires `onClose()`.
+ *
+ * @example
+ * ```tsx
+ * <InstrumentPicker
+ *   onPick={type => addTrack(type)}
+ *   onClose={() => setPickerOpen(false)}
+ * />
+ * ```
+ */
+export const InstrumentPicker = (props: InstrumentPickerProps): JSX.Element => {
+  const { onPick, onClose } = props
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const renderGroup = (entries: readonly InstrumentEntry[]) => (
+    <div style={styles.grid}>
+      {entries.map(({ label, type }) => (
+        <button
+          key={type}
+          style={styles.instrBtn}
+          aria-label={label}
+          onClick={() => onPick(type)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+
+  return (
+    <div style={styles.overlay} data-testid="instrument-picker-overlay">
+      <div style={styles.modal} role="dialog" aria-label="Pick an instrument">
+
+        <div style={styles.header}>
+          <span style={styles.title}>Add Instrument</span>
+          <button style={styles.closeBtn} aria-label="Close" onClick={onClose}>✕</button>
+        </div>
+
+        <div style={styles.section}>
+          <div style={styles.sectionLabel}>Drums</div>
+          {renderGroup(DRUMS)}
+        </div>
+
+        <div style={styles.section}>
+          <div style={styles.sectionLabel}>Melodic</div>
+          {renderGroup(MELODIC)}
+        </div>
+
+        <div style={styles.section}>
+          <div style={styles.sectionLabel}>Other</div>
+          {renderGroup(OTHER)}
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/packages/gui/tests/InstrumentPanel.test.tsx
+++ b/packages/gui/tests/InstrumentPanel.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi }  from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent                     from '@testing-library/user-event'
+import { axe }                       from './setup.js'
+import { InstrumentPanel }           from '../src/renderer/components/shared/InstrumentPanel.js'
+import type { InstrumentPanelProps } from '../src/renderer/components/shared/InstrumentPanel.js'
+
+// ── Default props ─────────────────────────────────────────────────────────────
+
+const defaultProps: InstrumentPanelProps = {
+  trackIndex:     0,
+  instrumentType: 'kick',
+  trackName:      'Kick',
+  params:         {},
+  muted:          false,
+  onChange:       vi.fn(),
+  onMute:         vi.fn(),
+}
+
+// ── Setup helper (Kent C. Dodds pattern) ─────────────────────────────────────
+
+const setup = (overrides: Partial<InstrumentPanelProps> = {}) => {
+  const user = userEvent.setup()
+  const result = render(<InstrumentPanel {...defaultProps} {...overrides} />)
+  return { user, ...result }
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('InstrumentPanel — rendering', () => {
+  it('renders the track name', () => {
+    setup()
+    expect(screen.getByText('Kick')).toBeInTheDocument()
+  })
+
+  it('renders a mute button with accessible name', () => {
+    setup()
+    expect(screen.getByRole('button', { name: /mute kick/i })).toBeInTheDocument()
+  })
+
+  it('renders a Volume slider for kick type', () => {
+    setup()
+    expect(screen.getByRole('slider', { name: /volume/i })).toBeInTheDocument()
+  })
+
+  it('renders a Reverb slider for kick type', () => {
+    setup()
+    expect(screen.getByRole('slider', { name: /reverb/i })).toBeInTheDocument()
+  })
+
+  it('renders a Tune slider for kick type', () => {
+    setup()
+    expect(screen.getByRole('slider', { name: /tune/i })).toBeInTheDocument()
+  })
+
+  it('renders a Decay slider for kick type', () => {
+    setup()
+    expect(screen.getByRole('slider', { name: /decay/i })).toBeInTheDocument()
+  })
+
+  it('renders Snappy slider for snare type', () => {
+    setup({ instrumentType: 'snare', trackName: 'Snare' })
+    expect(screen.getByRole('slider', { name: /snappy/i })).toBeInTheDocument()
+  })
+
+  it('renders Open toggle for hihat type', () => {
+    setup({ instrumentType: 'hihat', trackName: 'HiHat' })
+    expect(screen.getByRole('checkbox', { name: /open/i })).toBeInTheDocument()
+  })
+
+  it('renders Filter and Wobble sliders for bass303 type', () => {
+    setup({ instrumentType: 'bass303', trackName: 'Bass303' })
+    expect(screen.getByRole('slider', { name: /filter/i })).toBeInTheDocument()
+    expect(screen.getByRole('slider', { name: /wobble/i })).toBeInTheDocument()
+  })
+
+  it('renders Attack and Release sliders for synth type', () => {
+    setup({ instrumentType: 'synth', trackName: 'Synth' })
+    expect(screen.getByRole('slider', { name: /attack/i })).toBeInTheDocument()
+    expect(screen.getByRole('slider', { name: /release/i })).toBeInTheDocument()
+  })
+
+  it('renders Volume and Reverb for unknown instrument type (fallback)', () => {
+    setup({ instrumentType: 'unknown-future-instrument', trackName: 'Unknown' })
+    expect(screen.getByRole('slider', { name: /volume/i })).toBeInTheDocument()
+    expect(screen.getByRole('slider', { name: /reverb/i })).toBeInTheDocument()
+  })
+
+  it('shows muted state on mute button when muted=true', () => {
+    setup({ muted: true })
+    const btn = screen.getByRole('button', { name: /mute kick/i })
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('shows unmuted state when muted=false', () => {
+    setup({ muted: false })
+    const btn = screen.getByRole('button', { name: /mute kick/i })
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+  })
+})
+
+// ── Interactions ──────────────────────────────────────────────────────────────
+
+describe('InstrumentPanel — interactions', () => {
+  it('calls onMute when mute button is clicked', async () => {
+    const onMute = vi.fn()
+    const { user } = setup({ onMute })
+    await user.click(screen.getByRole('button', { name: /mute kick/i }))
+    expect(onMute).toHaveBeenCalledOnce()
+  })
+
+  it('calls onChange with method "volume" when Volume slider changes', () => {
+    const onChange = vi.fn()
+    setup({ onChange })
+    const slider = screen.getByRole('slider', { name: /volume/i })
+    // fireEvent.change is the accepted approach for range inputs —
+    // userEvent has no range-slide API and jsdom range inputs are not interactable
+    fireEvent.change(slider, { target: { value: '0.7' } })
+    expect(onChange).toHaveBeenCalledWith('volume', 0.7)
+  })
+
+  it('calls onChange with method "reverb" when Reverb slider changes', () => {
+    const onChange = vi.fn()
+    setup({ onChange })
+    const slider = screen.getByRole('slider', { name: /reverb/i })
+    fireEvent.change(slider, { target: { value: '0.3' } })
+    expect(onChange).toHaveBeenCalledWith('reverb', 0.3)
+  })
+
+  it('calls onChange with method "open" and value 1 when Open checkbox checked', async () => {
+    const onChange = vi.fn()
+    const { user } = setup({ instrumentType: 'hihat', trackName: 'HiHat', onChange })
+    await user.click(screen.getByRole('checkbox', { name: /open/i }))
+    expect(onChange).toHaveBeenCalledWith('open', 1)
+  })
+
+  it('calls onChange with method "open" and value 0 when Open checkbox unchecked', async () => {
+    const onChange = vi.fn()
+    const { user } = setup({ instrumentType: 'hihat', trackName: 'HiHat', onChange, params: { open: 1 } })
+    const checkbox = screen.getByRole('checkbox', { name: /open/i })
+    await user.click(checkbox)
+    expect(onChange).toHaveBeenCalledWith('open', 0)
+  })
+})
+
+// ── Accessibility ─────────────────────────────────────────────────────────────
+
+describe('InstrumentPanel — accessibility', () => {
+  it('has no axe violations for kick type', async () => {
+    const { container } = setup()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no axe violations for bass303 type', async () => {
+    const { container } = setup({ instrumentType: 'bass303', trackName: 'Bass303' })
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ── Props variants ────────────────────────────────────────────────────────────
+
+describe('InstrumentPanel — props variants', () => {
+  it('does not crash with empty params', () => {
+    expect(() => setup({ params: {} })).not.toThrow()
+  })
+
+  it('does not crash with kick808 type', () => {
+    expect(() => setup({ instrumentType: 'kick808', trackName: 'Kick 808' })).not.toThrow()
+  })
+
+  it('does not crash with kick909 type', () => {
+    expect(() => setup({ instrumentType: 'kick909', trackName: 'Kick 909' })).not.toThrow()
+  })
+
+  it('does not crash with snare909 type', () => {
+    expect(() => setup({ instrumentType: 'snare909', trackName: 'Snare 909' })).not.toThrow()
+  })
+
+  it('does not crash with subsynth type', () => {
+    expect(() => setup({ instrumentType: 'subsynth', trackName: 'Sub' })).not.toThrow()
+  })
+})

--- a/packages/gui/tests/InstrumentPicker.test.tsx
+++ b/packages/gui/tests/InstrumentPicker.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi }  from 'vitest'
+import { render, screen }            from '@testing-library/react'
+import userEvent                     from '@testing-library/user-event'
+import { axe }                       from './setup.js'
+import { InstrumentPicker }          from '../src/renderer/components/shared/InstrumentPicker.js'
+import type { InstrumentPickerProps } from '../src/renderer/components/shared/InstrumentPicker.js'
+
+// ── Default props ─────────────────────────────────────────────────────────────
+
+const defaultProps: InstrumentPickerProps = {
+  onPick:  vi.fn(),
+  onClose: vi.fn(),
+}
+
+// ── Setup helper (Kent C. Dodds pattern) ─────────────────────────────────────
+
+const setup = (overrides: Partial<InstrumentPickerProps> = {}) => {
+  const user = userEvent.setup()
+  const result = render(<InstrumentPicker {...defaultProps} {...overrides} />)
+  return { user, ...result }
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('InstrumentPicker — rendering', () => {
+  it('renders drum instrument buttons', () => {
+    setup()
+    expect(screen.getByRole('button', { name: /kick/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /snare/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hi.?hat/i })).toBeInTheDocument()
+  })
+
+  it('renders melodic instrument buttons', () => {
+    setup()
+    expect(screen.getByRole('button', { name: /bass ?303/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^synth$/i })).toBeInTheDocument()
+  })
+
+  it('renders all instrument labels', () => {
+    setup()
+    // Use exact string matching to avoid partial matches (e.g. "Synth" vs "SubSynth")
+    const labels = ['Kick', 'Snare', 'HiHat', 'Bass303', 'Synth', 'Pad', 'Pluck', 'FMSynth']
+    for (const label of labels) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it('renders a close button', () => {
+    setup()
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument()
+  })
+})
+
+// ── Interactions ──────────────────────────────────────────────────────────────
+
+describe('InstrumentPicker — interactions', () => {
+  it('calls onPick with "kick" when Kick button is clicked', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /kick/i }))
+    expect(onPick).toHaveBeenCalledWith('kick')
+  })
+
+  it('calls onPick with "snare" when Snare button is clicked', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /snare/i }))
+    expect(onPick).toHaveBeenCalledWith('snare')
+  })
+
+  it('calls onPick with "bass303" when Bass303 button is clicked', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /bass ?303/i }))
+    expect(onPick).toHaveBeenCalledWith('bass303')
+  })
+
+  it('calls onPick with "synth" when Synth button is clicked', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /^synth$/i }))
+    expect(onPick).toHaveBeenCalledWith('synth')
+  })
+
+  it('calls onPick with "pad" when Pad button is clicked', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /^pad$/i }))
+    expect(onPick).toHaveBeenCalledWith('pad')
+  })
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn()
+    const { user } = setup({ onClose })
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape key is pressed', async () => {
+    const onClose = vi.fn()
+    const { user } = setup({ onClose })
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})
+
+// ── Accessibility ─────────────────────────────────────────────────────────────
+
+describe('InstrumentPicker — accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = setup()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ── Props variants ────────────────────────────────────────────────────────────
+
+describe('InstrumentPicker — props variants', () => {
+  it('does not crash with vi.fn() callbacks', () => {
+    expect(() => setup()).not.toThrow()
+  })
+
+  it('calls onPick exactly once per click', async () => {
+    const onPick = vi.fn()
+    const { user } = setup({ onPick })
+    await user.click(screen.getByRole('button', { name: /^kick$/i }))
+    expect(onPick).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary
- `InstrumentPanel.tsx` — per-track panel with instrument-type-specific sliders (vol, tune, decay, reverb, filter) + mute. Prop-driven with onChange bridge.
- `InstrumentPicker.tsx` — grid of 14 instruments in 3 rows (drums/melodic/other), Escape closes.
- `docs/GUI_TESTING_STANDARD.md` + `docs/GUI_COMPONENT_STANDARD.md` — TDD mandate, userEvent v14, testing pyramid, E2E roadmap.
- 247 GUI tests passing. axe accessibility checks included.

## Test plan
- [ ] `pnpm --filter @score/gui test` passes (247 tests)
- [ ] InstrumentPanel renders correct sliders per instrument type
- [ ] InstrumentPicker closes on Escape
- [ ] Components are prop-driven, no codePatcher import inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)