### PR TITLE
docs: update README + add ROADMAP with full ecosystem decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A production-level, component-based audio framework for creating EDM music in JavaScript.
 
-**Status:** Active development — Phases 1–12 (scaffold) complete. Phase 12b (jam session) next.
+**Status:** Active development — Phase 13 (GUI + bidirectional wiring). Score Studio running. Friday demo target: full band playable in GUI.
 
 ---
 
@@ -10,111 +10,102 @@
 
 Score is two things simultaneously:
 
-1. **A framework** (TypeScript) — the engine, components, effects, sequencer, mixer, CLI, and GUI that power everything
+1. **A framework** (TypeScript) — the engine, components, effects, sequencer, mixer, CLI, and GUI
 2. **A language** (plain JavaScript) — the song file format that musicians and developers use to write music as code
 
-The core philosophy: **music is code, code is music.** Every note, pattern, effect value, and arrangement decision is written by hand. No AI generates any musical content — ever.
+The core philosophy: **a song is a pure function of time.** Every note, pattern, effect value, and arrangement decision is written by hand. No AI generates any musical content — ever.
+
+Score is part of a larger ecosystem. See [ROADMAP.md](./docs/ROADMAP.md) for the full picture.
+
+---
 
 ## Song files look like this
 
 ```js
-import { Song, Kick, Synth, Sequence, Intro, Drop, Outro } from '@score/dsl'
+import { Song, Kick808, Snare, HiHat, Bass303, Pad } from '@score/dsl'
 
-const kick = Kick({
-  pattern: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
-  volume: 0.9,
-})
+// Drums — pattern array (1 = hit, 0 = rest)
+const kick  = Kick808({ pattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0], volume: 0.75 })
+const snare = Snare({   pattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0], volume: 0.5  })
+const hihat = HiHat({   pattern: [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0], volume: 0.2  })
 
-const bass = Synth({
-  wave: 'sawtooth',
-  filter: { type: 'lowpass', frequency: 800 },
-  sequence: Sequence('A1 A1 . C2 . G1 . .'),
-})
+// Melodic — chain API
+const bass = Bass303('A2')
+  .filter(600)
+  .resonance(0.4)
+  .pattern([1,0,0,0, 0,0,1,0, 1,0,0,0, 0,1,0,0])
+  .volume(0.7)
 
-export default Song({
-  bpm: 140,
-  key: 'Am',
-  genre: 'techno',
-  tracks: [kick, bass],
-  arrangement: [Intro(4, [kick]), Drop(16, [kick, bass]), Outro(4, [kick])],
-})
+const pad = Pad('A3')
+  .attack(0.3)
+  .release(1.2)
+  .reverb(0.3)
+  .volume(0.35)
+
+export default Song({ bpm: 128, tracks: [kick, snare, hihat, bass, pad] })
 ```
 
-## Deterministic Reproducibility
+---
 
-Score's thesis is that **a song is a pure function of time** — same inputs always produce identical output. Stochastic pattern functions (`degrade`, `humanize`, `drunk`) draw from a seeded PRNG provided by [`@prime/prime-random`](../prime/packages/prime-random), a sibling workspace dependency. Calling `Song({ seed: 42 })` always produces the exact same patterns, timings, and arrangement on every run. If no seed is provided, Score falls back to `Date.now()` and logs the generated seed to the console so any session can be reproduced exactly by passing that value back as `seed`.
+## Score Studio (GUI)
 
-## CLI commands
+Score Studio is the Electron-based GUI that ships with Score. It runs your song file live — edit code on the left, hear and see changes in real time.
 
-| Command                              | What it does                                    |
-| ------------------------------------ | ----------------------------------------------- |
-| `score play <song.js>`               | Play a song file                                |
-| `score play <song.js> --watch`       | Live reload — hot-swap on every file save       |
-| `score repl`                         | Interactive REPL — load, play, patch live       |
-| `score list <song.js>`               | Show song info and track list                   |
-| `score export <song.js>`             | Render song to WAV                              |
-| `score export <song.js> --bars 16`   | Render a fixed number of bars                   |
-| `score new song <name>`              | Create a new song from template                 |
-| `score doctor`                       | Check system requirements                       |
+- **Live Code mode** — code editor wired to the engine. BPM and step changes sync back into the code.
+- **Performance mode** — full-screen audio visualizer. Theme declared in song file.
+- **Punchcard grid** — click steps to toggle them. Changes write back to the song file.
+- **Instrument panel** — adjust chain parameters live.
 
-### Watch mode
-
-`--watch` reloads on every save. If the new file has an error, the previous version keeps playing. Add `--trust` to skip the AST security scan on each reload.
-
-Score diffs the incoming song against the running engine: BPM and per-track volume changes apply live without a restart. Structural changes (new tracks, different instruments) trigger a full engine swap at the next bar boundary.
-
-### REPL commands
-
-```
-load <file>         Load a song file (.js / .mjs)
-play                Start playback
-stop                Stop playback
-patch bpm=<n>       Change BPM live
-patch vol=<n>       Change master volume live (0–1)
-status              Show loaded file, BPM, bar count, play state
-help                Show this list
-exit                Quit
+```bash
+# From the score repo
+cd packages/gui && pnpm dev
 ```
 
-## Target genres
+---
 
-House · Deep House · Techno · Industrial · Hardcore · Grime
+## CLI
+
+```bash
+score play <song.js>              # Play a song file
+score play <song.js> --watch      # Live reload on every save
+score new song <name>             # Create a new song from template
+score list <song.js>              # Show song info and track list
+score export <song.js>            # Render to WAV
+score repl                        # Interactive REPL
+score doctor                      # Check system requirements
+```
+
+---
 
 ## Packages
 
-| Package            | Purpose                                                        |
-| ------------------ | -------------------------------------------------------------- |
-| `@score/core`      | AudioContext, AudioGraphManager, ScoreError                    |
-| `@score/components`| Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp         |
-| `@score/effects`   | Reverb, Delay, Filter, Compressor, Sidechain, EQ, Phaser, etc. |
-| `@score/dsl`       | Song, Track, Sequence, arrangement section factories           |
-| `@score/sequencer` | Transport, Clock, TempoMap, Swing/Groove                       |
-| `@score/mixer`     | Mixer, Channel, return bus, master chain, hard limiter         |
-| `@score/math`      | Chaos, fractals, stochastic processes, tuning, transforms      |
-| `@score/modulation`| LFO, ADSR, ramp/sine/cosine sources, automation wiring         |
-| `@score/pattern`   | Pattern combinators, Euclidean rhythms, permutations           |
-| `@score/musical`   | Natural language instrument description (`describe()`)         |
-| `@score/cli`       | play, repl, list, export, new, doctor commands                 |
-| `@score/midi`      | WebMIDI bridge, Pioneer XDJ profiles, controller mappings      |
-| `@score/session`   | Jam session — engine + MIDI coordination for live performance  |
-| `@score/mcp`       | MCP servers for Claude Code integration                        |
-| `@score/gui`       | Score Studio — React DAW interface (Phase 13)                  |
+| Package | Purpose |
+|---|---|
+| `@score/core` | AudioContext, AudioGraphManager, ScoreError |
+| `@score/components` | Kick, Snare, HiHat, Synth, FMSynth, SubtractiveSynth |
+| `@score/effects` | Reverb, Delay, Filter, Compressor, Sidechain, EQ, Phaser |
+| `@score/dsl` | Song, Track, chain API (Bass303, Pad, Pluck, Rhodes) |
+| `@score/sequencer` | Transport, Clock, TempoMap, TemporalTick |
+| `@score/mixer` | Mixer, Channel, return bus, master chain |
+| `@score/math` | Chaos, fractals, stochastic (Lorenz, logistic map, OUProcess) |
+| `@score/modulation` | LFO, ADSR, ramp/sine, automation wiring |
+| `@score/pattern` | Euclidean rhythms, combinators, permutations |
+| `@score/visuals` | Visual themes, rendering targets, per-song canvas |
+| `@score/cli` | play, repl, list, export, new, doctor |
+| `@score/midi` | WebMIDI bridge, Pioneer XDJ profiles |
+| `@score/session` | Jam session, WebSocket sync |
+| `@score/mcp` | MCP servers for Claude Code integration |
+| `@score/gui` | Score Studio — Electron DAW interface |
+
+---
 
 ## Requirements
 
 - Node.js 20+
 - pnpm 10+
 
-## Open issues
-
-- [#22](https://github.com/bwyard/score/issues/22) — Standardise CLI switches and `--help` across all commands. The CLI currently hand-rolls flag parsing per-command with no consistent `--help` output format or unknown-flag handling. This needs a project-wide standard before more commands are added.
-
-## Status
-
-Building in phases. See `SCORE_HANDOFF.md` for the full architecture and phase plan.
-
-Phase 12 is the milestone that matters: `score play songs/first-track.js` runs and makes music.
+---
 
 ## License
 
-TBD
+Open source — license TBD. Author: Bree Yard.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,6 +6,7 @@
 
 | Doc | What it answers |
 |-----|-----------------|
+| [ROADMAP.md](./ROADMAP.md) | Current milestones, ecosystem architecture, all key decisions, release model |
 | [THESIS_COMPLIANCE.md](./THESIS_COMPLIANCE.md) | What "pure functional" means per layer, what is exempt, what is never allowed |
 | [TESTING_STRATEGY.md](./TESTING_STRATEGY.md) | Per-package testing approach, pyramid, E2E roadmap |
 | [DEVELOPMENT_STRATEGY.md](./DEVELOPMENT_STRATEGY.md) | Phase ownership, what ships now, what is stubbed, what is post-Friday |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,161 @@
+# Score — Roadmap & Architectural Decisions
+
+> This document captures the current roadmap, ecosystem scope, and key architectural decisions.
+> Read this alongside the ADRs in `docs/adr/` before making structural changes.
+> Last updated: 2026-03-23
+
+---
+
+## Immediate Milestones
+
+### Friday Demo — 2026-03-28
+Full band playable in Score Studio GUI. Target instruments:
+
+| Instrument | Status |
+|---|---|
+| Kick808 / Snare909 / HiHat808 | ✅ Done |
+| SubtractiveSynth lead | ✅ Done |
+| FMSynth | ✅ Done |
+| All modes accessible in GUI | ✅ Done (PR #63) |
+| BPM sync + punchcard step click | ✅ Done (PR #64) |
+| Percussion chain API + STARTER fix | ✅ Done (PR #66) |
+| Performance canvas | ✅ Done (PR #65) |
+| Pad engine | W3 in progress |
+| Rhodes engine | W3 in progress |
+| Pluck engine | W3 in progress |
+| Bass303 engine | W3 in progress |
+
+### Tester Package (after Friday)
+Hard blockers before any tester ships:
+- ⛔ t257 — Onboarding planning session (must happen first)
+- t184 — Engine crash resilience (W1 in progress)
+- Electron packaging / installers (W2 in progress)
+- Tester onboarding doc (output of t257)
+
+---
+
+## Ecosystem Architecture
+
+Score is one tool in a larger temporal architecture ecosystem. All tools share the same DSL philosophy — see `research/working/DSL_GUIDELINES.md` for the universal rules.
+
+### Named Tools
+
+| Tool | Domain | Status | Notes |
+|---|---|---|---|
+| **Prime** | Math primitives | Done | Rust + WASM, pure functions |
+| **Score** | Audio / EDM | Active Phase 13 | This repo |
+| **Form** | SDF graphics | Phase 6 complete, paused | Owns visual layer long-term |
+| **Stage** | Game runtime | 35 PRs merged, paused | Needs DSL layer |
+| **Trace** | Visual rendering | In `@score/visuals` (temp) | Extract when Form activates |
+| **Conductor** | Cross-tool sync | Not started | Needs Pact first |
+| **Pact** | Shared event schema | Not started | Required before Conductor |
+| **Chronicle** | Temporal storage/query | Not started | Stage `EventLog<T>` is the embryo |
+| **Gate** | Hardware/physical input | Not started | Stage `stage-input` is the embryo |
+| **Proof** | Temporal testing/invariants | Not started | SDET → thesis bridge |
+| **Relay** | Distributed sync | Not started | Most ambitious, last |
+
+### Visual Package Decision
+`@score/visuals` is a **temporary home**. The visual rendering layer belongs to Form or a standalone package (naming candidates: Trace, Prism, Lens — decision required before Form Phase 1 starts). **Do not add Score-specific assumptions to `@score/visuals`.**
+
+### Thesis Embryos Already Implemented
+- `stage-events` `EventLog<T>` → Chronicle
+- `stage-input` three-layer action-mapped input → Gate
+
+---
+
+## DSL Design Principles (universal across all tools)
+
+1. **Factory functions, not classes** — `Tool(config)` not `new Tool(config)`
+2. **Chaining over imperative** — `.filter(600).resonance(0.4)` not `instrument.setFilter(600)`
+3. **Pure functions at the call site** — song/scene/game files declare, they don't execute
+4. **`const` + arrow functions only** — zero `let`, zero `function` declarations
+5. **Immutable config** — never mutate props, return new state
+6. **Named intermediates over mega-chains** — name things at complexity boundaries
+7. **Progressive disclosure** — 5-10 methods cover 90% of use cases; `__raw` is the floor
+8. **Sensible defaults** — every parameter should produce something useful without config
+9. **TODO placeholders in templates** — never pre-fill values in generated files
+10. **Error factories not throws** — `ScoreError({ code, message, fix })` everywhere
+
+---
+
+## Phase 13 — Current Phase
+
+**Theme:** GUI + bidirectional wiring + full instrument band.
+
+### Completed
+- Score Studio scaffold (Electron + React)
+- InstrumentPanel + InstrumentPicker components (PR #56)
+- Performance Mode shell (PR #57)
+- `SongProps.theme` for visual selection (PR #58)
+- Strategy docs index (PR #59)
+- InstrumentPanel wiring — patchChainMethod, debounced re-eval (PR #60)
+- Thesis `let` cleanup (PR #61)
+- `@score/visuals` scaffold — 7 targets, 10 themes, 108 tests, TemporalTick (PR #62)
+- All modes unlocked for demo (PR #63)
+- Bidirectional wiring — BPM sync + punchcard step click (PR #64)
+- Percussion chain API migration — all drums now ChainablePart (PR #66)
+- PerformanceCanvas wiring — useAudioVisualState + live renderer (PR #65)
+
+### In Progress
+- Melodic instrument engines: Pad, Rhodes, Pluck, Bass303 (W3)
+- Engine crash resilience — keep playing on error, show toast (W1)
+- Electron packaging + installers (W2)
+
+### Pending (Phase 13 close-out)
+- feat/gui-accessibility-zoom — PR #67, CI running
+- ⛔ t257 Onboarding planning session — hard blocker before tester ships
+- t171 Full project status review before v0.1.0
+
+---
+
+## Post-Phase 13 Roadmap
+
+### Phase 14 — DSL Completeness
+- t245/t246 — Pattern utilities re-exported from `@score/dsl` + `.pattern(p)` chain method
+- t240 — theory.ts expansion (transpose, relativeMinor, dominantOf, etc.)
+- t244 — `dsl/src/math.ts` adapter layer (musical names, curried transforms)
+- t247 — `.phaser()/.gate()/.multiband()` chain methods
+
+### Planning Sessions Required Before Starting
+These areas require a dedicated planning session before any window touches them:
+- t252 — Undo/redo
+- t253 — File format + autosave
+- t254 — Pattern streams / `set()`
+- t255 — Export pipeline
+- t256 — Piano roll editing
+- t257 — ⛔ Onboarding (tester blocker)
+- t258 — Distribution / release candidate
+- t259 — Keyboard shortcuts
+- t260 — Collaboration / Conductor
+
+### Thesis Violations to Fix (tracked debt)
+- `@score/midi` — `let` violations (critical)
+- `@score/cli` play.ts — `let` violations (high)
+- `@score/components` fm.ts — `let` violations (high)
+
+---
+
+## Release Model
+
+**Free open-source release under real name: Bree Yard.**
+Pseudonymous / Satoshi-Bourbaki release model dropped (2026-03-23).
+Dual-license business model (Red Hat/MongoDB pattern) remains viable if desired later.
+
+**IP protection:**
+1. Email detailed thesis to Gmail before any public release — timestamp is legally meaningful
+2. GitHub ADRs are prior art with commit timestamps — **do not modify existing ADRs**
+3. Publish thesis MVP to arXiv when ready (pseudonymous release works there)
+4. US Copyright Office registration when paper is developed
+
+---
+
+## Key Non-Negotiables (do not reverse)
+
+- No AI-generated music, patterns, or full songs — ever
+- No samples bundled — user brings their own
+- Song files run as plain ESM — never compiled
+- Web Audio API fully abstracted behind the DSL
+- `ScoreError` factory for all errors — never `throw new Error()`
+- Zero `let`, zero `class`, zero `new` (except Web Audio API internals)
+- Every public export gets TSDoc
+- Tests and error handling ship with the component — never backfilled


### PR DESCRIPTION
## Summary
- README updated to reflect Phase 13 state, chain API song example, Score Studio section, accurate package list
- New `docs/ROADMAP.md` — single source of truth for milestones, ecosystem architecture, and all key decisions
- `docs/INDEX.md` — ROADMAP added as first strategy doc

## ROADMAP covers
- Friday demo + tester package milestones (current status)
- Full 11-tool ecosystem map with status (Score/Prime/Form/Stage/Trace/Conductor/Pact/Chronicle/Gate/Proof/Relay)
- Visual package architecture decision (`@score/visuals` is temporary, belongs to Form/Trace long-term)
- Universal DSL design principles (10 rules, apply to all tools)
- Phase 13 completed/in-progress/pending tracking
- Post-Phase 13 roadmap + planning session blockers
- Thesis debt violations flagged
- Release model: free open source, Bree Yard
- Non-negotiables section

## Test plan
- [ ] CI passes (docs only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)