### PR TITLE
feat(dsl): add SongProps.theme for Performance Mode visual selection

### DIFF
--- a/packages/dsl/src/song.ts
+++ b/packages/dsl/src/song.ts
@@ -60,5 +60,6 @@ export const Song = (props: SongProps): SongDefinition => {
     ...(props.backend !== undefined && { backend: props.backend }),
     ...(props.xdj     !== undefined && { xdj:     props.xdj }),
     ...(props.theme   !== undefined && { theme:   props.theme }),
+    ...(props.palette !== undefined && { palette: props.palette }),
   }
 }

--- a/packages/dsl/src/song.ts
+++ b/packages/dsl/src/song.ts
@@ -59,5 +59,6 @@ export const Song = (props: SongProps): SongDefinition => {
     ...(props.genre   !== undefined && { genre:   props.genre }),
     ...(props.backend !== undefined && { backend: props.backend }),
     ...(props.xdj     !== undefined && { xdj:     props.xdj }),
+    ...(props.theme   !== undefined && { theme:   props.theme }),
   }
 }

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -302,6 +302,12 @@ export type SongProps = {
    * @example `Song({ bpm: 120, seed: 42, tracks: [...] })`
    */
   readonly seed?: number
+  /**
+   * Visual theme name for Performance Mode. Resolved by `@score/visuals`
+   * `getTheme(name)` — defaults to `'dark-pulse'` when omitted.
+   * @example `Song({ bpm: 128, tracks: [...], theme: 'lorenz' })`
+   */
+  readonly theme?: string
 }
 
 /**
@@ -323,6 +329,8 @@ export type SongDefinition = {
   readonly xdj?: { mode: 'score-mixer' | 'hardware-mixer' | 'hybrid' }
   /** Resolved seed — always present (defaulted to Date.now() in Song() if not provided). */
   readonly seed: number
+  /** Visual theme name — passed through from {@link SongProps}. */
+  readonly theme?: string
 }
 
 /** The recognised section types for EDM arrangement structure. */

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -308,6 +308,13 @@ export type SongProps = {
    * @example `Song({ bpm: 128, tracks: [...], theme: 'lorenz' })`
    */
   readonly theme?: string
+  /**
+   * Named colour palette applied as the base `InstrumentVisualMap`.
+   * Per-instrument `.color()` overrides on top.
+   * Built-in: `'acid'` | `'neon'` | `'void'` | `'fire'`
+   * @example `Song({ bpm: 128, tracks: [...], palette: 'neon' })`
+   */
+  readonly palette?: string
 }
 
 /**
@@ -331,6 +338,8 @@ export type SongDefinition = {
   readonly seed: number
   /** Visual theme name — passed through from {@link SongProps}. */
   readonly theme?: string
+  /** Named colour palette — passed through from {@link SongProps}. */
+  readonly palette?: string
 }
 
 /** The recognised section types for EDM arrangement structure. */

--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -95,7 +95,7 @@ const pushSong = (song: SongDefinition): void => {
     const pattern = effectivePattern(desc)
     return { name: desc.instrumentType, type: desc.instrumentType, pattern }
   })
-  send('song:update', { tracks })
+  send('song:update', { tracks, ...(song.theme !== undefined && { theme: song.theme }) })
 
   // Emit piano roll note data for melodic tracks (Synth, Arp)
   const pianoNotes: Array<{ pitch: number; step: number; velocity: number; trackIndex: number }> = []

--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -95,7 +95,11 @@ const pushSong = (song: SongDefinition): void => {
     const pattern = effectivePattern(desc)
     return { name: desc.instrumentType, type: desc.instrumentType, pattern }
   })
-  send('song:update', { tracks, ...(song.theme !== undefined && { theme: song.theme }) })
+  send('song:update', {
+    tracks,
+    ...(song.theme   !== undefined && { theme:   song.theme }),
+    ...(song.palette !== undefined && { palette: song.palette }),
+  })
 
   // Emit piano roll note data for melodic tracks (Synth, Arp)
   const pianoNotes: Array<{ pitch: number; step: number; velocity: number; trackIndex: number }> = []

--- a/packages/gui/src/main/ipc-types.ts
+++ b/packages/gui/src/main/ipc-types.ts
@@ -61,7 +61,7 @@ export type MainToRenderer = {
   'engine:step':     { step: number; stepCount: number }
   'midi:status':     { connected: boolean }
   'error:report':    { message: string }
-  'song:update':     { tracks: ReadonlyArray<{ name: string; type: string; pattern: ReadonlyArray<number | string> }> }
+  'song:update':     { tracks: ReadonlyArray<{ name: string; type: string; pattern: ReadonlyArray<number | string> }>; theme?: string }
   'engine:analysis': { waveform: readonly number[] }
   /** Fires when a bar-boundary swap is queued or cleared. */
   'engine:pending':  { pending: boolean }

--- a/packages/gui/src/main/ipc-types.ts
+++ b/packages/gui/src/main/ipc-types.ts
@@ -61,7 +61,7 @@ export type MainToRenderer = {
   'engine:step':     { step: number; stepCount: number }
   'midi:status':     { connected: boolean }
   'error:report':    { message: string }
-  'song:update':     { tracks: ReadonlyArray<{ name: string; type: string; pattern: ReadonlyArray<number | string> }>; theme?: string }
+  'song:update':     { tracks: ReadonlyArray<{ name: string; type: string; pattern: ReadonlyArray<number | string> }>; theme?: string; palette?: string }
   'engine:analysis': { waveform: readonly number[] }
   /** Fires when a bar-boundary swap is queued or cleared. */
   'engine:pending':  { pending: boolean }


### PR DESCRIPTION
## Summary
- `SongProps.theme?: string` — optional visual theme name for Performance Mode
- `SongDefinition.theme?: string` — passed through from `Song()` factory
- `song:update` IPC payload includes `theme` when present

## Usage
\`\`\`ts
export default Song({ bpm: 128, tracks: [...], theme: 'lorenz' })
\`\`\`

`@score/visuals` `getTheme(name)` resolves it in `PerformanceCanvas` (Phase 13d wiring).

## Test plan
- [ ] DSL tests pass (69)
- [ ] GUI tests pass (208)
- [ ] Typecheck clean on `@score/dsl` and `@score/gui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)