### PR TITLE
docs: update README + CONTRIBUTING + GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Something isn't working
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What should have happened? -->
+
+## Song file / code snippet
+
+```js
+// Paste the minimal song or DSL snippet that triggers the bug
+```
+
+## Environment
+
+- Score version:
+- Node version (`node --version`):
+- OS:
+- Electron app or CLI (`score play`)?
+
+## Logs / error output
+
+```
+<!-- Paste the full error message or stack trace -->
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / questions
+    url: https://github.com/bwyard/score/discussions
+    about: Ask questions and share what you're making

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an instrument, synthesis technique, DSL method, or other addition
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## What do you want?
+
+<!-- A clear description of the feature. Be specific — instrument name, genre, chain method, etc. -->
+
+## Why?
+
+<!-- What genre, use case, or sound does this unlock? -->
+
+## DSL sketch (optional)
+
+```js
+// How would it look at the call site?
+// Example: Bass303('A2').slide(0.2).accent(0.8).pattern([...])
+```
+
+## References (optional)
+
+<!-- Links to synthesis papers, Wikipedia, existing tools, or audio examples. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Always welcome. Include a failing test that the fix makes pass.
 
 ## Reporting issues
 
-Open an issue on GitHub. For security vulnerabilities, email bree@breeyard.com directly — do not open a public issue.
+Open an issue on GitHub. For security vulnerabilities, email byard29@gmail.com directly — do not open a public issue.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing to Score
 
-Thank you for contributing to Score.
+Score is an open-source EDM audio framework. Contributions are welcome — instruments, synthesis techniques, DSL methods, effects, tests, and documentation.
+
+Read this before opening a PR.
+
+---
 
 ## Contributor License Agreement
 
@@ -10,32 +14,115 @@ before their pull request can be merged.**
 By opening a pull request, you automatically agree to the CLA terms. No
 separate signature is required — your PR submission is your agreement.
 
-## Code Standards
+---
 
-All contributions must follow the project thesis:
+## Philosophy
 
-- Zero `let` — `const` everywhere
-- Zero `class` — factory functions only
-- Pure functions by default
-- Append-only state — new versions, not mutations
-- IO and hardware boundaries annotated explicitly with `// BOUNDARY — [reason]`
+Score has a strict design philosophy. Every contribution must follow it.
 
-Contributions that do not follow these standards will receive a change request.
+- **Math reads as music.** Frequencies, rhythms, envelopes — a song is a pure function of time.
+- **Factory functions, not classes.** `createKick808(props)` returns a plain object. Never `new`.
+- **Zero `let`, zero `class`, zero `new`** (except Web Audio API internals).
+- **Immutable config.** Never mutate props — return new state.
+- **`const` and arrow functions only.**
+- **`ScoreError` factory for all errors.** Never `throw new Error(...)`.
+- **No AI-generated music, patterns, or full songs.** Ever.
+- **No audio samples bundled.** Users bring their own.
+- **Song files run as plain ESM.** Never compiled.
 
-## Pull Request Process
+If you haven't read the ADRs in `docs/adr/`, start there. ADR 001 and ADR 014 are essential.
 
-1. Fork the repository and create your branch from `dev`
-2. Write tests for any new functionality
-3. Ensure all existing tests pass (`pnpm test`)
-4. Add TSDoc comments to all public exports
-5. Open your PR against `dev` (not `main`)
-6. A maintainer will review and merge
+---
 
-## Reporting Issues
+## Getting started
 
-Open an issue on GitHub. For security issues, email bree@breeyard.com directly.
+```bash
+# Prerequisites: Node 20 LTS, pnpm
+git clone https://github.com/bwyard/score
+cd score
+pnpm install
+pnpm turbo build --filter='!@score/gui'
+pnpm test
+```
+
+Branch off `dev`. PRs go into `dev`. Never target `main` directly.
+
+```bash
+git checkout dev
+git checkout -b feat/your-feature
+```
+
+---
+
+## What we want
+
+### Instruments
+New synthesis engines following the `AudioComponent` interface. See existing engines in `packages/components/src/` for examples:
+- `createKick808.ts` — envelope + sine body
+- `createFMSynth.ts` — operator-based FM
+- `createSubtractiveSynth.ts` — oscillator + filter + envelope
+
+Every instrument needs:
+- Factory function returning a plain object (`AudioComponent` shape)
+- Full TSDoc on all public exports
+- Tests shipping with the component (not backfilled)
+- Chain method support via `ChainableTrack` from `@score/dsl`
+
+### Chain methods
+New `.method()` additions to the fluent DSL (ADR 014). Pitch, modulation, effects, sequencing. Open an issue first to discuss scope.
+
+### Effects
+`@score/effects` — reverb, delay, distortion, etc. Must be functional, no class instances.
+
+### DSL / patterns
+`@score/pattern` and `@score/dsl` — pattern utilities, mini-notation, theory helpers.
+
+### Bug fixes
+Always welcome. Include a failing test that the fix makes pass.
+
+---
+
+## Code standards
+
+- TypeScript strict mode. No `any`.
+- All public exports get TSDoc: `/** */` block with `@param`, `@returns`, `@example`, `@throws {ScoreError}`.
+- Tests use Vitest. Coverage thresholds: 90/85/90/90 (statements/branches/functions/lines).
+- CI must pass before merge: `typecheck → lint → test → coverage`.
+- Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`.
+- IO and hardware boundaries annotated with `// BOUNDARY — [reason]`.
+
+---
+
+## PR checklist
+
+- [ ] Branched off `dev`, targeting `dev`
+- [ ] All tests pass (`pnpm test`)
+- [ ] No `let`, no `class`, no `new` (outside Web Audio API)
+- [ ] Every public export has TSDoc
+- [ ] Tests ship with the component (not in a separate PR)
+- [ ] `ScoreError` used for all errors
+- [ ] CI green
+
+---
+
+## What we don't accept
+
+- AI-generated music, patterns, or songs
+- Bundled audio samples
+- Class-based architecture
+- Direct mutations of config objects
+- Raw `throw new Error(...)` — use `ScoreError`
+- PRs that break existing tests without explanation
+- Features that conflict with ADRs without a new ADR discussion
+
+---
+
+## Reporting issues
+
+Open an issue on GitHub. For security vulnerabilities, email bree@breeyard.com directly — do not open a public issue.
+
+---
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the
-same terms as the project. See [LICENSE](LICENSE) and [CLA.md](CLA.md).
+By contributing, you agree that your contributions will be licensed under the same terms as the project. See [LICENSE](LICENSE) and [CLA.md](CLA.md).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Score
 
-> A production-level, component-based audio framework for creating EDM music in JavaScript.
+> A production-level, component-based EDM audio framework for creating music as code in TypeScript/JavaScript.
 
-**Status:** Active development — Phase 13 (GUI + bidirectional wiring). Score Studio running. Friday demo target: full band playable in GUI.
+**Author:** Bree Yard
+**Status:** Active development — Phase 13 (Score Studio GUI). Tester release in progress.
 
 ---
 
@@ -10,55 +11,56 @@
 
 Score is two things simultaneously:
 
-1. **A framework** (TypeScript) — the engine, components, effects, sequencer, mixer, CLI, and GUI
-2. **A language** (plain JavaScript) — the song file format that musicians and developers use to write music as code
+1. **A framework** (TypeScript) — the engine, instruments, effects, sequencer, mixer, CLI, and GUI
+2. **A language** (plain ESM) — the song file format that musicians and developers use to write music as code
 
 The core philosophy: **a song is a pure function of time.** Every note, pattern, effect value, and arrangement decision is written by hand. No AI generates any musical content — ever.
-
-Score is part of a larger ecosystem. See [ROADMAP.md](./docs/ROADMAP.md) for the full picture.
 
 ---
 
 ## Song files look like this
 
 ```js
-import { Song, Kick808, Snare, HiHat, Bass303, Pad } from '@score/dsl'
+import { Song, Kick808, Snare909, Hihat808, Bass303, Pad } from '@score/dsl'
 
-// Drums — pattern array (1 = hit, 0 = rest)
-const kick  = Kick808({ pattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0], volume: 0.75 })
-const snare = Snare({   pattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0], volume: 0.5  })
-const hihat = HiHat({   pattern: [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0], volume: 0.2  })
+// Drums — chain API
+const kick  = Kick808().pattern([1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0]).volume(0.8)
+const snare = Snare909().pattern([0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0]).volume(0.55)
+const hihat = Hihat808().pattern([1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0]).volume(0.25)
 
-// Melodic — chain API
+// Melodic — chain API preserves sub-type through composition
 const bass = Bass303('A2')
-  .filter(600)
+  .cutoff(600)
   .resonance(0.4)
-  .pattern([1,0,0,0, 0,0,1,0, 1,0,0,0, 0,1,0,0])
+  .pattern(['A2', 0, 0, 0, 'D3', 0, 0, 0])
   .volume(0.7)
 
-const pad = Pad('A3')
+const pad = Pad('Am')
   .attack(0.3)
   .release(1.2)
   .reverb(0.3)
-  .volume(0.35)
+  .volume(0.4)
 
 export default Song({ bpm: 128, tracks: [kick, snare, hihat, bass, pad] })
 ```
+
+Chain methods are fully type-safe. `Bass303().cutoff(600).volume(0.8)` returns `Bass303Part` — sub-type methods are preserved through every composition step.
 
 ---
 
 ## Score Studio (GUI)
 
-Score Studio is the Electron-based GUI that ships with Score. It runs your song file live — edit code on the left, hear and see changes in real time.
+Score Studio is the Electron-based GUI that ships with Score. Edit code on the left, hear and see changes in real time.
 
-- **Live Code mode** — code editor wired to the engine. BPM and step changes sync back into the code.
+- **Live Code mode** — code editor wired to the engine. Ctrl+Enter evals. BPM, step toggles, and mixer changes write back to the code.
 - **Performance mode** — full-screen audio visualizer. Theme declared in song file.
-- **Punchcard grid** — click steps to toggle them. Changes write back to the song file.
-- **Instrument panel** — adjust chain parameters live.
+- **Punchcard grid** — click steps to toggle. Changes write back to the editor.
+- **Mixer** — per-track volume/mute faders. Drag to update `.volume()` in code.
+- **Import toggle** — hide/show the import block for a cleaner editing view.
 
 ```bash
-# From the score repo
-cd packages/gui && pnpm dev
+# From the score repo root
+pnpm --filter @score/gui dev
 ```
 
 ---
@@ -81,28 +83,50 @@ score doctor                      # Check system requirements
 
 | Package | Purpose |
 |---|---|
-| `@score/core` | AudioContext, AudioGraphManager, ScoreError |
-| `@score/components` | Kick, Snare, HiHat, Synth, FMSynth, SubtractiveSynth |
-| `@score/effects` | Reverb, Delay, Filter, Compressor, Sidechain, EQ, Phaser |
-| `@score/dsl` | Song, Track, chain API (Bass303, Pad, Pluck, Rhodes) |
-| `@score/sequencer` | Transport, Clock, TempoMap, TemporalTick |
-| `@score/mixer` | Mixer, Channel, return bus, master chain |
-| `@score/math` | Chaos, fractals, stochastic (Lorenz, logistic map, OUProcess) |
-| `@score/modulation` | LFO, ADSR, ramp/sine, automation wiring |
-| `@score/pattern` | Euclidean rhythms, combinators, permutations |
+| `@score/core` | AudioContext backend, ScoreError, UID |
+| `@score/components` | Kick808/909, Snare909, Hihat808, FMSynth, SubtractiveSynth, Bass303, Pad, Rhodes, Pluck |
+| `@score/effects` | Reverb, Delay, Filter, Compressor, EQ, Distortion, Chorus, Phaser, Flanger, Limiter, Gate, Saturation, AutoPan, BitCrusher, StereoWidener |
+| `@score/dsl` | Song, Track, chain API (Bass303, Pad, Pluck, Rhodes, Kick808, etc.), `ChainMethods<T>` |
+| `@score/sequencer` | Transport, step sequencer, bar callbacks |
+| `@score/mixer` | Mixer, channel strips, return bus, master chain |
+| `@score/math` | Chaos math — Lorenz, logistic map, OUProcess (stochastic basis) |
+| `@score/modulation` | LFO, ADSR, ramp/sine/OU, automation wiring |
+| `@score/pattern` | Euclidean rhythms, combinators, reverse, shift, degrade |
 | `@score/visuals` | Visual themes, rendering targets, per-song canvas |
 | `@score/cli` | play, repl, list, export, new, doctor |
 | `@score/midi` | WebMIDI bridge, Pioneer XDJ profiles |
 | `@score/session` | Jam session, WebSocket sync |
-| `@score/mcp` | MCP servers for Claude Code integration |
+| `@score/mcp` | MCP tools for Claude Code integration |
 | `@score/gui` | Score Studio — Electron DAW interface |
 
 ---
 
-## Requirements
+## Development
 
-- Node.js 20+
-- pnpm 10+
+```bash
+# Install dependencies
+pnpm install
+
+# Build all library packages (Turborepo, cached)
+pnpm turbo build --filter='!@score/gui'
+
+# Run all tests
+pnpm test
+
+# Type-check everything
+pnpm typecheck
+
+# Start Score Studio (Electron dev server)
+pnpm --filter @score/gui dev
+```
+
+**Node.js 20 LTS** and **pnpm 10+** required.
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md). All contributors must agree to the [CLA](./CLA.md) before their PR can be merged.
 
 ---
 


### PR DESCRIPTION
## Summary

- **README** — updated to reflect current chain API, correct `Bass303` example (`.cutoff()` not `.filter()`), `ChainMethods<T>` note, full package table, proper dev commands
- **CONTRIBUTING.md** — expanded with PR checklist, test requirements, branch naming
- **`.github/ISSUE_TEMPLATE/`** — add `bug_report.md`, `feature_request.md`, `config.yml`

## Test plan

- [ ] README song example compiles with current `@score/dsl`
- [ ] Issue templates render correctly on GitHub new issue page

🤖 Generated with [Claude Code](https://claude.com/claude-code)