### PR TITLE
fix(gui): renderer black screen on launch

### DIFF
--- a/packages/gui/electron.vite.config.ts
+++ b/packages/gui/electron.vite.config.ts
@@ -33,7 +33,15 @@ export default defineConfig({
     build:    { externalizeDeps: true },
   },
   renderer: {
+    // BOUNDARY — renderer: Chromium/browser environment, no Node.js APIs
+    // Only alias packages that are imported as values (not type-only) in renderer source.
+    // @score/visuals pulls in @score/math (lorenz theme) — both must be aliased together.
+    // @score/sequencer / @score/dsl etc. are type-only in renderer — no alias needed.
     root:    'src/renderer',
     plugins: [react()],
+    resolve: { alias: {
+      '@score/visuals': ws('visuals/src/index.ts'),
+      '@score/math':    ws('math/src/index.ts'),
+    }},
   },
 })

--- a/packages/gui/src/renderer/main.tsx
+++ b/packages/gui/src/renderer/main.tsx
@@ -2,11 +2,39 @@ import React        from 'react'
 import { createRoot } from 'react-dom/client'
 import { App }      from './App.js'
 
+// Dev error boundary — surfaces render crashes that would otherwise leave a blank screen.
+// Shows the error message + stack directly in the window so DevTools aren't needed to diagnose.
+class DevErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props)
+    this.state = { error: null }
+  }
+  static getDerivedStateFromError(error: Error) { return { error } }
+  render() {
+    const { error } = this.state
+    if (error) {
+      return (
+        <div style={{ padding: '2rem', fontFamily: 'monospace', color: '#ff6b6b', background: '#0d0d0f', height: '100vh' }}>
+          <h2 style={{ color: '#ff6b6b', marginBottom: '1rem' }}>Renderer crash</h2>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.85rem' }}>{error.message}</pre>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.75rem', color: '#888', marginTop: '1rem' }}>{error.stack}</pre>
+        </div>
+      )
+    }
+    return this.state.error === null ? this.props.children : null
+  }
+}
+
 const root = document.getElementById('root')
 if (!root) throw new Error('root element not found')
 
 createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <DevErrorBoundary>
+      <App />
+    </DevErrorBoundary>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Problem

Score Studio launched with a black window — no UI, no error message in the terminal.

Three root causes:

**1. `electron-updater` not installed**
`main/index.ts` imports `{ autoUpdater } from 'electron-updater'` at the top level but the package wasn't in `dependencies`. The `require()` at module load time threw before `app.on('ready')` ran, so `loadURL` was never called. Window opened (OS chrome) but renderer never loaded.

**2. Renderer Vite config had no `@score/*` aliases**
`PerformanceCanvas.tsx` has `import { getTheme } from '@score/visuals'` — a runtime value import. `@score/visuals` internally imports `createLorenz` from `@score/math`. The renderer config had no aliases so Vite tried to resolve both through pnpm's virtual store symlinks on Windows. This fails silently — React tree unmounts, `#root` stays empty, you see the `backgroundColor` (`#0c0c0e` = black), zero error output.

Fix: added `@score/visuals` and `@score/math` to `renderer.resolve.alias` pointing to TypeScript source. Both packages are browser-safe (no Node.js APIs).

**3. No error boundary**
Any renderer crash left a blank page with no feedback. Added `DevErrorBoundary` in `main.tsx` — renders the error message + stack directly on screen so DevTools aren't needed to diagnose future crashes.

## Changes

- `packages/gui/package.json` — added `electron-updater` to `dependencies`
- `packages/gui/electron.vite.config.ts` — added renderer aliases for `@score/visuals` + `@score/math`; removed redundant `rollupOptions.external` (not needed now package is installed)
- `packages/gui/src/renderer/main.tsx` — added `DevErrorBoundary`

## Test

```bash
pnpm --filter @score/gui dev
```

Should show Score Studio splash screen — "What are you doing today?" with 4 mode cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)