### PR TITLE
feat(gui): unlock all modes on splash screen for demo

### DIFF
--- a/packages/gui/src/renderer/components/SplashScreen.tsx
+++ b/packages/gui/src/renderer/components/SplashScreen.tsx
@@ -31,21 +31,18 @@ const MODES: readonly ModeCard[] = [
     label:       'Produce',
     description: 'Arrange tracks, automate parameters, export stems.',
     icon:        '▦',
-    disabled:    true,
   },
   {
     id:          'dj-set',
     label:       'DJ Set',
     description: 'Mix decks, manage cues, crossfade. Score is your DJ software.',
     icon:        '⊙',
-    disabled:    true,
   },
   {
     id:          'jam-session',
     label:       'Jam Session',
     description: 'Perform live with MIDI hardware. Patch anything to anything.',
     icon:        '⊕',
-    disabled:    true,
   },
 ]
 

--- a/packages/gui/tests/SplashScreen.test.tsx
+++ b/packages/gui/tests/SplashScreen.test.tsx
@@ -26,18 +26,17 @@ describe('SplashScreen — rendering', () => {
 
   it('renders all four mode buttons', () => {
     setup()
-    // Live Code is enabled; Produce/DJ Set/Jam Session are disabled (coming soon)
     expect(screen.getByRole('button', { name: 'Live Code' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Produce — coming soon' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'DJ Set — coming soon' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Jam Session — coming soon' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Produce' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'DJ Set' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Jam Session' })).toBeInTheDocument()
   })
 
-  it('disabled mode buttons are not interactive', () => {
+  it('all mode buttons are enabled', () => {
     setup()
-    expect(screen.getByRole('button', { name: 'Produce — coming soon' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'DJ Set — coming soon' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Jam Session — coming soon' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Produce' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'DJ Set' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Jam Session' })).toBeEnabled()
   })
 
   it('renders three hardware level buttons', () => {
@@ -70,7 +69,7 @@ describe('SplashScreen — initial state', () => {
 // ── Mode selection ────────────────────────────────────────────────────────────
 
 describe('SplashScreen — mode selection', () => {
-  it('start button shows Live Code label (only enabled mode)', () => {
+  it('start button shows Live Code label (pre-selected mode)', () => {
     setup()
     expect(screen.getByRole('button', { name: /start live code/i })).toBeEnabled()
   })
@@ -80,13 +79,11 @@ describe('SplashScreen — mode selection', () => {
     expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('disabled mode cards stay unselected when clicked', async () => {
+  it('clicking another mode card selects it', async () => {
     const { user } = setup()
-    // Disabled buttons can't be clicked via userEvent — live-code remains pressed
-    expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'true')
-    // Disabled cards report aria-pressed=false (not selected)
-    expect(screen.getByRole('button', { name: 'Produce — coming soon' })).toHaveAttribute('aria-pressed', 'false')
-    void user
+    await user.click(screen.getByRole('button', { name: 'Produce' }))
+    expect(screen.getByRole('button', { name: 'Produce' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'false')
   })
 })
 


### PR DESCRIPTION
## Summary
- Remove `disabled: true` from Produce, DJ Set, and Jam Session splash screen cards
- All 5 modes now selectable for demo exploration
- Shell-only modes (no full content yet) — re-gate before tester release if needed

## Test plan
- [ ] Launch GUI, verify all 5 mode cards are clickable on splash screen
- [ ] Confirm no "Coming soon" labels remain
- [ ] Existing tests pass (SplashScreen.tsx only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)