### PR TITLE
docs(dsl): chain API audit + math-bridge design

### DIFF
--- a/docs/design/dsl-audit.md
+++ b/docs/design/dsl-audit.md
@@ -1,0 +1,286 @@
+# DSL Chain API Audit — @score/dsl
+
+**Date:** 2026-03-24
+**Branch:** feat/dsl-chain-audit
+**Author:** W3 audit pass
+
+Definitive picture of what the chain API has, what the engine hydrates, and what silently no-ops.
+
+---
+
+## How to read this table
+
+| Column | Meaning |
+|---|---|
+| **method** | Chain method name as called by the song author |
+| **DSL field** | `PartDescriptor` field set by the method |
+| **exists in DSL** | Method is defined in `chain.ts` and callable |
+| **engine hydrates** | `partToInstrumentDescriptor` (or sequencer) actually uses this field |
+| **note** | How the field is resolved — pre-expand / pass-through / unhydrated |
+
+Hydration path: `partToInstrumentDescriptor` in `packages/cli/src/engine.ts:113-137`.
+
+---
+
+## Pattern group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.speed(n)` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` in DSL — engine gets resolved array |
+| `.slow(n)` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.fast(n)` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.rev()` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.halfTime()` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.doubleTime()` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.tripletTime()` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` |
+| `.retrograde()` | `_speed`, `_pattern` | ✅ | ✅ | Alias for `.rev()` — pre-expands |
+| `.augment(n?)` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` via `slow()` |
+| `.diminish(n?)` | `_speed`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` via `fast()` |
+| `.euclidean(h, s?)` | `_pattern` | ✅ | ✅ | Pre-computes via `euclidean()` from `@score/pattern` |
+| `.shift(n)` | `_pattern` | ✅ | ✅ | Pre-rotates `_pattern` |
+| `.invert()` | `_pattern` | ✅ | ✅ | Flips array in place, engine gets result |
+| `.palindrome()` | `_palindrome`, `_pattern` | ✅ | ✅ | Pre-expands `_pattern` (arr + reversed arr) |
+| `.hits(...args)` | `_pattern` | ✅ | ✅ | Pre-computes step array |
+| `.pattern(pat)` | `_pattern`, `_notes` | ✅ | ✅ | Splits pitch+rhythm — both fields set |
+| `.repeat(n)` | `_repeat` | ✅ | ❌ | `_repeat` NOT in `partToInstrumentDescriptor` — silent no-op |
+| `.mask(pattern)` | `_mask` | ✅ | ❌ | `_mask` NOT hydrated — silent no-op |
+| `.stutter(n)` | `_stutter` | ✅ | ❌ | `_stutter` NOT hydrated — silent no-op |
+| `.degrade(p)` | `_degrade` | ✅ | ❌ | `_degrade` NOT in `partToInstrumentDescriptor` — silent no-op |
+| `.humanize(amt)` | `_humanize` | ✅ | ⚠️ | Passes through as `props.humanize` but `createStepSequencer` only takes `{pattern, steps, seed}` — dead at per-track level |
+| `.swing(amount)` | `_swing` | ✅ | ⚠️ | Passes through as `props.swing` but `createStepSequencer` never reads it — dead at per-track level. Global swing via `createTempoMap` is separate |
+| `.stepProb(probs)` | `_stepProb` | ✅ | ❌ | `_stepProb` NOT hydrated — silent no-op |
+| `.apply(fn)` | `_applyFn` | ✅ | ❌ | `_applyFn` NOT hydrated — silent no-op. Custom pattern transforms are ignored |
+| `.every(n, fn)` | `_every` | ✅ | ❌ | `_every` NOT hydrated — silent no-op |
+| `.stretch(bars)` | `_stretch` | ✅ | ❌ | `_stretch` NOT hydrated — silent no-op |
+| `.phase(amount)` | `_phase` | ✅ | ❌ | `_phase` NOT hydrated — silent no-op |
+| `.fromBar(n)` | `_fromBar` | ✅ | ❌ | `_fromBar` NOT hydrated — silent no-op |
+| `.untilBar(n)` | `_untilBar` | ✅ | ❌ | `_untilBar` NOT hydrated — silent no-op |
+| `.fadeIn(bars)` | `_fadeInBars` | ✅ | ❌ | `_fadeInBars` NOT hydrated — silent no-op |
+| `.fadeOut(bars)` | `_fadeOutBars` | ✅ | ❌ | `_fadeOutBars` NOT hydrated — silent no-op |
+| `.mapNotes(fn)` | `_mapNotesFn` | ✅ | ❌ | `_mapNotesFn` NOT hydrated — silent no-op |
+
+---
+
+## Pitch / notes group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.note(pitch)` | `_notes` | ✅ | ✅ | `_notes: [pitch]` — hydrated to `props.notes` |
+| `.notes(arr)` | `_notes` | ✅ | ✅ | Hydrated to `props.notes` |
+| `.scale(name, root)` | `_scale` | ✅ | ❌ | `_scale` NOT hydrated — silent no-op |
+| `.pitch(semitones)` | `_pitchOffset` | ✅ | ❌ | `_pitchOffset` NOT hydrated — silent no-op |
+| `.octave(n)` | `_octave` | ✅ | ❌ | `_octave` NOT hydrated — silent no-op |
+| `.glide(time)` | `_glide` | ✅ | ❌ | `_glide` NOT hydrated via descriptor. Some instruments read `props.glide` if set via old props API |
+| `.dur(time)` | `_dur` | ✅ | ❌ | `_dur` NOT hydrated — silent no-op |
+
+---
+
+## Amplitude group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.volume(v)` | `_volume` | ✅ | ✅ | Mapped to `gain` (melodic) or `volume` (percussion) |
+| `.attack(s)` | `_adsr.attack` | ✅ | ✅ | Merged into `_adsr` → hydrated as `props.envelope` |
+| `.decay(s)` | `_adsr.decay` | ✅ | ✅ | Same |
+| `.sustain(v)` | `_adsr.sustain` | ✅ | ✅ | Same |
+| `.release(s)` | `_adsr.release` | ✅ | ✅ | Same |
+| `.duckWith(src, opts?)` | `_sidechain` | ✅ | ❌ | `_sidechain` NOT hydrated — pump/duck effects silent no-op |
+| `.pumpWith(src, release?)` | `_sidechain` | ✅ | ❌ | Alias for `duckWith` — same: silent no-op |
+| `.swellWith(src)` | `_sidechain` | ✅ | ❌ | `_sidechain` NOT hydrated — silent no-op |
+| `.sidechain(src, opts?)` | `_sidechain` | ✅ | ❌ | `_sidechain` NOT hydrated — silent no-op |
+
+---
+
+## Tone group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.filter(freq, q?)` | `_filter` | ✅ | ❌ | `_filter` NOT in `partToInstrumentDescriptor` — silent no-op. Note: old props-style instruments read `props.filter` directly but `_filter` is never mapped to `props.filter` |
+| `.eq(lo, mid, hi)` | `_eq` | ✅ | ❌ | `_eq` NOT hydrated — silent no-op |
+| `.bit(bits)` | `_effects` (appended) | ✅ | ✅ | Appends `bitcrusher` EffectDescriptor to `_effects` — hydrated |
+| `.saturate(amt)` | `_effects` (appended) | ✅ | ✅ | Appends `saturation` EffectDescriptor — hydrated |
+
+---
+
+## Space group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.pan(v)` | `_pan` | ✅ | ⚠️ | `_pan` passes through as `props.pan` — but engine never applies it to mixer channel. Mixer channel is created with no pan parameter. Likely dead |
+| `.widen(amt)` | `_effects` (appended) | ✅ | ✅ | Appends `stereo-widener` EffectDescriptor — hydrated |
+| `.reverb(wet, opts?)` | `_effects` (appended) | ✅ | ✅ | Appends `reverb` EffectDescriptor — hydrated |
+| `.delay(time, fb?)` | `_effects` (appended) | ✅ | ✅ | Appends `delay` EffectDescriptor — hydrated |
+| `.chorus(depth?)` | `_effects` (appended) | ✅ | ✅ | Appends `chorus` EffectDescriptor — hydrated |
+| `.flange(depth?)` | `_effects` (appended) | ✅ | ✅ | Appends `flanger` EffectDescriptor — hydrated |
+
+---
+
+## Routing group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.send(bus, amount?)` | `_sends` | ✅ | ❌ | `_sends` NOT hydrated — named bus routing silent no-op |
+| `.mute()` | `_mute` | ✅ | ❌ | `_mute` NOT in `partToInstrumentDescriptor`. GUI muting works via `PatchProps` at runtime |
+| `.solo()` | `_solo` | ✅ | ❌ | `_solo` NOT hydrated — silent no-op |
+| `.chokeGroup(name)` | `_chokeGroup` | ✅ | ❌ | `_chokeGroup` NOT hydrated — hi-hat choke groups silent no-op |
+| `.layer(...parts)` | `_layers` | ✅ | ❌ | `_layers` NOT hydrated — layered parts silent no-op |
+
+---
+
+## Modulation group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.tremolo(rate, depth?)` | `_modulations` | ✅ | ❌ | `_modulations` NOT in `partToInstrumentDescriptor`. Entire modulation system inert |
+| `.vibrato(rate, depth?)` | `_modulations` | ✅ | ❌ | Same |
+| `.wobble(rate, depth?)` | `_modulations` | ✅ | ❌ | Same — LFO on filter cutoff is inert |
+| `.autopan(rate, depth?)` | `_modulations` | ✅ | ❌ | Same |
+| `.flutter(rate?)` | `_modulations` | ✅ | ❌ | Same |
+| `.breathe(rate?)` | `_modulations` | ✅ | ❌ | Same |
+| `.drift(amt?)` | `_modulations` | ✅ | ❌ | Same — OU process pitch drift inert |
+| `.swell(bars)` | `_modulations` | ✅ | ❌ | Same |
+| `.modulate(param, src)` | `_modulations` | ✅ | ❌ | Same — power escape hatch is inert |
+
+---
+
+## Meta group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.seed(n)` | `_seed` | ✅ | ❌ | `_seed` NOT in `partToInstrumentDescriptor`. Only `song.seed` is passed to `createStepSequencer` — per-track seed override silent no-op |
+| `.name(label)` | `_name` | ✅ | ❌ | Cosmetic — GUI mixer only. Not needed for audio |
+| `.model(variant)` | `_model` | ✅ | ✅ | Hydrated to `props.model` — engine dispatches Kick808/Kick909/Snare909/Hihat808 |
+
+---
+
+## Visual group
+
+| method | DSL field | exists in DSL | engine hydrates | note |
+|---|---|---|---|---|
+| `.visual(override)` | `_visual` | ✅ | — | Engine-agnostic by design. `@score/visuals` reads from `TrackVisualState` |
+| `.color(hex)` | `_visual.color` | ✅ | — | Same |
+| `.glyph(kind)` | `_visual.glyph` | ✅ | — | Same |
+| `.label(text)` | `_visual.label` | ✅ | — | Same |
+
+---
+
+## Instrument sub-types
+
+### `SubSynthPart` (from `SubSynth()`)
+
+| method | works? | note |
+|---|---|---|
+| All `ChainMethods<SubSynthPart>` | See table above | Same hydration gaps apply |
+| `.unison(n)` | ✅ | Sets `props.unison` directly — passes through `...part.props` |
+| `.detune(cents)` | ✅ | Sets `props.detune` — passes through `...part.props` |
+
+### `FMSynthPart` (from `FMSynth()`)
+
+| method | works? | note |
+|---|---|---|
+| All `ChainMethods<FMSynthPart>` | See table above | |
+| `.ratio(n)` | ✅ | Sets `props.ratio` — passes through |
+| `.modIndex(n)` | ✅ | Sets `props.modIndex` — passes through |
+| `.feedback(n)` | ✅ | Sets `props.feedback` — passes through |
+
+### `Bass303Part` (from `Bass303()`)
+
+| method | works? | note |
+|---|---|---|
+| All `ChainMethods<Bass303Part>` | See table above | |
+| `.cutoff(freq)` | ✅ | Sets `props.cutoff` — passes through |
+| `.resonance(q)` | ✅ | Sets `props.resonance` — passes through |
+| `.accent(pattern)` | ✅ | Sets `props.accent` — passes through |
+| `.slide(pattern)` | ✅ | Sets `props.slide` — passes through |
+| `.filter()` | ❌ | Base method — `_filter` NOT hydrated (see Tone group above). Use `.cutoff()` + `.resonance()` instead |
+
+---
+
+## Export gap: modulation sources not in `@score/dsl` index
+
+`packages/dsl/src/modulation.ts` defines and exports: `lfo`, `sine`, `ramp`, `lorenz`, `ou`, `logistic`.
+
+**These are NOT re-exported from `packages/dsl/src/index.ts`.**
+
+`import { lfo } from '@score/dsl'` — fails at runtime. Users importing modulation sources must reach into the internal path (`@score/dsl/src/modulation`) which is not the public API.
+
+Fix (separate PR): add to `packages/dsl/src/index.ts`:
+```ts
+export { lfo, sine, ramp, lorenz, ou, logistic } from './modulation.js'
+export type { ModulationDescriptor } from './modulation.js'
+```
+
+---
+
+## Summary of hydration gaps by severity
+
+### Critical — method commonly used, silently no-ops
+
+| method | impact |
+|---|---|
+| `.filter(freq, q?)` | Every bass/pad filter sweep produces no audio effect |
+| `.degrade(p)` | Pattern probability drops silently ignored |
+| `.wobble(rate)` | Dubstep/acid LFO filter wobble inert |
+| `.tremolo(rate)` / `.vibrato(rate)` | Volume/pitch modulation inert |
+| `.duckWith()` / `.pumpWith()` | EDM pumping effect inert |
+| `.swing(amount)` | Per-track swing dead (global swing exists via TempoMap) |
+| `.humanize(amt)` | Per-track timing jitter dead |
+
+### High — used in arrangements
+
+| method | impact |
+|---|---|
+| `.fromBar(n)` / `.untilBar(n)` | Track arrangement timing inert |
+| `.fadeIn(bars)` / `.fadeOut(bars)` | Volume automation inert |
+| `.chokeGroup(name)` | Open/closed hihat choke inert |
+| `.apply(fn)` | Custom pattern transforms (drunk, fibonacci, lorenz) inert |
+| `.scale(name, root)` | Note constraining inert |
+| `.pitch(semitones)` | Transpose inert |
+
+### Normal — less commonly called
+
+| method | impact |
+|---|---|
+| `.send(bus, amount)` | Named bus routing inert |
+| `.solo()` | Solo inert at eval time |
+| `.layer(...parts)` | Layered instruments inert |
+| `.stepProb(probs)` | Per-step probability array inert |
+| `.every(n, fn)` | Cyclic pattern variation inert |
+| `.stretch(bars)` | Pattern bar-fitting inert |
+| `.seed(n)` | Per-track seed override inert |
+| `.stutter(n)` | Stutter repeat inert |
+| `.mask(pattern)` | Pattern gating inert |
+| `.phase(amount)` | Pattern offset inert |
+| `.octave(n)` | Octave shift inert |
+| `.glide(time)` | Portamento inert |
+| `.dur(time)` | Note duration inert |
+| `.mapNotes(fn)` | Note transform inert |
+| `.repeat(n)` | Pattern repeat inert |
+| `.pan(v)` | Stereo pan likely inert (passes through props but engine never applies to channel) |
+
+### Low — cosmetic / design-intent not yet reached
+
+| method | impact |
+|---|---|
+| `.eq(lo, mid, hi)` | 3-band EQ inert |
+| `.swellWith(src)` | Reverse sidechain inert |
+| `.name(label)` | GUI-only, not needed for audio |
+
+---
+
+## ADR 014 conformance
+
+ADR 014 spec matches what was built in structure — `ChainablePart`, immutable spread, factory functions, correct method groupings. The gap is hydration depth, not design.
+
+ADR 014 method set (committed):
+- Pattern group ✅ (pre-expand methods work; stochastic/sequence methods deferred)
+- Pitch/notes ✅ (notes/note hydrated; scale/pitch/octave deferred)
+- Amplitude ✅ (volume + ADSR work; sidechain deferred)
+- Tone ⚠️ (bit/saturate via effects work; `.filter()` and `.eq()` are critical gaps)
+- Space ✅ (reverb/delay/chorus/flange/widen via effects work; pan questionable)
+- Routing ❌ (send/solo/chokeGroup/layer all deferred)
+- Modulation ❌ (entire `_modulations` system deferred — nothing hydrates it)
+- Meta ⚠️ (model ✅, name cosmetic, seed deferred)
+- Visual — engine-agnostic by design ✅
+
+All deferred items are Phase 13 hydration work, not DSL structure work.

--- a/docs/design/dsl-math-bridge.md
+++ b/docs/design/dsl-math-bridge.md
@@ -1,0 +1,345 @@
+# DSL–Math Bridge Design
+
+**Date:** 2026-03-24
+**Branch:** feat/dsl-chain-audit
+**Author:** W3 audit pass
+
+Answers the open question from the DSL chain audit:
+> Should `@score/math` expose a DSL adapter (e.g. `drift()`, `lorenz()`, `scatter()` as chain modifiers)? Where does that belong — `@score/dsl` or a new `@score/math-dsl`?
+
+---
+
+## Answer
+
+**Yes — add `packages/dsl/src/math.ts` as a thin adapter layer inside `@score/dsl`.**
+
+Do NOT create a separate `@score/math-dsl` package. The adapter lives in `@score/dsl` and re-exports from `@score/math` with musical ergonomics.
+
+Do NOT straight re-export `@score/math` into `@score/dsl/index.ts`. Raw math functions have argument orders and names designed for generality, not live coding. The adapter adapts them.
+
+---
+
+## What the adapter does
+
+Four jobs:
+
+1. **Musical naming aliases** — rename functions to read as music at the call site
+2. **Argument order** — musical intent first, math parameter second
+3. **Curried transforms** — wrap functions so they compose with `.apply()` naturally
+4. **Selective re-export** — only expose what belongs in the song authoring layer
+
+---
+
+## `packages/dsl/src/math.ts` — design
+
+```ts
+// dsl/src/math.ts — DSL adapter for @score/math
+//
+// @score/math is the raw math layer — use it directly for anything not listed here.
+// This file adapts math functions to be ergonomic at the song authoring call site:
+//   - Musical naming (fibonacciRhythm → fibonacci)
+//   - Argument order (musical intent first)
+//   - Curried .apply() wrappers
+//
+// Thesis: @score/math stays pure math. This adapter stays pure DSL sugar.
+
+import {
+  fibonacciRhythm, drunk, circleOfFifths,
+  polyrhythm, tile, entropy,
+  normalize, clip, range, interp, smooth,
+  createLorenz, logisticMap, createOUProcess,
+  lsystem, lsystemToPattern, wolframCA,
+} from '@score/math'
+import type { PatternInput } from '@score/pattern'
+
+// ── Rhythm generators ──────────────────────────────────────────────────────────
+
+/**
+ * Fibonacci rhythm — n steps distributed via Fibonacci spacing.
+ * Alias for `fibonacciRhythm(n)` with musical arg name.
+ *
+ * @example
+ * ```ts
+ * HiHat().apply(fibonacci(8))     // 8-step Fibonacci spacing
+ * HiHat().apply(fibonacci(13))    // 13-step Fibonacci hi-hat
+ * ```
+ */
+export const fibonacci = (n: number): ReturnType<typeof fibonacciRhythm> =>
+  fibonacciRhythm(n)
+
+/**
+ * Drunk walk pattern — steps that wander ±stepSize from each position.
+ * Adapted: length first (musical), stepSize second (math detail).
+ *
+ * @example
+ * ```ts
+ * Bass303('A2').apply(drunkWalk(16))         // 16-step drunk walk, default step 1
+ * Synth().apply(drunkWalk(16, 2))            // wider steps
+ * ```
+ */
+export const drunkWalk = (length: number, stepSize = 1): ReturnType<typeof drunk> =>
+  drunk(length, stepSize)
+
+/**
+ * Polyrhythm combinator — OR two patterns of different lengths.
+ * Gives the union of hits when the two cycles align.
+ *
+ * @example
+ * ```ts
+ * Kick().apply(poly([1,0,0,0], [1,0,0]))  // 4-beat + 3-beat polyrhythm
+ * ```
+ */
+export const poly = (a: number[], b: number[]): number[] =>
+  polyrhythm(a, b)
+
+/**
+ * Tile a short pattern to fill `length` steps.
+ * Useful for building variations from a seed cell.
+ *
+ * @example
+ * ```ts
+ * HiHat().apply(fill([1,0,1], 16))  // tile [1,0,1] to 16 steps
+ * ```
+ */
+export const fill = (cell: number[], length: number): number[] =>
+  tile(cell, length)
+
+// ── Curried .apply() transforms ───────────────────────────────────────────────
+//
+// These return (pattern: number[]) => number[] so they compose directly with
+// ChainablePart.apply(). Call as: Kick(4).apply(clamp(0)(1)).
+//
+// Note: .apply() is currently unhydrated in the engine (see dsl-audit.md).
+// These are designed for when engine hydration lands — they are ready.
+
+/**
+ * Clamp pattern values to [lo, hi].
+ * Curried: `clamp(lo)(hi)(pattern)` — compose with `.apply()`.
+ *
+ * @example
+ * ```ts
+ * Kick(4).apply(clamp(0)(1))
+ * ```
+ */
+export const clamp =
+  (lo: number) =>
+  (hi: number) =>
+  (pattern: number[]): number[] =>
+    pattern.map(v => clip(v, lo, hi))
+
+/**
+ * Normalise pattern values to [0, 1].
+ *
+ * @example
+ * ```ts
+ * Synth().apply(norm)
+ * ```
+ */
+export const norm = (pattern: number[]): number[] =>
+  normalize(pattern)
+
+/**
+ * Rescale pattern values to [lo, hi].
+ *
+ * @example
+ * ```ts
+ * Kick(4).apply(rescale(0.2)(0.8))
+ * ```
+ */
+export const rescale =
+  (lo: number) =>
+  (hi: number) =>
+  (pattern: number[]): number[] =>
+    pattern.map(v => interp(v, lo, hi))
+
+/**
+ * Smooth pattern values with a sliding average of `window` steps.
+ *
+ * @example
+ * ```ts
+ * Pad('A3').apply(smoothed(4))
+ * ```
+ */
+export const smoothed =
+  (window: number) =>
+  (pattern: number[]): number[] =>
+    smooth(pattern, window)
+
+// ── Chaos generators ──────────────────────────────────────────────────────────
+//
+// These return PatternInput-compatible generators. Use directly with .apply()
+// (when hydrated) or pass as step functions to createStepSequencer.
+//
+// These do NOT replace the modulation source API (lfo/lorenz in modulation.ts).
+// Use modulation sources for continuous DSP-level modulation.
+// Use these for discrete step-level pattern generation.
+
+/**
+ * Lorenz attractor step generator — returns a (length: number) => number[] pattern.
+ * Produces deterministic chaos that never exactly repeats.
+ *
+ * @param axis - Which axis to use: 'x' | 'y' | 'z'. Default 'x'.
+ * @param speed - Traversal speed through attractor. Default 0.01.
+ *
+ * @example
+ * ```ts
+ * HiHat(8).apply(lorenzPattern())          // chaotic hi-hat pattern
+ * Kick().apply(lorenzPattern('z', 0.02))   // z-axis, faster traversal
+ * ```
+ */
+export const lorenzPattern =
+  (axis: 'x' | 'y' | 'z' = 'x', speed = 0.01) =>
+  (length: number): number[] => {
+    const lorenz = createLorenz({ speed })
+    return Array.from({ length }, () => {
+      const state = lorenz.next()
+      const v = state[axis]
+      return Math.abs(v) > 14 ? 1 : 0  // threshold: hit when attractor is in outer lobe
+    })
+  }
+
+/**
+ * Logistic map pattern generator — edge-of-chaos sequence.
+ * At `r` near 4, produces unpredictable but bounded patterns.
+ *
+ * @example
+ * ```ts
+ * HiHat().apply(logistic())                 // default r=3.9
+ * Perc().apply(logistic(3.57))              // onset of chaos
+ * ```
+ */
+export const logistic =
+  (r = 3.9, seed = 0.5) =>
+  (length: number): number[] =>
+    logisticMap(r, seed, length).map(v => (v > 0.5 ? 1 : 0))
+
+/**
+ * L-system pattern generator — grammar-based self-similar rhythm.
+ * Good for fractal drumming and procedural structure.
+ *
+ * @example
+ * ```ts
+ * const rules = { A: 'AB', B: 'A' }
+ * Snare().apply(lsystemPattern('A', rules, 5))  // 5 iterations
+ * ```
+ */
+export const lsystemPattern =
+  (axiom: string, rules: Record<string, string>, iterations = 4) =>
+  (_length: number): number[] =>
+    lsystemToPattern(lsystem(axiom, rules, iterations))
+
+// ── Harmony utilities ─────────────────────────────────────────────────────────
+
+/**
+ * Circle of fifths lookup — interval n from C in the circle of fifths.
+ * Re-exported as-is. Already musical naming in @score/math.
+ *
+ * @example
+ * ```ts
+ * const root = circleOf(2)  // 'D' (2 steps from C)
+ * ```
+ */
+export { circleOfFifths as circleOf } from '@score/math'
+
+// ── Pattern analysis ──────────────────────────────────────────────────────────
+
+/**
+ * Pattern density — fraction of steps that are hits (0–1).
+ * Useful in `.apply()` guards: if (density(p) < 0.3) return sparsify(p).
+ *
+ * @example
+ * ```ts
+ * const d = density([1,0,0,0,1,0,0,0])  // → 0.25
+ * ```
+ */
+export { entropy, density } from '@score/math'
+```
+
+---
+
+## What stays in `@score/math`
+
+`@score/math` is the escape hatch for song authors who need raw math.
+
+Never adapt these — expose as-is from `@score/math`:
+
+- `createLorenz`, `createOUProcess` — full stateful system access
+- `rk4` — Runge-Kutta numerical integration
+- `just`, `pythagorean`, `meantone`, `edo19`, `edo31` — tuning systems
+- `markov` — Markov chain (complex interface, not ready for DSL sugar yet)
+- `wolframCA` — Wolfram cellular automaton (same)
+- `lyapunovExponent` — analysis tool, not live coding
+
+---
+
+## What does NOT belong in a DSL adapter
+
+The modulation sources (`lfo`, `sine`, `ramp`, `lorenz`, `ou`, `logistic`) are in `dsl/src/modulation.ts`, not `@score/math`. They are DSP-level descriptors for continuous parameter modulation. They belong in the DSL modulation system and should be exported from `@score/dsl/src/index.ts` directly.
+
+This is a separate fix from the math adapter — see the export gap noted in `dsl-audit.md`.
+
+---
+
+## Where does the adapter belong
+
+`@score/dsl` — not a new package.
+
+Reason: Song authors import from `@score/dsl`. Adding a new `@score/math-dsl` package creates an import split that hurts ergonomics. The adapter is DSL sugar, not new math. It stays coupled to the DSL.
+
+```ts
+// Song file (correct — single import)
+import { Kick, HiHat, Song, fibonacci, drunkWalk, lorenzPattern } from '@score/dsl'
+```
+
+vs.
+
+```ts
+// Song file (wrong — two imports for one authoring layer)
+import { Kick, HiHat, Song } from '@score/dsl'
+import { fibonacci, drunkWalk } from '@score/math-dsl'  // ← package sprawl
+```
+
+---
+
+## Index exports to add
+
+When `packages/dsl/src/math.ts` is created, add to `packages/dsl/src/index.ts`:
+
+```ts
+export {
+  fibonacci, drunkWalk, poly, fill,
+  clamp, norm, rescale, smoothed,
+  lorenzPattern, logistic, lsystemPattern,
+  circleOf,
+  entropy, density,
+} from './math.js'
+```
+
+And for modulation sources (separate fix, same PR opportunity):
+
+```ts
+export { lfo, sine, ramp, lorenz, ou, logistic } from './modulation.js'
+export type { ModulationDescriptor } from './modulation.js'
+```
+
+---
+
+## Implementation note: `.apply()` dependency
+
+The curried transform functions (`clamp`, `norm`, `rescale`, `smoothed`) are designed for `.apply()`. As of this audit, `.apply()` is unhydrated in the engine (`_applyFn` not passed to `partToInstrumentDescriptor`).
+
+The adapter can be written now — it is pure data construction. The engine hydration of `_applyFn` is a separate Phase 13 task. Once hydrated, all `.apply(clamp(0)(1))` and `.apply(fibonacci(8))` calls will work without changes to the adapter.
+
+See `dsl-audit.md` for the full list of unhydrated fields.
+
+---
+
+## Naming decision: `drift` vs `drunkWalk`
+
+`@score/dsl/src/modifiers.ts` already exports a `drift(center, sigma, theta)` function — this is a note-pitch drift via OU process, returning a `PatternFn<string>`.
+
+The math adapter's `drunkWalk(length, stepSize)` is different — it generates a numeric pattern array.
+
+These are different things. `drift` stays in `modifiers.ts`. `drunkWalk` goes in `math.ts`. No naming conflict.
+
+`@score/math`'s raw `drunk(length, stepSize)` is the underlying function. The adapter renames it `drunkWalk` to distinguish it from the pitch-drift `drift` in the DSL.


### PR DESCRIPTION
## Summary

- `docs/design/dsl-audit.md` — full audit of all 58 `ChainMethods` against `partToInstrumentDescriptor`. Row-per-method table with: method, DSL field, exists in DSL, engine hydrates, note. Groups: pattern, pitch/notes, amplitude, tone, space, routing, modulation, meta, visual. Instrument sub-type tables (SubSynthPart, FMSynthPart, Bass303Part). Includes modulation sources export gap (`lfo`/`sine`/`ramp`/`lorenz`/`ou` defined in `dsl/src/modulation.ts` but not exported from index).
- `docs/design/dsl-math-bridge.md` — design for `packages/dsl/src/math.ts` adapter. Answers open question: adapter belongs in `@score/dsl`, not a separate package. Covers musical naming aliases, arg order convention, curried `.apply()` transforms, chaos generators, what stays in `@score/math`.

**No code changes — audit + design docs only.**

## Key findings

`partToInstrumentDescriptor` hydrates only 9 of ~50 `PartDescriptor` fields. Critical silent no-ops:
- `.filter()` — `_filter` never mapped (every bass/pad filter call is inert)
- `.degrade()` — `_degrade` not in engine
- **Entire modulation system** — `_modulations` not passed through; `.tremolo()`, `.vibrato()`, `.wobble()`, `.autopan()`, `.drift()`, `.swell()`, `.modulate()` all inert
- `.duckWith()` / `.pumpWith()` — `_sidechain` not hydrated
- `.swing()` / `.humanize()` — pass through props but `createStepSequencer` never reads them per-track
- `.fromBar()` / `.untilBar()` / `.fadeIn()` / `.fadeOut()` — arrangement timing inert
- `.chokeGroup()` — hi-hat choke inert

Pattern pre-expand methods (speed/slow/fast/rev/euclidean/shift/invert/palindrome/hits/pattern) work correctly — DSL resolves them before engine sees the descriptor.

## Test plan

- [ ] Verify `docs/design/dsl-audit.md` renders correctly on GitHub
- [ ] Cross-check audit table against `packages/cli/src/engine.ts:113-137` (`partToInstrumentDescriptor`)
- [ ] Cross-check audit table against `packages/dsl/src/chain.ts` `ChainMethods<T>` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)