### PR TITLE
feat(gui): t152 resizable editor/canvas split

### DIFF
--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -556,7 +556,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
 
       <div style={styles.body} ref={bodyRef}>
         {/* Editor pane — CodeWaveform behind textarea, Strudl aesthetic */}
-        <div style={{ ...styles.editorPane, flex: `0 0 ${splitPct}%` }}>
+        <div style={{ ...styles.editorPane, flex: `0 0 ${String(splitPct)}%` }}>
           {error !== null && (
             <div style={styles.errorBanner} role="alert">
               {error}

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -143,6 +143,38 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   // Debounce timer for re-eval after instrument param changes
   const evalDebounceRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // t152 — resizable editor/canvas split
+  const [splitPct, setSplitPct] = useState(50)
+  const bodyRef = useRef<HTMLDivElement | null>(null)
+  // HARDWARE BOUNDARY — drag state: append-only transitions during pointer lifecycle
+  const dragRef = useRef<{ active: boolean; startX: number; startPct: number }>({
+    active: false, startX: 0, startPct: 50,
+  })
+
+  const onSplitterMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    dragRef.current.active  = true
+    dragRef.current.startX  = e.clientX
+    dragRef.current.startPct = splitPct
+  }, [splitPct])
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent): void => {
+      if (!dragRef.current.active) return
+      const containerW = bodyRef.current?.offsetWidth ?? 1
+      const dx = e.clientX - dragRef.current.startX
+      const newPct = dragRef.current.startPct + (dx / containerW) * 100
+      setSplitPct(Math.min(80, Math.max(20, newPct)))
+    }
+    const onMouseUp = (): void => { dragRef.current.active = false }
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup',   onMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup',   onMouseUp)
+    }
+  }, [])
+
   // t218 — panel layout persistence
   const [savedLayout, setSavedLayout] = useState<PanelLayoutMap>({})
   // Track layout generation so DraggablePanels remount once when saved layout loads
@@ -522,9 +554,9 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
         </div>
       </div>
 
-      <div style={styles.body}>
+      <div style={styles.body} ref={bodyRef}>
         {/* Editor pane — CodeWaveform behind textarea, Strudl aesthetic */}
-        <div style={styles.editorPane}>
+        <div style={{ ...styles.editorPane, flex: `0 0 ${splitPct}%` }}>
           {error !== null && (
             <div style={styles.errorBanner} role="alert">
               {error}
@@ -577,6 +609,15 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
             </div>
           </div>
         </div>
+
+        {/* Drag splitter — resize editor/canvas split */}
+        <div
+          role="separator"
+          aria-label="Resize editor pane"
+          aria-orientation="vertical"
+          style={styles.splitter}
+          onMouseDown={onSplitterMouseDown}
+        />
 
         {/* Floating panel canvas */}
         <div style={styles.canvas}>
@@ -759,11 +800,20 @@ const styles = {
   },
   body: { display: 'flex', flex: 1, overflow: 'hidden' },
   editorPane: {
+    // flex is overridden inline with splitPct state — this value acts as fallback only
     flex:          '0 0 50%',
-    borderRight:   '1px solid #1e1e22',
     display:       'flex',
     flexDirection: 'column' as const,
     background:    '#0d0d10',
+    overflow:      'hidden',
+  },
+  splitter: {
+    width:          '6px',
+    cursor:         'col-resize',
+    background:     '#1e1e22',
+    flexShrink:     0,
+    transition:     'background 0.15s',
+    userSelect:     'none' as const,
   },
   errorBanner: {
     background:   '#3a1a1a',

--- a/packages/gui/tests/LiveCode.test.tsx
+++ b/packages/gui/tests/LiveCode.test.tsx
@@ -166,3 +166,38 @@ describe('LiveCode — song:error crash resilience (t184)', () => {
     expect(window.scoreBridge.send).not.toHaveBeenCalledWith('transport:stop', expect.anything())
   })
 })
+
+// ── t152: resizable editor split ──────────────────────────────────────────────
+
+describe('LiveCode — resizable editor/canvas split (t152)', () => {
+  it('renders splitter with aria-label "Resize editor pane"', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    expect(screen.getByLabelText('Resize editor pane')).toBeInTheDocument()
+  })
+
+  it('splitter has role=separator', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    const splitter = screen.getByLabelText('Resize editor pane')
+    expect(splitter).toHaveAttribute('role', 'separator')
+  })
+
+  it('splitter has col-resize cursor style', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    const splitter = screen.getByLabelText('Resize editor pane')
+    expect(splitter).toHaveStyle({ cursor: 'col-resize' })
+  })
+
+  it('mousedown on splitter does not throw', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    const splitter = screen.getByLabelText('Resize editor pane')
+    expect(() => { fireEvent.mouseDown(splitter, { clientX: 400 }) }).not.toThrow()
+  })
+
+  it('mousemove after splitter mousedown does not throw', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    const splitter = screen.getByLabelText('Resize editor pane')
+    fireEvent.mouseDown(splitter, { clientX: 400 })
+    expect(() => { fireEvent.mouseMove(window, { clientX: 450 }) }).not.toThrow()
+    fireEvent.mouseUp(window)
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces hard-coded `flex: 0 0 50%` on the editor pane with a draggable divider
- `splitPct` state (default 50, clamped 20–80) drives the split ratio
- 6px splitter div inserted between editor and canvas panes with `cursor: col-resize`
- Drag gesture: mousedown on splitter → window mousemove computes new % → mouseup releases
- `bodyRef` measures container width for correct relative calculation
- `role="separator"` + `aria-label="Resize editor pane"` for accessibility

## Test plan

- [ ] 5 new tests: splitter present, role, cursor, drag events (312 total GUI tests, all passing)
- [ ] Typecheck clean
- [ ] Manual: drag the divider left/right in LiveCode mode — editor and canvas resize proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)