### PR TITLE
feat(gui): wire InstrumentPanel into LiveCode — debounced patchChainMethod re-eval

### DIFF
--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -674,8 +674,8 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
               {selectedTrack !== null && tracks[selectedTrack] !== undefined && (
                 <InstrumentPanel
                   trackIndex={selectedTrack}
-                  instrumentType={tracks[selectedTrack]!.type}
-                  trackName={tracks[selectedTrack]!.name}
+                  instrumentType={tracks[selectedTrack].type}
+                  trackName={tracks[selectedTrack].name}
                   params={{ volume: stripStates[selectedTrack]?.volume ?? 1 }}
                   muted={stripStates[selectedTrack]?.muted ?? false}
                   onChange={(method: string, value: number | string) => { onInstrumentChange(selectedTrack, method, value) }}

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -20,7 +20,8 @@ import { EvalStatus }                       from '../status/index.js'
 import type { EvalStatusKind }             from '../status/EvalStatus.js'
 import { BarCounter }                       from '../status/index.js'
 import { PendingSwapBadge }                 from '../status/index.js'
-import { patchBpm, patchTrackPattern, patchTrackVolume, patchTrackNote } from '../../lib/codePatcher.js'
+import { patchBpm, patchTrackPattern, patchTrackVolume, patchTrackNote, patchChainMethod } from '../../lib/codePatcher.js'
+import { InstrumentPanel } from '../shared/InstrumentPanel.js'
 import type { PianoRollNote }              from '../visualizer/PianoRoll.js'
 import type { PanelLayoutMap }            from '../../../main/ipc-types.js'
 
@@ -133,9 +134,13 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   const [pianoNotes,  setPianoNotes]  = useState<ReadonlyArray<PianoRollNote>>([])
   // t220 — import visibility toggle (stub: fold/unfold in Monaco; auto-inject deferred for DSL chain API)
   const [importsVisible, setImportsVisible] = useState(true)
+  // Instrument panel — which track is currently selected (null = none)
+  const [selectedTrack, setSelectedTrack] = useState<number | null>(null)
   // Set to true when the user clicks play before eval — song:update handler will
   // fire transport:play once the eval succeeds (eval-then-play flow).
-  const autoPlayRef   = useRef(false)
+  const autoPlayRef      = useRef(false)
+  // Debounce timer for re-eval after instrument param changes
+  const evalDebounceRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // t218 — panel layout persistence
   const [savedLayout, setSavedLayout] = useState<PanelLayoutMap>({})
@@ -354,6 +359,29 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
     setStripStates(prev => updateStrip(prev, index, { muted: mute }))
     window.scoreBridge.send('engine:patch', { tracks: [{ index, mute }] })
   }, [stripStates])
+
+  /**
+   * Optimistic UI: patch code immediately, then re-eval after 300ms idle.
+   * Prevents 60fps re-evals during slider drag while keeping the editor in sync.
+   */
+  const onInstrumentChange = useCallback((trackIndex: number, method: string, value: number | string): void => {
+    setCode(prev => patchChainMethod(prev, trackIndex, method, value))
+    if (evalDebounceRef.current !== null) clearTimeout(evalDebounceRef.current)
+    evalDebounceRef.current = setTimeout(() => {
+      setError(null)
+      setEvalStatus('pending')
+      addLog('info', 'Evaluating…')
+      // Read latest code via functional setCode to avoid stale closure
+      setCode(latest => {
+        window.scoreBridge.send('engine:eval', { code: latest })
+        return latest
+      })
+    }, 300)
+  }, [addLog])
+
+  const onInstrumentMute = useCallback((trackIndex: number): void => {
+    onMixerMute(trackIndex)
+  }, [onMixerMute])
 
   const onBpmChange = useCallback((bpm: number): void => {
     setCode(prev => patchBpm(prev, bpm))
@@ -622,21 +650,38 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
             >
               <div style={styles.mixerInner}>
                 {tracks.map((track, i) => (
-                  <MixerStrip
+                  <div
                     key={`${track.name}-${String(i)}`}
-                    name={track.name}
-                    type={track.type}
-                    volume={stripStates[i]?.volume ?? 1}
-                    muted={stripStates[i]?.muted ?? false}
-                    level={0}
-                    onVolume={v => { onMixerVolume(i, v) }}
-                    onMute={() => { onMixerMute(i) }}
-                  />
+                    style={{ outline: selectedTrack === i ? '1px solid #4a8fff' : 'none', cursor: 'pointer' }}
+                    onClick={() => { setSelectedTrack(prev => prev === i ? null : i) }}
+                    aria-label={`Select ${track.name} track`}
+                  >
+                    <MixerStrip
+                      name={track.name}
+                      type={track.type}
+                      volume={stripStates[i]?.volume ?? 1}
+                      muted={stripStates[i]?.muted ?? false}
+                      level={0}
+                      onVolume={v => { onMixerVolume(i, v) }}
+                      onMute={() => { onMixerMute(i) }}
+                    />
+                  </div>
                 ))}
                 {tracks.length === 0 && (
                   <span style={styles.mixerEmpty}>No tracks — eval a song first</span>
                 )}
               </div>
+              {selectedTrack !== null && tracks[selectedTrack] !== undefined && (
+                <InstrumentPanel
+                  trackIndex={selectedTrack}
+                  instrumentType={tracks[selectedTrack]!.type}
+                  trackName={tracks[selectedTrack]!.name}
+                  params={{ volume: stripStates[selectedTrack]?.volume ?? 1 }}
+                  muted={stripStates[selectedTrack]?.muted ?? false}
+                  onChange={(method: string, value: number | string) => { onInstrumentChange(selectedTrack, method, value) }}
+                  onMute={() => { onInstrumentMute(selectedTrack) }}
+                />
+              )}
             </DraggablePanel>
           )}
 

--- a/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
@@ -102,7 +102,7 @@ export const InstrumentPicker = (props: InstrumentPickerProps): React.JSX.Elemen
   const { onPick, onClose } = props
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') { onClose() } }
     window.addEventListener('keydown', handler)
     return () => { window.removeEventListener('keydown', handler) }
   }, [onClose])

--- a/packages/gui/src/renderer/lib/codePatcher.ts
+++ b/packages/gui/src/renderer/lib/codePatcher.ts
@@ -229,23 +229,16 @@ export const patchChainMethod = (
   // Method not present — append it to the last non-empty line of the region
   // that belongs to this track's chain (before next const/export default).
   const lines = slice.split('\n')
-  // Find the last line that contains a chain call (starts with whitespace + dot,
-  // or is the instrument declaration line itself)
-  let insertLineIdx = 0
-  for (let i = 0; i < lines.length; i++) {
-    const ln = lines[i] ?? ''
-    if (ln.trim().length > 0 && !ln.trim().startsWith('const ') && !ln.trim().startsWith('export ')) {
-      insertLineIdx = i
-    } else if (ln.trim().startsWith('const ') || ln.trim().startsWith('export ')) {
-      break
-    }
-    if (i === 0) insertLineIdx = 0  // always accept the first line
-  }
+  // Slice up to the first next-track or export boundary, then find last non-empty line.
+  const stopIdx = lines.findIndex(ln =>
+    ln.trim().startsWith('const ') || ln.trim().startsWith('export '))
+  const regionLines = stopIdx === -1 ? lines : lines.slice(0, stopIdx)
+  const insertLineIdx = regionLines.reduce((acc, ln, i) =>
+    ln.trim().length > 0 ? i : acc, 0)
 
-  const targetLine = lines[insertLineIdx] ?? ''
-  lines[insertLineIdx] = targetLine + `.${method}(${formatted})`
-  const newSlice = lines.join('\n')
-  return code.slice(0, start) + newSlice + code.slice(end)
+  const patched = lines.map((ln, i) =>
+    i === insertLineIdx ? ln + `.${method}(${formatted})` : ln)
+  return code.slice(0, start) + patched.join('\n') + code.slice(end)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Wires `InstrumentPanel` into `LiveCode/index.tsx` — click a MixerStrip to select it, panel appears below the strip row
- `onChange`: `patchChainMethod(code, trackIndex, method, value)` → `setCode` immediately (optimistic UI) → debounced re-eval 300ms after last event (no 60fps re-evals during drag)
- `onMute`: delegates to existing `onMixerMute` (engine:patch + strip state sync)
- Adds `patchChainMethod` + `patchAddInstrument` to `codePatcher.ts` (chain API patchers)
- Thesis compliant: zero `let` in new code — `insertLineIdx` loop replaced with `findIndex` + `reduce` + `map`

## Test plan

- [ ] 247 GUI tests passing
- [ ] Typecheck clean
- [ ] Select a track by clicking its MixerStrip → InstrumentPanel appears
- [ ] Click same strip again → panel dismisses
- [ ] Drag a slider → code updates instantly, re-eval fires once after 300ms idle
- [ ] Mute button in InstrumentPanel mutes the track

🤖 Generated with [Claude Code](https://claude.com/claude-code)