### PR TITLE
chore: turbo build hooks + session checklist + ROADMAP planning sessions

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Rebuild library packages after branch switch — dist/ may differ between branches.
+# Excludes @score/gui (Electron app, not a library — run pnpm dev separately).
+# Turbo only rebuilds what changed (cached), so this is fast on small switches.
+pnpm turbo build --filter='!@score/gui'

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Rebuild library packages after pulling — keeps dist/ in sync with source.
+# Excludes @score/gui (Electron app, not a library — run pnpm dev separately).
+# Turbo only rebuilds what changed (cached), so this is fast on small pulls.
+pnpm turbo build --filter='!@score/gui'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,5 +151,8 @@ Key docs:
 1. Read session file: `../claude-resources/sessions/score/current.md`
 2. Check signals: `node ../claude-resources/session.js signals`
 3. Read `docs/INDEX.md` — find the doc you need
-4. Run `pnpm test` — confirm all tests passing
-5. Check current phase in `SCORE_HANDOFF.md`
+4. Run `pnpm turbo build --filter='!@score/gui'` — rebuild all library packages in dependency order (keeps dist/ in sync after pulls/merges). Excludes the Electron app — run `pnpm dev` separately for GUI work.
+5. Run `pnpm test` — confirm all tests passing
+6. Check current phase in `SCORE_HANDOFF.md`
+
+> **Why turbo build:** Packages like `@score/sequencer` and `@score/visuals` resolve via `dist/`. If a PR added new exports and you haven't rebuilt, imports fail at runtime even though source is correct. Turbo is cached — only rebuilds what changed, so this is fast.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,6 +127,8 @@ These areas require a dedicated planning session before any window touches them:
 - t258 — Distribution / release candidate
 - t259 — Keyboard shortcuts
 - t260 — Collaboration / Conductor
+- t281 — Instrument panel UX + full channel strip (dockable, expandable, full ADR 014 chain method set — DAW-competitive GUI)
+- t282 — Per-instrument panel layouts (schedule with t281): Kick/Snare/HiHat/Bass303/FMSynth/SubSynth/Pad/Pluck/Rhodes each get purpose-built compact + expanded panel — progressive disclosure, instrument-aware controls
 
 ### Thesis Violations to Fix (tracked debt)
 - `@score/midi` — `let` violations (critical)


### PR DESCRIPTION
## Summary
- Adds `post-merge` and `post-checkout` husky hooks that run `pnpm turbo build --filter='!@score/gui'` automatically after pulls and branch switches — fixes the `@score/visuals` dist/ stale issue that blocked `pnpm dev`
- Updates CLAUDE.md start-of-session checklist with turbo build step (step 4)
- Adds t281 (instrument panel UX) and t282 (per-instrument panel layouts) planning session blockers to ROADMAP

## Test plan
- [ ] `git pull` on dev triggers auto-rebuild of library packages
- [ ] `git checkout <branch>` triggers auto-rebuild
- [ ] `pnpm --filter @score/gui dev` starts without `@score/visuals` resolution error after a fresh clone + hooks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)