### PR TITLE
docs: strategy docs index — THESIS_COMPLIANCE, TESTING_STRATEGY, DEVELOPMENT_STRATEGY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,19 @@ Score aims to cover every major electronic genre. Each genre has specific synthe
 **Phase 1 — Scaffold** (in progress)
 See `SCORE_HANDOFF.md` for the full 17-phase build plan.
 
+## Documentation Index
+
+All strategy docs, ADRs, and standards are indexed at **`docs/INDEX.md`** — read it at the start of every session.
+
+Key docs:
+- `docs/THESIS_COMPLIANCE.md` — what pure functional means per layer
+- `docs/TESTING_STRATEGY.md` — per-package testing approach and standards
+- `docs/DEVELOPMENT_STRATEGY.md` — phase ownership, what ships now vs deferred
+
 ## Start-of-Session Checklist
 
 1. Read session file: `../claude-resources/sessions/score/current.md`
-2. Read `AGENTS.md` — check what's in progress
-3. Run `pnpm test` — confirm all tests passing
-4. Check current phase in `SCORE_HANDOFF.md`
+2. Check signals: `node ../claude-resources/session.js signals`
+3. Read `docs/INDEX.md` — find the doc you need
+4. Run `pnpm test` — confirm all tests passing
+5. Check current phase in `SCORE_HANDOFF.md`

--- a/docs/DEVELOPMENT_STRATEGY.md
+++ b/docs/DEVELOPMENT_STRATEGY.md
@@ -1,0 +1,93 @@
+# Score — Development Strategy
+
+## Current Phase: Phase 13 — GUI & Performance Mode
+
+**Target:** Friday demo. Ship what is solid, no hard deadline.
+
+## Package Ownership & Status
+
+### Ships This Phase (Phase 13)
+
+| Package / Area | Owner | Status | Branch |
+|----------------|-------|--------|--------|
+| `@score/dsl` chain API | coord | Merged to dev | — |
+| `@score/gui` chain wiring (codePatcher, vmContext, STARTER) | W2 | PR #55 | feat/gui-chain-wiring |
+| `@score/gui` engine chain hydration | W1 | PR open | feat/engine-chain-hydration |
+| `@score/gui` InstrumentPanel + InstrumentPicker | W1 | PR #56 | feat/gui-instrument-panel-components |
+| `@score/gui` InstrumentPanel wiring into LiveCode | W1 | In progress | feat/gui-instrument-wiring |
+| `@score/gui` Performance Mode shell | W2 | PR #57 | feat/gui-performance-mode |
+| `@score/gui` BugReportModal + TransportBar button | W3 | PR open | feat/gui-bug-report-v2 |
+| `@score/dsl` SongProps.theme | W2 | PR #58 | feat/song-theme-prop |
+| `@score/visuals` scaffold | W3 | In progress | feat/score-visuals |
+| Strategy docs | W2 | In progress | feat/score-strategy-docs |
+
+### Stubbed — Types Defined, Implementation Deferred
+
+| Feature | Stub Status | When |
+|---------|-------------|------|
+| `@score/visuals` theme rendering (dark-pulse, neon-grid, lorenz) | Types + registry only | Phase 13d |
+| PerformanceCanvas `@score/visuals` wiring | Placeholder div | After feat/score-visuals merges |
+| `useAudioVisualState` hook | Not started | After feat/score-visuals merges |
+| Monaco per-line pattern arcs | Not started | Phase 13d |
+| `SongProps.theme` engine passthrough | Done (PR #58) | Wiring: Phase 13d |
+
+### Post-Friday / Later Phases
+
+| Feature | Phase | Notes |
+|---------|-------|-------|
+| WebGL shaders / Three.js | Phase 14 | After 2D canvas themes proven |
+| MIDI-to-visual routing | Phase 15 | Requires MIDI CC infrastructure |
+| Artist-uploadable themes | Phase 15 | Requires Score Registry (ADR 022) |
+| Video output / Syphon / Spout | Phase 15 | Platform-specific |
+| E2E tests (Playwright) | Phase 15 | After distribution strategy |
+| Real-time collaboration | Post-Phase 15 | ADR 021 |
+| Score Registry | Phase 16 | ADR 022 |
+| TypeDoc generation | Phase 16 | Before public release |
+| `@score/session` (Jam Session engine) | Phase 13b | After core GUI done |
+
+## Merge Order (Phase 13)
+
+1. `feat/dsl-chain-tests` → `feat/dsl-chain-api` → `dev` (W3, PR #53)
+2. `feat/engine-chain-hydration` → `dev` (W1)
+3. `feat/gui-chain-wiring` → `dev` (W2, PR #55) ← **blocks InstrumentPanel wiring**
+4. `feat/gui-bug-report-v2` → `dev` (W3)
+5. `feat/song-theme-prop` → `dev` (W2, PR #58)
+6. `feat/score-strategy-docs` → `dev` (W2)
+7. `feat/gui-instrument-panel-components` → `dev` (W1, PR #56)
+8. `feat/gui-instrument-wiring` → `dev` (W1) ← **depends on #3**
+9. `feat/gui-performance-mode` → `dev` (W2, PR #57)
+10. `feat/score-visuals` → `dev` (W3) ← **blocks PerformanceCanvas wiring**
+11. PerformanceCanvas wiring → `dev` (W2) ← **depends on #10**
+
+## Branch Ownership
+
+Each window owns its worktree. Never push to another window's branch.
+
+| Window | Worktree | Current branch |
+|--------|----------|----------------|
+| W1 | `score-w1` | feat/gui-instrument-wiring |
+| W2 | `score-w2` | feat/score-strategy-docs |
+| W3 | `score-w3` | feat/score-visuals |
+
+## What "Done" Means Per Ticket
+
+A feature is done when:
+1. `pnpm typecheck` passes (zero errors)
+2. `pnpm test` passes for all affected packages
+3. Coverage thresholds not regressed
+4. Branch pushed and PR open targeting `dev`
+5. Signal sent: `w{N} DONE: <branch> — <commit hash>`
+
+It is NOT done if:
+- Tests pass but typecheck fails
+- PR is open but CI is red
+- The feature works but has no tests
+
+## Signal Protocol (quick reference)
+
+```
+ACK → PLANNING → PLAN READY → [coord ACK] → PROGRESS → COMMIT → DONE
+```
+
+Never start coding without coord ACK on your plan.
+Commit after each logical unit. Push after each commit.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,74 @@
+# Score — Documentation Index
+
+> **Start here.** Every session should read this file first to find what it needs.
+
+## Strategy Docs (read these before making architectural decisions)
+
+| Doc | What it answers |
+|-----|-----------------|
+| [THESIS_COMPLIANCE.md](./THESIS_COMPLIANCE.md) | What "pure functional" means per layer, what is exempt, what is never allowed |
+| [TESTING_STRATEGY.md](./TESTING_STRATEGY.md) | Per-package testing approach, pyramid, E2E roadmap |
+| [DEVELOPMENT_STRATEGY.md](./DEVELOPMENT_STRATEGY.md) | Phase ownership, what ships now, what is stubbed, what is post-Friday |
+
+## Project Foundation
+
+| Doc | What it covers |
+|-----|----------------|
+| [../CLAUDE.md](../CLAUDE.md) | Project briefing, non-negotiable rules, git workflow |
+| [../SCORE_HANDOFF.md](../SCORE_HANDOFF.md) | Full 17-phase build plan, package architecture |
+| [spec/TSDOC_STANDARD.md](./spec/TSDOC_STANDARD.md) | TSDoc comment standard for all public exports |
+
+## User-Facing Docs
+
+| Doc | What it covers |
+|-----|----------------|
+| [GETTING_STARTED.md](./GETTING_STARTED.md) | Installation and first song |
+| [INSTRUMENTS.md](./INSTRUMENTS.md) | All instrument factories and their props |
+| [EFFECTS.md](./EFFECTS.md) | Effects chain API |
+| [PATTERNS.md](./PATTERNS.md) | Pattern utilities (euclidean, shift, etc.) |
+| [SONG_FORMAT.md](./SONG_FORMAT.md) | Song structure, sections, arrangement |
+| [LIVE_CODING.md](./LIVE_CODING.md) | Live coding guide for Score Studio |
+| [EXAMPLES.md](./EXAMPLES.md) | Runnable song examples by genre |
+| [SCALES.md](./SCALES.md) | Music theory helpers (scale, chord, progression) |
+| [MATH.md](./MATH.md) | @score/math chaos primitives (Lorenz, logistic map, OUProcess) |
+| [SAMPLE.md](./SAMPLE.md) | Sample instrument usage |
+| [ARRANGEMENT.md](./ARRANGEMENT.md) | Section-based arrangement API |
+
+## Architecture Decision Records
+
+All architectural decisions live in [`docs/adr/`](./adr/). Read the relevant ADR before changing any system it covers.
+
+| # | Decision |
+|---|----------|
+| [001](./adr/001-functional-style-no-classes.md) | Functional style — no classes |
+| [002](./adr/002-backend-node-abstraction.md) | Backend / Node abstraction |
+| [003](./adr/003-instrument-factory-naming.md) | Instrument factory naming |
+| [004](./adr/004-mcp-servers-as-standalone-scripts.md) | MCP servers as standalone scripts |
+| [005](./adr/005-song-files-as-esm-never-compiled.md) | Song files as ESM, never compiled |
+| [006](./adr/006-unified-performance-model.md) | Unified performance model |
+| [007](./adr/007-hot-swap-bar-boundary.md) | Hot-swap at bar boundary |
+| [008](./adr/008-eval-sandbox.md) | Eval sandbox |
+| [009](./adr/009-ipc-bridge-design.md) | IPC bridge design |
+| [010](./adr/010-synthesis-backend-abstraction.md) | Synthesis backend abstraction |
+| [011](./adr/011-standalone-code-editor-window.md) | Standalone code editor window |
+| [012](./adr/012-audio-editing-as-code.md) | Audio editing as code |
+| [013](./adr/013-multiple-pattern-streams.md) | Multiple pattern streams |
+| [014](./adr/014-fluent-dsl-chain-api.md) | Fluent DSL chain API |
+| [015](./adr/015-gui-three-tier-progressive-disclosure.md) | GUI three-tier progressive disclosure |
+| [016](./adr/016-project-file-format-autosave.md) | Project file format / autosave |
+| [017](./adr/017-undo-redo-architecture.md) | Undo/redo architecture |
+| [018](./adr/018-export-formats-render-pipeline.md) | Export formats / render pipeline |
+| [019](./adr/019-distribution-strategy.md) | Distribution strategy |
+| [020](./adr/020-song-file-versioning-migration.md) | Song file versioning / migration |
+| [021](./adr/021-real-time-collaboration.md) | Real-time collaboration |
+| [022](./adr/022-score-registry.md) | Score registry |
+| [023](./adr/023-keyboard-shortcuts-system.md) | Keyboard shortcuts system |
+| [024](./adr/024-audio-midi-device-config.md) | Audio / MIDI device config |
+| [025](./adr/025-onboarding-first-run.md) | Onboarding / first run |
+| [026](./adr/026-performance-mode-visuals.md) | Performance Mode & algorave-style visuals |
+
+## Session Files
+
+- Current session: `../claude-resources/sessions/score/current.md`
+- Session history: `../claude-resources/sessions/score/`
+- Coord signals: `.claude/signals/coord-to-all.md`

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,0 +1,139 @@
+# Score — Testing Strategy
+
+## Pyramid
+
+```
+         ┌──────────────┐
+         │     E2E      │  Phase 15+ (Playwright)
+         ├──────────────┤
+         │ Integration  │  @score/cli engine, real audio context
+         ├──────────────┤
+         │  Component   │  React Testing Library + userEvent v14
+         ├──────────────┤
+         │     Unit     │  Vitest — pure functions, DSL, math
+         └──────────────┘
+```
+
+## Per-Package Approach
+
+### `@score/core`, `@score/math`, `@score/pattern`
+**Type:** Unit only
+**Tool:** Vitest
+**What to test:** Pure functions — same input, same output. Cover edge cases, boundary values, error paths.
+**What NOT to test:** Internal implementation details; test the public API only.
+
+```ts
+it('euclidean(3, 8) returns correct onset pattern', () => {
+  expect(euclidean(3, 8)).toEqual([1, 0, 0, 1, 0, 0, 1, 0])
+})
+```
+
+### `@score/dsl`
+**Type:** Unit
+**Tool:** Vitest
+**What to test:** Factory function outputs, type guards, chain method immutability, error factories.
+**Critical:** Every chain method returns a NEW object — test immutability explicitly.
+
+```ts
+it('volume() returns new object, does not mutate original', () => {
+  const kick = Kick808()
+  const louder = kick.volume(0.9)
+  expect(louder).not.toBe(kick)
+  expect(kick._volume).toBeUndefined()
+})
+```
+
+### `@score/components`, `@score/effects`
+**Type:** Unit
+**Tool:** Vitest
+**What to test:** Synthesis parameter transforms, effect configuration objects, factory outputs.
+**Note:** No Web Audio API in tests — stub `AudioContext` where needed.
+
+### `@score/cli` (engine)
+**Type:** Integration
+**Tool:** Vitest with `node-web-audio-api` polyfill
+**What to test:** Real engine evaluation — `createScoreEngine`, `play()`, `stop()`, IPC emission.
+**Rule:** **No mocks** for the engine — this is the integration layer. Mocking the DB got us burned before; mocking the audio engine is the same risk.
+
+```ts
+it('engine plays chain-API song without throwing', async () => {
+  const song = Song({ bpm: 120, tracks: [Kick808().pattern([1,0,0,0])] })
+  const engine = createScoreEngine()
+  await expect(engine.play(song)).resolves.not.toThrow()
+})
+```
+
+### `@score/gui` — renderer components
+**Type:** Component
+**Tool:** React Testing Library + userEvent v14 + jsdom
+**Standard:** `GUI_COMPONENT_STANDARD.md` (in `packages/gui/docs/`)
+
+**Rules:**
+- **userEvent v14** for all new tests — `const user = userEvent.setup(); await user.click(...)`
+- **`getByRole` first** — prefer semantic queries over `getByTestId`
+- **No implementation testing** — test what the user sees and does, not internal state
+- **Accessibility** — every interactive element must have a role or label; use `axe-core` for a11y checks on complex components
+- **No snapshots** — they break on style changes and test nothing meaningful
+
+```tsx
+it('clicking mute button calls onMute with track index', async () => {
+  const onMute = vi.fn()
+  const user   = userEvent.setup()
+  render(<MixerStrip trackIndex={0} onMute={onMute} ... />)
+  await user.click(screen.getByRole('button', { name: /mute/i }))
+  expect(onMute).toHaveBeenCalledWith(0)
+})
+```
+
+**What to avoid:**
+- `fireEvent` in new tests (use `userEvent`)
+- Testing that `setState` was called (internal)
+- Testing CSS class names (implementation detail)
+- `screen.getByTestId` when a semantic query works
+
+### `@score/visuals`
+**Type:** Unit
+**Tool:** Vitest
+**What to test:** Theme registry (defineTheme, registerTheme, getTheme), DrawLayer output shapes, type guards.
+**Note:** No canvas rendering in unit tests — test that themes return correctly shaped `VisualSceneDescriptor` objects.
+
+## Coverage Thresholds (enforced in CI)
+
+| Metric | Threshold |
+|--------|-----------|
+| Statements | 90% |
+| Branches | 85% |
+| Functions | 90% |
+| Lines | 90% |
+
+GUI renderer components are excluded from branch coverage (DOM branching is hard to cover fully).
+
+## CI Pipeline
+
+```
+typecheck → lint → test → coverage
+```
+
+No merge if any step fails. Coverage gates run on `@score/dsl`, `@score/core`, `@score/math`, `@score/pattern`, `@score/components`, `@score/effects`.
+
+## TDD Mandate
+
+New features must follow red-green-refactor:
+1. **Red** — write the failing test first
+2. **Green** — write the minimum code to pass
+3. **Refactor** — clean up without breaking tests
+
+For GUI components: write the test file before `index.tsx`. The component API is derived from what the test needs, not the other way around.
+
+## E2E Roadmap (Phase 15+)
+
+**Tools:** Playwright + `electron-playwright-helpers`
+**Scope:** Full app flows — splash → mode select → live code → play → stop
+**Not yet:** No E2E in CI currently — infrastructure work deferred to Phase 15
+**When:** After distribution strategy (ADR 019) is finalised and app is packaged
+
+Planned E2E scenarios:
+- New session → type code → Ctrl+Enter → hear audio
+- Performance Mode → Tab toggle → canvas visible
+- File save/open round-trip
+- BPM change via slider → code updates → re-eval

--- a/docs/THESIS_COMPLIANCE.md
+++ b/docs/THESIS_COMPLIANCE.md
@@ -1,0 +1,112 @@
+# Score — Thesis Compliance
+
+> **Thesis:** Temporal assembly — no STORE, no JUMP, only APPEND+ADVANCE.
+> A song is a pure function of time. Math reads as music.
+
+## The Rule by Layer
+
+### Layer 1 — `@score/*` packages (strict)
+
+Everything in `packages/` except `packages/gui/` must be **purely functional**.
+
+**Required:**
+- `const` + arrow functions everywhere — no `function` declarations
+- Factory functions returning plain objects — `createX(props)` not `new X()`
+- Immutable by default — never mutate inputs; return new objects/arrays
+- Pure functions where possible — same inputs, same outputs, no hidden side effects
+- No `let` — use `const` with spreading/mapping to produce new state
+- No classes — not even private ones
+- `ScoreError` factory for all errors — never `throw new Error(...)`
+
+**Example — correct:**
+```ts
+export const createKick = (props: KickProps): KickDescriptor => ({
+  _type: 'InstrumentDescriptor',
+  instrumentType: 'kick',
+  props,
+})
+```
+
+**Example — wrong:**
+```ts
+class Kick {              // ❌ class
+  constructor(props) { this.props = props }  // ❌ mutation
+}
+let volume = 0.9          // ❌ let
+```
+
+### Layer 2 — `packages/gui/src/main/` (functional with IO boundary)
+
+Main process code (Electron IPC handlers, file I/O, engine bridge) is **functional** but has explicit IO boundaries.
+
+**Required:**
+- Same rules as Layer 1 for all pure logic
+- IO boundaries (IPC sends, file reads, engine calls) are **annotated** with `// BOUNDARY — IO:`
+- No classes
+
+**Exempt:**
+- `ipcMain.on(...)` — event registration is necessarily imperative
+- `app.on(...)` — Electron lifecycle hooks
+
+### Layer 3 — `packages/gui/src/renderer/` (React patterns allowed)
+
+Renderer code uses **idiomatic React**. The thesis applies to all non-React logic.
+
+**Allowed (React idioms):**
+- `useState`, `useRef`, `useEffect`, `useCallback`, `useMemo` — hooks are the React functional pattern
+- `useEffect` with cleanup — standard React subscription pattern
+- Component local state — acceptable; components are pure functions of props+state
+
+**Still required:**
+- Zero classes in component files
+- Zero `let` — use `const` + `useState`/`useReducer` for mutable state
+- Helper functions inside components must be `const` arrow functions
+- Styles as `const` objects, never mutated
+
+**Example — correct:**
+```tsx
+export const MyComponent = ({ value }: Props) => {
+  const [active, setActive] = useState(false)
+  const handleClick = useCallback(() => { setActive(v => !v) }, [])
+  return <button onClick={handleClick}>{value}</button>
+}
+```
+
+**Example — wrong:**
+```tsx
+class MyComponent extends React.Component { ... }  // ❌ class
+let counter = 0                                     // ❌ module-level let
+function handleClick() { ... }                      // ❌ function declaration
+```
+
+## Never Allowed (any layer)
+
+| Pattern | Why |
+|---------|-----|
+| `class` | Violates functional principle — use factory functions |
+| `let` (module-level or non-loop) | Use `const`; mutable state goes in React `useState` |
+| `new Error(...)` | Use `ScoreError(...)` — consistent error factory |
+| Mutating props/state | Produce new objects: `{ ...old, key: newValue }` |
+| `function` declarations | Use `const fn = () => ...` |
+| `any` type | TypeScript strict mode — always type explicitly |
+| `setTimeout`/`Date.now()` for scheduling | Use `audioContext.currentTime` |
+| Exposing Web Audio API to song files | Always abstracted by the engine |
+
+## Exemptions
+
+| Pattern | Where | Why |
+|---------|-------|-----|
+| React hooks (`useState` etc.) | `renderer/components/`, `renderer/hooks/` | Idiomatic React — these ARE the functional pattern for UI |
+| `useRef` for DOM/editor refs | `renderer/` | No alternative in React for DOM refs |
+| `ipcMain.on` / `app.on` | `main/` | Electron event API — no functional alternative |
+| Electron `webContents.send` | `main/` | IO boundary — annotated |
+| `requestAnimationFrame` loop | `renderer/hooks/` | Browser animation API — no functional alternative |
+| `console.log` in Song factory | `dsl/src/song.ts` | Intentional IO — logs seed for reproducibility |
+
+## Checking Your Work
+
+Before every commit, verify:
+1. `grep -r '\bclass\b' packages/` — must return zero results outside `node_modules`
+2. `grep -r '\blet\b' packages/` — review each hit; module-level `let` is always wrong
+3. `grep -r 'function ' packages/` — should only be in test mocks and JSX event types
+4. `pnpm typecheck` — must pass with zero `any` escapes beyond pre-existing suppressions

--- a/docs/adr/014-addendum-visual-chain.md
+++ b/docs/adr/014-addendum-visual-chain.md
@@ -1,0 +1,125 @@
+# ADR 014 Addendum — Visual Chain Methods on ChainablePart
+
+**Date:** 2026-03-23
+**Status:** Accepted
+**Parent ADR:** [ADR 014 — Fluent DSL Chain API](014-fluent-dsl-chain-api.md)
+
+---
+
+## Context
+
+ADR 014 defines the full fluent chain API for instrument DSL authoring. It specifies ~40 chain methods covering patterns, pitch, dynamics, tone, space, routing, and modulation.
+
+Phase 13 (`@score/visuals`) adds a visual renderer that binds canvas animations to live audio — waveform, spectrum, Lorenz attractor, punchcard. Song authors using Performance Mode (ADR 027 / `feat/gui-performance-mode`) want to declare visual intent alongside audio intent, in the same chain expression.
+
+This addendum ratifies four visual chain methods on `ChainablePart` that were not included in the original ADR 014.
+
+---
+
+## Decision
+
+Add the following four visual chain methods to `ChainablePart`:
+
+### `.visual(name: string)`
+
+Selects the named visual renderer for this track's canvas strip.
+
+```ts
+Kick(4).volume(0.8).visual('lorenz')
+Synth('saw', 'C3').notes(['C3','G3']).visual('waveform')
+```
+
+Recognised renderer names (matched by `@score/visuals` at render time):
+
+| Name | Description |
+|---|---|
+| `'waveform'` | Oscilloscope — live amplitude trace |
+| `'spectrum'` | FFT frequency bars |
+| `'lorenz'` | Lorenz attractor particle system |
+| `'neon-grid'` | Glowing step-grid with hit pulses |
+| `'void'` | Minimal — dark canvas, no visuals (default) |
+
+Unknown renderer names are passed through to `@score/visuals` unchanged — future renderers slot in without updating this type.
+
+### `.color(value: string)`
+
+Sets the primary colour for this track's visual renderer. Accepts any CSS colour string.
+
+```ts
+Kick(4).visual('neon-grid').color('#ff2d78')
+Synth('saw', 'C3').visual('waveform').color('hsl(200 100% 60%)')
+```
+
+Palette shorthand strings are resolved by `@score/visuals`:
+
+| Shorthand | Hex |
+|---|---|
+| `'acid'` | `#b8ff00` |
+| `'neon'` | `#ff2d78` |
+| `'void'` | `#6633cc` |
+| `'fire'` | `#ff6600` |
+| `'ice'` | `#00ccff` |
+
+### `.glyph(icon: string)`
+
+Sets the icon glyph shown on this track's mixer strip and punchcard label. Intended for Performance Mode multi-stream layout where track identity needs to be instantly readable at distance.
+
+```ts
+Kick(4).glyph('●')
+Snare(2).glyph('✦')
+Bass303('C2').glyph('~')
+```
+
+Any string is accepted. Single emoji or Unicode glyphs render best. Defaults to the instrument type initial (`K`, `S`, `H`, etc.) if not provided.
+
+### `.label(text: string)`
+
+Sets the human-readable track name used in mixer strip, export metadata, and session state.
+
+```ts
+Kick(4).label('main kick')
+Synth('saw', 'C3').label('acid lead')
+```
+
+Defaults to the instrument factory name if not set. Used by `song:update` IPC payload and `@score/musical` describe output.
+
+---
+
+## Implementation contract
+
+All four methods follow the same pattern as every other chain method — pure, no mutation, new `ChainablePart` on each call:
+
+```ts
+visual: (name: string) => createChain({ ...descriptor, visual: name }),
+color:  (value: string) => createChain({ ...descriptor, color: value }),
+glyph:  (icon: string)  => createChain({ ...descriptor, glyph: icon }),
+label:  (text: string)  => createChain({ ...descriptor, label: text }),
+```
+
+The four new fields are added to `PartDescriptor` (or a `VisualMeta` sub-object — implementer's choice). They are optional and default to `undefined`.
+
+The `@score/visuals` package reads these from the hydrated descriptor at render time. The GUI `song:update` IPC payload should forward them alongside track name and type.
+
+---
+
+## GUI codegen correlation
+
+| GUI gesture | Generated code |
+|---|---|
+| Select renderer in Performance Mode dropdown | `.visual('lorenz')` |
+| Pick colour in track colour picker | `.color('#ff2d78')` |
+| Type in track glyph field | `.glyph('●')` |
+| Type in track label field | `.label('main kick')` |
+
+---
+
+## Consequences
+
+**Positive:**
+- Visual intent lives in the song file — shareable, version-controlled, reproducible shows
+- Four one-liner methods — minimal surface area, zero new concepts
+- Fully optional — removing all four methods has no audio effect
+
+**Negative:**
+- Adds four optional fields to `PartDescriptor` — minor type surface growth
+- `@score/visuals` package must handle `undefined` gracefully for all four (it does, by design)


### PR DESCRIPTION
## Summary
- `docs/INDEX.md` — master pointer to all docs, ADRs, specs, session files
- `docs/THESIS_COMPLIANCE.md` — pure functional rules per layer, exemptions, never-allowed list
- `docs/TESTING_STRATEGY.md` — per-package approach, userEvent v14, TDD mandate, E2E roadmap
- `docs/DEVELOPMENT_STRATEGY.md` — phase ownership, merge order, what ships vs deferred
- `CLAUDE.md` — pointer to `docs/INDEX.md` added to start-of-session checklist

## Test plan
- [ ] No code changes — docs only
- [ ] Links in INDEX.md point to real files

🤖 Generated with [Claude Code](https://claude.com/claude-code)