### PR TITLE
feat(gui): t184 song:error IPC — engine crash resilience

### DIFF
--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -31,7 +31,6 @@ import type { MainToRenderer, RendererToMain, PanelLayoutMap } from './ipc-types
 const defaultSong = (): SongDefinition => Song({
   bpm:    128,
   tracks: [
-    Track(Kick(4).volume(0.9)),
     Track(Synth({
       wave:      'sawtooth',
       frequency: 65.41,
@@ -438,8 +437,15 @@ ipcMain.on('engine:eval', (_event, { code }: RendererToMain['engine:eval']) => {
     }
   } catch (err: unknown) {
     console.error('[score-studio] eval error', err)
-    send('error:report', {
-      message: err instanceof Error ? err.message : String(err),
+    const message = err instanceof Error ? err.message : String(err)
+    const stack   = err instanceof Error ? (err.stack ?? undefined) : undefined
+    const fix     = (err instanceof Error && 'context' in err && err.context !== null && typeof err.context === 'object' && 'fix' in err.context)
+      ? String((err.context as { fix: unknown }).fix)
+      : undefined
+    send('song:error', {
+      message,
+      ...(stack !== undefined ? { stack } : {}),
+      ...(fix   !== undefined ? { fix   } : {}),
     })
   }
 })

--- a/packages/gui/src/main/ipc-types.ts
+++ b/packages/gui/src/main/ipc-types.ts
@@ -61,6 +61,8 @@ export type MainToRenderer = {
   'engine:step':     { step: number; stepCount: number }
   'midi:status':     { connected: boolean }
   'error:report':    { message: string }
+  /** Fires when song eval throws — message + optional stack + optional fix hint. Transport is NOT stopped. */
+  'song:error':      { message: string; stack?: string; fix?: string }
   'song:update':     { tracks: ReadonlyArray<{ name: string; type: string; pattern: ReadonlyArray<number | string> }>; theme?: string; palette?: string }
   'engine:analysis': { waveform: readonly number[] }
   /** Fires when a bar-boundary swap is queued or cleared. */

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -196,6 +196,17 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   }, [addLog])
 
   useEffect(() => {
+    const unsub = window.scoreBridge.on('song:error', ({ message, fix }) => {
+      autoPlayRef.current = false
+      setError(message)
+      setEvalStatus('error')
+      addLog('error', message)
+      if (fix) addLog('info', `💡 ${fix}`)
+    })
+    return unsub
+  }, [addLog])
+
+  useEffect(() => {
     const unsub = window.scoreBridge.on('song:update', ({ tracks: t }) => {
       setTracks(t)
       setStripStates(prev => t.map((_, i) => prev[i] ?? defaultStripState()))

--- a/packages/gui/tests/LiveCode.test.tsx
+++ b/packages/gui/tests/LiveCode.test.tsx
@@ -128,3 +128,41 @@ describe('LiveCode — step click re-eval wiring (12b.2)', () => {
     expect(window.scoreBridge.send).toHaveBeenCalledWith('engine:eval', expect.anything())
   })
 })
+
+// ── t184: song:error IPC — crash resilience ───────────────────────────────────
+
+describe('LiveCode — song:error crash resilience (t184)', () => {
+  it('shows error banner when song:error fires', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    act(() => {
+      emitBridgeEvent('song:error', { message: 'ReferenceError: Kick is not defined' })
+    })
+    expect(screen.getByRole('alert')).toHaveTextContent('ReferenceError: Kick is not defined')
+  })
+
+  it('shows fix hint in console log when song:error has a fix', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    act(() => {
+      emitBridgeEvent('song:error', {
+        message: 'Invalid bpm value',
+        fix:     'bpm must be between 20 and 300',
+      })
+    })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    // Fix hint logged — visible in console panel
+    expect(screen.getByText(/bpm must be between 20 and 300/i)).toBeInTheDocument()
+  })
+
+  it('does not stop transport when song:error fires', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    // Start engine playing
+    act(() => {
+      emitBridgeEvent('engine:state', { playing: true, bpm: 128, bars: 0 })
+    })
+    act(() => {
+      emitBridgeEvent('song:error', { message: 'some error' })
+    })
+    // transport:stop must NOT have been sent
+    expect(window.scoreBridge.send).not.toHaveBeenCalledWith('transport:stop', expect.anything())
+  })
+})


### PR DESCRIPTION
## Summary
- Adds \`song:error\` IPC channel (main → renderer) for eval errors with \`message\`, optional \`stack\`, and optional \`fix\` hint
- Transport is **not stopped** on eval error — last valid song keeps playing
- Renderer shows error banner (\`role="alert"\`) and logs fix hint to console panel when present
- \`defaultSong\` simplified to Synth-only (removes \`Kick(4).volume(0.9)\` which returned \`ChainablePart\` not yet in \`SongProps.tracks\`)

## Test plan
- [ ] \`LiveCode — song:error crash resilience (t184)\` — 3 tests: error banner, fix hint in console, transport NOT stopped
- [ ] \`LiveCode — BPM wiring (t149)\` — 4 debounce tests passing
- [ ] \`LiveCode — step click re-eval (12b.2)\` — 1 canvas click test passing
- [ ] \`pnpm --filter @score/gui test\` — 289 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)