### PR TITLE
docs: rewrite user-facing docs to chain API

### DIFF
--- a/docs/EFFECTS.md
+++ b/docs/EFFECTS.md
@@ -1,472 +1,341 @@
 # Effects
 
-All effects are imported from `@score/effects`. They are descriptor factories — they return plain data objects. No AudioContext is created in song files. The engine hydrates descriptors at play time.
+Effects are applied via chain methods on any instrument. No imports needed for the common effects.
 
 ```js
-import { Delay, Reverb, Filter, Distortion, EQ, Compressor, Limiter, BitCrusher, Chorus, Phaser, Flanger, StereoWidener, Gate } from '@score/effects'
+const bass = Bass303('A2').cutoff(600).wobble(0.5).delay(0.375, 0.3).reverb(0.15)
+const kick  = Kick(4).volume(0.9).reverb(0.08)
+const lead  = Synth('sawtooth', 'E4').filter(1200, 2.0).chorus(0.4).delay(0.25)
 ```
 
-Attach effects to any instrument via its `effects` prop:
-
-```js
-const bass = Synth({
-  wave: 'sawtooth',
-  gain: 0.3,
-  pattern: ['A2', 0, 'A2', 0,  'D3', 0, 'E3', 0],
-  effects: [
-    Delay({ time: 0.375, feedback: 0.4, mix: 0.3 }),
-    Reverb({ decay: 2.0, mix: 0.2 }),
-  ],
-})
-```
-
-Effects process in array order — left to right, top to bottom. The output of each effect feeds the input of the next.
+Effects process in chain order — left to right. The output of each effect feeds the input of the next.
 
 ---
 
-## Delay
+## Chain effects reference
+
+### `.reverb(wet, opts?)`
+
+Simulates acoustic space. Adds depth, dimension, and glue.
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `wet` | `number` | — | Dry/wet blend 0–1. `0.1–0.2` for drums. `0.3–0.6` for pads. |
+| `opts.decay` | `number` | `2.0` | Tail length in seconds. `0.5` = small room. `6.0` = large hall. |
+| `opts.preDelay` | `number` | `0` | Pre-delay in seconds. `0.02–0.04` keeps attack punchy. |
+
+```js
+Kick(4).reverb(0.08)                              // tight room on kick
+Synth('triangle').reverb(0.4, { decay: 6.0 })    // large hall on pad
+Snare().reverb(0.2, { decay: 1.2, preDelay: 0.03 }) // deep house snare tail
+```
+
+**Routing:** Place reverb last (or second-to-last before a limiter). Reverb after distortion smears harmonics; reverb before distortion gives lo-fi texture.
+
+---
+
+### `.delay(time, feedback?)`
 
 Repeats the signal after a fixed time. Creates echoes, rhythmic doubling, and spatial depth.
 
-### Props
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `time` | `number \| string` | — | Delay time in seconds, or a note value string (`'1/8d'`). |
+| `feedback` | `number` | `0.3` | How much of the wet signal feeds back. Higher = longer echo tail. Keep below `0.9`. |
 
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `time` | `number` | `0.25` | `0–5` | Delay time in seconds. `0.25` = quarter note at 60 BPM. `0.375` = dotted-eighth at 80 BPM. |
-| `feedback` | `number` | `0.3` | `0–0.95` | How much of the wet signal feeds back into the delay. Higher = longer decaying echo tail. Keep below `0.9` for stability. |
-| `mix` | `number` | `0.5` | `0–1` | Dry/wet blend. `0` = dry only, `1` = wet only. Most uses stay between `0.2–0.5`. |
-
-### Examples
-
-**Tight rhythmic doubling** — eighth-note echo, subtle mix, fast decay:
 ```js
-Delay({ time: 0.1875, feedback: 0.15, mix: 0.25 })
+Synth('sawtooth').delay(0.375, 0.35)   // dotted-eighth sync, moderate tail
+Arp(['C4','E4','G4']).delay(0.1875, 0.2)  // tight eighth-note doubling
+FMSynth('A3').delay(0.375, 0.5).reverb(0.2)  // delay into reverb — natural echo space
 ```
 
-**Ping-pong ambient tail** — dotted-eighth sync, long feedback, moderate mix:
-```js
-Delay({ time: 0.375, feedback: 0.65, mix: 0.4 })
-```
-
-### Signal routing note
-
-Delay sits best before Reverb in the chain. Delaying into reverb creates natural-sounding echo spaces. Reversing the order (reverb into delay) produces a smeared, washed-out character.
+**Routing:** Delay sits best before reverb. Delaying into reverb → natural echo space. Reversed order → smeared, washed-out character.
 
 ---
 
-## Reverb
+### `.filter(freq, q?)`
 
-Simulates acoustic space by convolving the signal with a room impulse. Adds depth, dimension, and glue.
+Lowpass filter. Attenuates frequencies above the cutoff.
 
-### Props
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `freq` | `number` | — | Cutoff frequency in Hz. |
+| `q` | `number` | `1.0` | Resonance. Higher = peak at cutoff. Above `10` resonance becomes audible as a tone. |
 
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `decay` | `number` | `2.0` | `0.1–30` | Reverb tail length in seconds. `0.5` = small room. `2.0` = medium hall. `8.0+` = cathedral or plate. |
-| `mix` | `number` | `0.3` | `0–1` | Dry/wet blend. Drums typically `0.1–0.2`. Pads `0.3–0.6`. |
-| `preDelay` | `number` | `0` | `0–0.1` | Delay before the reverb body in seconds. `0.02–0.04` (20–40ms) separates the dry transient from the reverb tail — keeps attack punchy in dense mixes. Omit or set `0` to bypass. |
-
-### Examples
-
-**Tight room** — short decay, low mix, keeps transients punchy:
 ```js
-Reverb({ decay: 0.5, mix: 0.12 })
+Synth('sawtooth').filter(900)           // basic tone-shaping
+Bass303('A2').filter(400, 8.0)          // acid squelch — high resonance
+SubSynth('C2').filter(600, 1.2)        // analogue warmth
 ```
 
-**Large hall** — long tail, higher mix, for atmospheric pads:
-```js
-Reverb({ decay: 6.0, mix: 0.45 })
-```
-
-**Deep house snare reverb** — pre-delay separates hit from tail:
-```js
-Reverb({ decay: 1.2, mix: 0.2, preDelay: 0.03 })
-```
-
-### Signal routing note
-
-Place Reverb last in the effects chain (or second-to-last before Limiter). Reverb after Distortion smears the distorted harmonics into unpleasant mud; Reverb before Distortion can work for lo-fi texture.
+For **highpass** or **bandpass** filtering, or for full `@score/effects` filter control (e.g. notch), use the `Filter` descriptor factory — see [Advanced: `@score/effects` factories](#advanced-scoreeffects-factories) below.
 
 ---
 
-## Filter
+### `.eq(low, mid, high)`
 
-A biquad filter for frequency shaping. Use to sculpt tone, add resonance, or cut unwanted frequencies.
+Three-band equalizer. Gains in dB.
 
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `type` | `string` | `'lowpass'` | `'lowpass'` \| `'highpass'` \| `'bandpass'` \| `'notch'` | Filter shape. See table below. |
-| `frequency` | `number` | `1000` | `20–20000` | Cutoff frequency in Hz. |
-| `Q` | `number` | `1.0` | `0.001–1000` | Resonance. At low values, smooth roll-off. Higher values create a peak at the cutoff frequency. Above `10` the resonance becomes audible as a tone. |
-| `gain` | `number` | `0` | any dB | Only used by `peaking` and shelf filter types. No effect on `lowpass`, `highpass`, `bandpass`, or `notch`. |
-
-### Filter types
-
-| Type | What it does |
+| Param | Description |
 |---|---|
-| `lowpass` | Passes frequencies below cutoff. Rolls off highs. Most common for bass tone-shaping. |
-| `highpass` | Passes frequencies above cutoff. Rolls off lows. Use to thin out bass mud or isolate tops. |
-| `bandpass` | Passes a band around cutoff, attenuates above and below. |
-| `notch` | Attenuates a narrow band at cutoff. Use to remove specific resonances. |
+| `low` | Low shelf gain in dB. Positive = boost lows. |
+| `mid` | Mid peak gain in dB. |
+| `high` | High shelf gain in dB. |
 
-### Examples
-
-**Low-pass sub carve** — removes mud below 120 Hz from bass instruments:
 ```js
-Filter({ type: 'highpass', frequency: 80, Q: 0.7 })
-```
-
-**Resonant acid sweep** — classic TB-303 character, high Q at cutoff:
-```js
-Filter({ type: 'lowpass', frequency: 400, Q: 12.0 })
+Synth('sawtooth').eq(4, -2, 2)    // warm bass boost — lift lows, cut harsh mids, add air
+Kick(4).eq(2, 0, -3)              // lift sub, cut harsh top
 ```
 
 ---
 
-## Compressor
+### `.chorus(depth?)`
 
-Reduces the dynamic range of the signal. Attenuates peaks that exceed the threshold, bringing up the overall level and gluing elements together.
+Modulates a short delayed copy with an LFO and mixes it back. Creates thickness and shimmer.
 
-### Props
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `depth` | `number` | `0.5` | Modulation depth 0–1. Low = subtle detuning. High = wide warble. |
 
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `threshold` | `number` | `-24` | `-100–0` dBFS | Level in dBFS where compression begins. Signals below this are unaffected. |
-| `ratio` | `number` | `4` | `1–20` | Compression ratio (N:1). `4` = for every 4 dB over threshold, output increases 1 dB. `20` = near brick-wall. |
-| `attack` | `number` | `0.003` | `0–1` | Seconds before compression engages after threshold is crossed. Fast attack catches transients; slow attack lets them through. |
-| `release` | `number` | `0.25` | `0–1` | Seconds for gain to recover after signal drops below threshold. |
-| `knee` | `number` | `10` | `0–40` dB | Width of the soft-knee transition zone around the threshold. `0` = hard knee (abrupt). Higher = smooth gradual onset. |
-
-### Examples
-
-**Drum bus glue** — moderate ratio, fast attack/release, soft knee:
 ```js
-Compressor({ threshold: -18, ratio: 4, attack: 0.005, release: 0.1, knee: 6 })
+SubSynth('C3').chorus(0.4)       // lush pad doubling
+Synth('triangle').chorus(0.25)   // subtle vocal-style shimmer
 ```
 
-**Heavy limiting compression** — high ratio, tight knee, catches peaks hard:
+---
+
+### `.flange(depth?)`
+
+Short modulated delay mixed with dry signal. Jet-plane sweeps, comb filtering, metallic shimmer.
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `depth` | `number` | `0.5` | Modulation depth 0–1. |
+
 ```js
+Synth('square').flange(0.4)      // subtle jet sweep
+FMSynth('C4').flange(0.8)        // intense metallic flange
+```
+
+---
+
+### `.bit(bits)`
+
+Bit crusher. Reduces bit depth for digital degradation and lo-fi texture.
+
+| Param | Type | Description |
+|---|---|---|
+| `bits` | `number` | Bit depth 4–16. `16` = CD quality (no effect). `8` = classic 8-bit. `4` = extreme crunch. |
+
+```js
+Snare().bit(8)          // classic 8-bit snare
+HiHat(8).bit(12)       // subtle vintage sampler texture
+Sample('./samples/kick.wav').bit(6)  // extreme crush
+```
+
+---
+
+### `.saturate(amt)`
+
+Overdrive / saturation. Adds harmonics and warmth.
+
+| Param | Type | Description |
+|---|---|---|
+| `amt` | `number` | Drive 0–1. `0.1` = subtle tape warmth. `0.5` = moderate crunch. `0.8+` = heavy clip. |
+
+```js
+Bass303('A2').saturate(0.3)     // analog warmth
+SubSynth('A1').saturate(0.6)    // Reese bass grit
+```
+
+---
+
+### `.widen(amt)`
+
+Mid-side stereo width control.
+
+| Param | Type | Description |
+|---|---|---|
+| `amt` | `number` | `0` = mono. `1` = unity. `2` = maximum width. Values above `1.5` may cause phase issues on mono playback — check in mono. |
+
+```js
+Synth('triangle').reverb(0.4).widen(1.5)   // wide atmospheric pad
+FMSynth('A3').widen(1.2)                    // spread chords
+```
+
+**Routing:** Do not apply `.widen()` to kick or bass — wide low frequencies cause phase cancellation on mono speakers.
+
+---
+
+### `.pan(v)`
+
+Stereo position.
+
+| Param | Type | Description |
+|---|---|---|
+| `v` | `number` | `-1` = hard left. `0` = center. `1` = hard right. |
+
+```js
+HiHat(8).pan(0.3)     // slight right
+Arp(['C4','E4']).pan(-0.4)  // slight left
+```
+
+---
+
+## Chain recipes
+
+### Classic delay + reverb send
+
+```js
+const lead = FMSynth('A3')
+  .ratio(1.273)
+  .modIndex(3)
+  .delay(0.375, 0.4)
+  .reverb(0.25)
+  .volume(0.4)
+```
+
+### Lo-fi drum texture
+
+```js
+const snare = Snare909()
+  .bit(12)
+  .saturate(0.2)
+  .reverb(0.15)
+  .volume(0.6)
+```
+
+### Deep house pad
+
+```js
+const pad = SubSynth('C3')
+  .unison(2)
+  .detune(12)
+  .filter(1200, 1.5)
+  .chorus(0.35)
+  .reverb(0.45, { decay: 4.0 })
+  .widen(1.3)
+  .volume(0.4)
+```
+
+### EDM pump (sidechain)
+
+```js
+const kick = Kick808(4).volume(0.9)
+const pad  = SubSynth('C3').reverb(0.4).pumpWith(kick, 0.3).volume(0.5)
+```
+
+---
+
+## Advanced: `@score/effects` factories
+
+For effects not yet available as chain methods — Compressor, Limiter, Phaser, Gate, and Distortion (with mode control) — import the descriptor factories from `@score/effects` and attach them via the `_effects` field directly, or wait for upcoming chain methods.
+
+```js
+import { Compressor, Limiter, Phaser, Gate, Distortion } from '@score/effects'
+```
+
+> **Note:** These factories produce `EffectDescriptor` objects. Direct `_effects` attachment is the current escape hatch while chain methods for these effects are planned.
+
+### Compressor
+
+Reduces dynamic range. Attenuates peaks above the threshold.
+
+```js
+// Drum bus glue
+Compressor({ threshold: -18, ratio: 4, attack: 0.005, release: 0.1, knee: 6 })
+
+// Heavy limiting compression
 Compressor({ threshold: -12, ratio: 16, attack: 0.001, release: 0.05, knee: 2 })
 ```
 
-### Signal routing note
-
-Compressor before EQ shapes dynamics first, then tone. Compressor after EQ applies dynamics to the already-toned signal. Both are valid — use whichever gives the result you want.
-
----
-
-## EQ
-
-Three-band equalizer: low shelf, mid peak, high shelf. Use for tone shaping and frequency balance.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `low` | `number` | `0` | `-40–40` dB | Low shelf gain in dB. Positive boosts lows; negative cuts. |
-| `mid` | `number` | `0` | `-40–40` dB | Peaking mid gain in dB. |
-| `high` | `number` | `0` | `-40–40` dB | High shelf gain in dB. |
-| `lowFreq` | `number` | `250` | `20–500` Hz | Low shelf transition frequency. |
-| `midFreq` | `number` | `1000` | `200–8000` Hz | Mid peak center frequency. |
-| `highFreq` | `number` | `4000` | `2000–20000` Hz | High shelf transition frequency. |
-
-### Examples
-
-**Warm bass boost** — lift lows, cut harsh mids, add air:
-```js
-EQ({ low: 4, mid: -2, high: 2, lowFreq: 120, midFreq: 800, highFreq: 8000 })
-```
-
-**Presence cut** — scoop harsh upper-mids for smooth leads:
-```js
-EQ({ low: 0, mid: -5, high: 1, midFreq: 3000, highFreq: 10000 })
-```
-
----
-
-## Distortion
-
-Applies nonlinear waveshaping to the signal. Adds harmonics and grit.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `amount` | `number` | `0.5` | `0–1` | Distortion intensity. `0.1` = subtle saturation. `0.5` = moderate crunch. `0.8+` = heavy clip. |
-| `mode` | `string` | `'soft'` | `'soft'` \| `'hard'` \| `'foldback'` | Waveshaping algorithm. See table below. |
-
-### Distortion modes
-
-| Mode | Character | Use for |
+| Prop | Default | Description |
 |---|---|---|
-| `soft` | Smooth harmonic saturation. Even harmonics predominant. | Bass warmth, analog tape character. |
-| `hard` | Abrupt clipping. Odd harmonics, more aggressive. | Industrial textures, harsh leads. |
-| `foldback` | Signal folds back when it exceeds the ceiling. Chaotic at high amounts. | Metallic, sci-fi, experimental sound design. |
+| `threshold` | `-24` dBFS | Level where compression begins. |
+| `ratio` | `4` | Compression ratio (N:1). `20` = near brick-wall. |
+| `attack` | `0.003` | Seconds before compression engages. Fast = catches transients. |
+| `release` | `0.25` | Seconds for gain to recover after signal drops below threshold. |
+| `knee` | `10` dB | Soft-knee width. `0` = hard knee. |
 
-### Examples
+### Limiter
 
-**Tape saturation** — subtle soft clip for analog warmth:
+Brick-wall limiter. No signal exceeds the ceiling. Place last in mastering chains.
+
 ```js
-Distortion({ amount: 0.15, mode: 'soft' })
-```
-
-**Reese bass grit** — moderate hard clip on a sawtooth bass:
-```js
-Distortion({ amount: 0.55, mode: 'hard' })
-```
-
----
-
-## Limiter
-
-A brick-wall limiter. No signal ever exceeds the ceiling. Place at the end of mastering chains to prevent clipping.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `ceiling` | `number` | `-0.3` | `-40–0` dBFS | Maximum output level. The signal will never exceed this value. `-0.3` leaves headroom for codec encoding. |
-| `release` | `number` | `0.05` | `0–1` | Seconds for gain to recover after limiting. Shorter = snappier. Longer = smoother. |
-| `lookahead` | `number` | `0.005` | `0–0.1` | Seconds of lookahead. Allows the limiter to anticipate peaks and reduce distortion. |
-
-### Examples
-
-**Mastering limiter** — transparent ceiling with short lookahead:
-```js
+// Mastering limiter
 Limiter({ ceiling: -0.3, release: 0.05, lookahead: 0.005 })
 ```
 
-**Hard clip protection** — tighter ceiling, faster release:
-```js
-Limiter({ ceiling: -1.0, release: 0.02, lookahead: 0.003 })
-```
+| Prop | Default | Description |
+|---|---|---|
+| `ceiling` | `-0.3` dBFS | Maximum output level. |
+| `release` | `0.05` | Seconds for gain to recover. |
+| `lookahead` | `0.005` | Seconds of lookahead — anticipates peaks, reduces distortion. |
 
-### Signal routing note
+### Phaser
 
-Always place Limiter last in any chain where it appears. Its purpose is final output protection — nothing should process after it.
+Allpass filter bank swept by an LFO. Sweeping, organic, whooshing movement.
 
----
-
-## BitCrusher
-
-Reduces bit depth and sample rate to create digital degradation. Classic lo-fi texture.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `bitDepth` | `number` | `8` | `1–16` | Bit depth of the output. `16` = CD quality (no effect). `8` = classic 8-bit. `4` = extreme crunch. `1` = 1-bit comparator. |
-| `sampleRate` | `number` | `0.5` | `0–1` | Normalized sample rate reduction. `1.0` = original sample rate (no effect). `0.5` = half rate. `0.1` = extreme decimation. |
-
-### Examples
-
-**Classic 8-bit** — bit depth crunch, moderate sample rate reduction:
-```js
-BitCrusher({ bitDepth: 8, sampleRate: 0.5 })
-```
-
-**Extreme decimation** — 4-bit depth, severe sample rate reduction:
-```js
-BitCrusher({ bitDepth: 4, sampleRate: 0.15 })
-```
-
----
-
-## Chorus
-
-Modulates a short delayed copy of the signal with an LFO and mixes it back. Creates thickness and shimmer.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `rate` | `number` | `1.5` | `0.01–20` Hz | LFO rate in Hz. How fast the pitch modulates. Below `0.5` Hz = slow, lush. `2–4` Hz = obvious shimmer. |
-| `depth` | `number` | `0.5` | `0–1` | Modulation depth. How far the pitch deviates. Low = subtle detuning. High = wide warble. |
-| `mix` | `number` | `0.5` | `0–1` | Dry/wet blend. |
-
-### Examples
-
-**Lush pad doubling** — slow rate, moderate depth:
-```js
-Chorus({ rate: 0.3, depth: 0.6, mix: 0.4 })
-```
-
-**Tight vocal-style shimmer** — faster rate, low depth, subtle mix:
-```js
-Chorus({ rate: 2.5, depth: 0.25, mix: 0.3 })
-```
-
----
-
-## Phaser
-
-An allpass filter bank swept by an LFO. Creates a sweeping, organic, whooshing movement.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `rate` | `number` | `1.0` | `0.01–20` Hz | LFO rate in Hz. |
-| `depth` | `number` | `0.5` | `0–1` | Modulation depth. |
-| `stages` | `number` | `4` | `2–12` | Number of allpass filter stages. More stages = more pronounced notches and a richer sweep. |
-| `mix` | `number` | `0.5` | `0–1` | Dry/wet blend. |
-
-### Examples
-
-**Classic 4-stage sweep** — moderate rate, standard stages:
 ```js
 Phaser({ rate: 0.8, depth: 0.6, stages: 4, mix: 0.5 })
 ```
 
-**Deep 8-stage sweep** — slow, hypnotic, rich notching:
+| Prop | Default | Description |
+|---|---|---|
+| `rate` | `1.0` Hz | LFO rate. |
+| `depth` | `0.5` | Modulation depth 0–1. |
+| `stages` | `4` | Allpass stages. More = richer sweep. |
+| `mix` | `0.5` | Dry/wet blend. |
+
+### Gate
+
+Noise gate. Silences the signal below the threshold. Cuts bleed, tightens sustained sounds.
+
 ```js
-Phaser({ rate: 0.2, depth: 0.9, stages: 8, mix: 0.6 })
-```
-
----
-
-## Flanger
-
-Short modulated delay mixed with dry signal. Creates jet-plane sweeps, comb filtering, and metallic shimmer.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `rate` | `number` | `0.5` | `0.01–20` Hz | LFO rate in Hz. |
-| `depth` | `number` | `0.5` | `0–1` | Modulation depth. |
-| `feedback` | `number` | `0.7` | `0–0.95` | How much of the wet signal recirculates. Higher = more intense comb filtering. |
-| `mix` | `number` | `0.5` | `0–1` | Dry/wet blend. |
-
-### Examples
-
-**Subtle jet sweep** — slow rate, moderate feedback:
-```js
-Flanger({ rate: 0.3, depth: 0.4, feedback: 0.5, mix: 0.4 })
-```
-
-**Intense metallic flange** — fast rate, high feedback:
-```js
-Flanger({ rate: 2.0, depth: 0.8, feedback: 0.85, mix: 0.6 })
-```
-
----
-
-## StereoWidener
-
-Mid-side processing to expand or collapse the stereo image.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `width` | `number` | `0.5` | `0–1` | `0` = fully mono. `0.5` = natural stereo. `1` = maximum width. Values above `0.7` may cause phase issues on mono playback systems — check in mono. |
-
-### Examples
-
-**Subtle widening** — adds space without phase risk:
-```js
-StereoWidener({ width: 0.6 })
-```
-
-**Maximum width** — for pads and atmospheric layers:
-```js
-StereoWidener({ width: 1.0 })
-```
-
-### Signal routing note
-
-Keep low-frequency instruments (kick, bass) in mono — do not apply StereoWidener to them, or use it at very low values (`0.1` or less). Wide bass causes phase cancellation on mono speakers.
-
----
-
-## Gate
-
-Noise gate. Silences the signal when its level drops below the threshold. Use to cut bleed and tighten sustained sounds.
-
-### Props
-
-| Prop | Type | Default | Range | Description |
-|---|---|---|---|---|
-| `threshold` | `number` | `-40` | `-100–0` dBFS | Signal below this level is silenced. Set just above the noise floor or bleed you want to remove. |
-| `attack` | `number` | `0.005` | `0–1` | Seconds for the gate to open once the signal exceeds threshold. |
-| `release` | `number` | `0.1` | `0–1` | Seconds for the gate to close after the signal drops below threshold. Longer = more natural decay. |
-
-### Examples
-
-**Tight snare gate** — fast open, fast close, high threshold:
-```js
+// Tight snare gate
 Gate({ threshold: -30, attack: 0.002, release: 0.05 })
-```
 
-**Gated reverb** — classic 80s effect, slow gate close on reverb tail:
-```js
+// Classic 80s gated reverb
 Gate({ threshold: -35, attack: 0.001, release: 0.3 })
 ```
 
----
+| Prop | Default | Description |
+|---|---|---|
+| `threshold` | `-40` dBFS | Signal below this level is silenced. |
+| `attack` | `0.005` | Seconds for gate to open. |
+| `release` | `0.1` | Seconds for gate to close. Longer = more natural decay. |
 
-## Chaining Effects
+### Distortion
 
-Effects chain in array order. Output of `effects[0]` feeds `effects[1]`, and so on.
-
-### Mastering chain
-
-Full track output chain. Compression first, then EQ, then limiting:
-
-```js
-import { EQ, Compressor, Limiter } from '@score/effects'
-
-const masterChain = [
-  Compressor({ threshold: -18, ratio: 3, attack: 0.01, release: 0.2, knee: 8 }),
-  EQ({ low: 1.5, mid: -1, high: 2, lowFreq: 100, midFreq: 2000, highFreq: 10000 }),
-  Limiter({ ceiling: -0.3, release: 0.05, lookahead: 0.005 }),
-]
-
-const kick = Kick({ pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0], effects: masterChain })
-```
-
-### Creative send chain
-
-Delay feeding a long reverb for a washy ambient send effect:
+Nonlinear waveshaping. Soft, hard, or foldback modes.
 
 ```js
-import { Delay, Reverb, Filter } from '@score/effects'
+// Tape saturation
+Distortion({ amount: 0.15, mode: 'soft' })
 
-const ambientSend = [
-  Filter({ type: 'highpass', frequency: 300, Q: 0.7 }),
-  Delay({ time: 0.375, feedback: 0.5, mix: 0.6 }),
-  Reverb({ decay: 5.0, mix: 0.7 }),
-]
-
-const pad = Synth({
-  wave: 'triangle',
-  gain: 0.15,
-  envelope: { attack: 0.8, decay: 0.2, sustain: 0.9, release: 1.5 },
-  pattern: ['C4', 0, 0, 0,  'E4', 0, 0, 0,  'G4', 0, 0, 0,  'A4', 0, 0, 0],
-  effects: ambientSend,
-})
+// Hard industrial crunch
+Distortion({ amount: 0.6, mode: 'hard' })
 ```
 
-### Lo-fi drum chain
+| Prop | Default | Description |
+|---|---|---|
+| `amount` | `0.5` | Intensity 0–1. |
+| `mode` | `'soft'` | `'soft'` = even harmonics, tape character. `'hard'` = aggressive clipping. `'foldback'` = chaotic fold. |
 
-BitCrusher and noise Gate for vintage sampler texture:
+### Filter (full control)
+
+For highpass, bandpass, or notch filtering — the chain `.filter()` method is lowpass only.
 
 ```js
-import { Filter, BitCrusher, Compressor, Gate } from '@score/effects'
+// Highpass — remove sub mud
+Filter({ type: 'highpass', frequency: 80, Q: 0.7 })
 
-const lofiDrums = [
-  Filter({ type: 'lowpass', frequency: 8000, Q: 0.5 }),
-  BitCrusher({ bitDepth: 12, sampleRate: 0.7 }),
-  Compressor({ threshold: -20, ratio: 6, attack: 0.002, release: 0.08, knee: 4 }),
-  Gate({ threshold: -45, attack: 0.001, release: 0.08 }),
-]
-
-const snare = Snare({
-  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.7,
-  effects: lofiDrums,
-})
+// Resonant notch — remove a specific frequency
+Filter({ type: 'notch', frequency: 1200, Q: 5.0 })
 ```
+
+| Prop | Default | Description |
+|---|---|---|
+| `type` | `'lowpass'` | `'lowpass'` \| `'highpass'` \| `'bandpass'` \| `'notch'` |
+| `frequency` | `1000` Hz | Cutoff frequency. |
+| `Q` | `1.0` | Resonance. |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,8 +2,6 @@
 
 Play your first song in under 5 minutes.
 
-> **Note — fluent DSL chain API pending:** The import syntax used throughout this doc (`import { Kick, Synth } from '@score/dsl'`) will be simplified to a single import in an upcoming release. Examples will be updated once the new API lands. The current syntax continues to work.
-
 ## Install
 
 ```bash
@@ -56,10 +54,7 @@ Press `Ctrl+C` to stop.
 ```js
 import { Song, Kick } from '@score/dsl'
 
-const kick = Kick({
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.9,
-})
+const kick = Kick(4).volume(0.9)
 
 export default Song({ bpm: 128, tracks: [kick] })
 ```
@@ -68,33 +63,23 @@ export default Song({ bpm: 128, tracks: [kick] })
 score play kick-only.js
 ```
 
+`Kick(4)` — four euclidean hits across 16 steps. `4` is the hit count, not a beat position.
+
 ## A full beat
 
 ```js
 import { Song, Kick, Snare, HiHat, Synth } from '@score/dsl'
 
-const kick = Kick({
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.9,
-})
+const kick = Kick(4).volume(0.9)
 
-const snare = Snare({
-  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.6,
-})
+const snare = Snare(2).volume(0.6)
 
-const hihat = HiHat({
-  pattern: [1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0],
-  volume: 0.25,
-})
+const hihat = HiHat(8).volume(0.25)
 
-const bass = Synth({
-  wave: 'sawtooth',
-  gain: 0.3,
-  envelope: { attack: 0.005, decay: 0.1, sustain: 0.6, release: 0.05 },
-  filter: { type: 'lowpass', frequency: 900 },
-  pattern: ['A2', 0, 'A2', 0,  0, 'A2', 0, 'D3',  'E3', 0, 'E3', 0,  0, 'A3', 0, 0],
-})
+const bass = Synth('sawtooth', 'A2')
+  .filter(900)
+  .notes(['A2', 'A2', 'D3', 'E3'])
+  .volume(0.3)
 
 export default Song({
   bpm: 128,
@@ -152,6 +137,7 @@ Every importable symbol across all packages.
 | `Synth` | `@score/dsl` | Subtractive synth with ADSR, filter, and effects |
 | `SubSynth` | `@score/dsl` | Full Juno-60/Minimoog model — unison, filter envelope |
 | `FMSynth` | `@score/dsl` | 2-operator FM — DX7 Rhodes, metallic leads, bells |
+| `Bass303` | `@score/dsl` | Roland TB-303 acid bass — squelch, resonance, accent, slide |
 | `Arp` | `@score/dsl` | Arpeggiator cycling through a note list |
 | `Theremin` | `@score/dsl` | Smooth pitch-glide melodic voice |
 | `Sax` | `@score/dsl` | Stepped melodic voice with note sequence |
@@ -174,11 +160,11 @@ Every importable symbol across all packages.
 | `beat` | `@score/pattern` | Builds a pattern from beat positions |
 | `scaleNotes` | `@score/pattern` | Returns note name array for a scale and root |
 | `chordNotes` | `@score/pattern` | Returns note name array for a chord symbol |
-| `Delay` | `@score/effects` | Repeating echo effect |
-| `Reverb` | `@score/effects` | Room/hall simulation |
-| `Filter` | `@score/effects` | Biquad filter (lowpass, highpass, bandpass, notch) |
+| `Delay` | `@score/effects` | Repeating echo effect (descriptor factory) |
+| `Reverb` | `@score/effects` | Room/hall simulation (descriptor factory) |
+| `Filter` | `@score/effects` | Biquad filter (descriptor factory) |
 | `Distortion` | `@score/effects` | Waveshaping — soft, hard, or foldback |
-| `EQ` | `@score/effects` | Three-band equalizer (low shelf, mid peak, high shelf) |
+| `EQ` | `@score/effects` | Three-band equalizer (descriptor factory) |
 | `Compressor` | `@score/effects` | Dynamic range compression |
 | `Limiter` | `@score/effects` | Brick-wall output limiter |
 | `BitCrusher` | `@score/effects` | Bit depth and sample rate reduction |
@@ -230,8 +216,8 @@ Every importable symbol across all packages.
 
 | File | Contents |
 |---|---|
-| [INSTRUMENTS.md](INSTRUMENTS.md) | All 14 instruments — Kick, Snare, HiHat, Kick808, Kick909, Snare909, Hihat808, Synth, SubSynth, FMSynth, Arp, Theremin, Sax, Sample |
-| [EFFECTS.md](EFFECTS.md) | All 14 effects — props, examples, and chain recipes |
+| [INSTRUMENTS.md](INSTRUMENTS.md) | All instruments — chain API reference |
+| [EFFECTS.md](EFFECTS.md) | Chain effects methods + advanced descriptor factories |
 | [SCALES.md](SCALES.md) | scaleNotes, chordNotes, tuning systems, circleOfFifths |
 | [ARRANGEMENT.md](ARRANGEMENT.md) | Intro/Buildup/Drop/Breakdown/Outro — section-based arrangement |
 | [SAMPLE.md](SAMPLE.md) | Sample instrument — file formats, paths, rate, looping |

--- a/docs/INSTRUMENTS.md
+++ b/docs/INSTRUMENTS.md
@@ -1,136 +1,256 @@
 # Instruments
 
-All instruments are imported from `@score/dsl`. They return descriptors — plain objects the engine hydrates at play time. No AudioContext is created in song files.
+All instruments are imported from `@score/dsl`. They return `ChainablePart` objects — immutable builders that the engine hydrates at play time. No AudioContext is created in song files.
 
 ```js
-import { Kick, Snare, HiHat, Synth, Kick808, Kick909, Snare909, Hihat808, SubSynth, FMSynth, Arp, Sample, Theremin, Sax } from '@score/dsl'
+import { Kick, Snare, HiHat, Kick808, Kick909, Snare909, Hihat808,
+         Synth, SubSynth, FMSynth, Bass303, Arp, Sample, Theremin, Sax } from '@score/dsl'
 ```
+
+Every instrument method returns a **new** instance — original is never mutated. Chain as many methods as you like:
+
+```js
+const kick = Kick(4).volume(0.9).reverb(0.1).swing(0.05)
+```
+
+---
+
+## Common chain methods
+
+All instruments share these methods.
+
+### Pattern
+
+| Method | Description |
+|---|---|
+| `.euclidean(hits, steps?)` | Replace pattern with euclidean distribution. Default steps = 16. |
+| `.pattern(arr)` | Set combined pitch+rhythm array. Strings = note names, `0` = rest. |
+| `.hits(...steps)` | Hit only at these step indices. `.hits(0, 4, 8, 12)` = four-on-floor. |
+| `.fast(n)` | Play pattern `n` times faster. |
+| `.slow(n)` | Play pattern `n` times slower. |
+| `.rev()` | Reverse the pattern. |
+| `.shift(n)` | Rotate `n` steps right (positive) or left (negative). |
+| `.degrade(p)` | Randomly drop hits at probability `p` (0–1). |
+| `.humanize(amt)` | Timing jitter in seconds. |
+| `.swing(amount)` | Swing offset on off-beats (0–1). |
+| `.every(n, fn)` | Apply `fn` every `n` bars. |
+| `.fromBar(n)` | Start playing at bar `n`. |
+| `.untilBar(n)` | Stop playing at bar `n`. |
+| `.fadeIn(bars)` | Fade in over `bars` bars. |
+| `.fadeOut(bars)` | Fade out over `bars` bars. |
+
+### Pitch and notes
+
+| Method | Description |
+|---|---|
+| `.note(pitch)` | Set a single pitch, e.g. `'C3'`. |
+| `.notes(arr)` | Set a note sequence. `0` or `'R'` = rest. |
+| `.octave(n)` | Shift `n` octaves up or down. |
+| `.pitch(semitones)` | Transpose ±N semitones. |
+| `.glide(time)` | Portamento time in seconds. |
+| `.dur(time)` | Note duration in seconds. |
+
+### Amplitude
+
+| Method | Description |
+|---|---|
+| `.volume(v)` | Output gain 0–1. |
+| `.attack(s)` | ADSR attack in seconds. |
+| `.decay(s)` | ADSR decay in seconds. |
+| `.sustain(v)` | ADSR sustain level 0–1. |
+| `.release(s)` | ADSR release in seconds. |
+
+### Effects
+
+| Method | Description |
+|---|---|
+| `.reverb(wet, opts?)` | Reverb — `wet` = 0–1. |
+| `.delay(time, feedback?)` | Echo — `time` in seconds or `'1/8d'`. |
+| `.filter(freq, q?)` | Lowpass filter — cutoff Hz + optional resonance. |
+| `.eq(low, mid, high)` | 3-band EQ in dB. |
+| `.chorus(depth?)` | Chorus — `depth` = 0–1 (default 0.5). |
+| `.flange(depth?)` | Flanger — `depth` = 0–1 (default 0.5). |
+| `.bit(bits)` | Bit crusher — `bits` = 4–16. |
+| `.saturate(amt)` | Saturation/distortion — `amt` = 0–1. |
+| `.widen(amt)` | Stereo width — 0–2, 1 = unity. |
+| `.pan(v)` | Stereo position — -1 (left) to 1 (right). |
+
+### Modulation
+
+| Method | Description |
+|---|---|
+| `.tremolo(rate, depth?)` | LFO on volume. `rate` Hz, `depth` 0–1. |
+| `.vibrato(rate, depth?)` | Sine on pitch. `rate` Hz, `depth` Hz. |
+| `.wobble(rate, depth?)` | LFO on filter cutoff (wobble bass / dubstep). |
+| `.autopan(rate, depth?)` | LFO on pan (stereo movement). |
+| `.drift(amt?)` | OU process on pitch — analog warmth. |
+| `.swell(bars)` | Ramp volume over `bars` bars. |
+
+### Routing
+
+| Method | Description |
+|---|---|
+| `.mute()` | Silence this part. |
+| `.solo()` | Solo this part. |
+| `.chokeGroup(name)` | Hits cut each other off within the group. |
+| `.send(bus, amount?)` | Route to a named effect bus. |
+| `.pumpWith(source, release?)` | EDM pump — duck gain on source hits. |
+| `.duckWith(source, opts?)` | Sidechain ducking. |
 
 ---
 
 ## Kick
 
-Synthesized bass drum. Pitched sine with pitch drop envelope.
+Synthesized bass drum. Sine body with pitch envelope and amplitude decay.
 
 ```js
-const kick = Kick({
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.9,
-  synth: { frequency: 75, pitchDrop: 0.09 },
-})
+// Four-on-the-floor (engine default)
+Kick().volume(0.9)
+
+// Euclidean — shorthand: pass hit count
+Kick(4).volume(0.9)          // same as Kick().euclidean(4, 16)
+Kick(5).swing(0.08)          // 5 hits, with swing
+
+// Custom pattern
+Kick().pattern([1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0]).volume(0.85)
+
+// With reverb
+Kick(4).volume(0.9).reverb(0.08)
 ```
 
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` or `(step, bar) => number` | four-on-floor | 16-step rhythm. `1` = hit, `0` = rest. |
-| `volume` | `number` | `0.85` | Output level 0–1. |
-| `synth.frequency` | `number` | `80` | Starting pitch in Hz. |
-| `synth.pitchDrop` | `number` | `0.1` | How fast the pitch falls (seconds). |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain — use descriptor factories from `@score/effects`. |
-
-All props are optional.
+`Kick(hits?)` — `hits` is optional euclidean hit count (1–16). Omit for engine default (four-on-the-floor).
 
 ---
 
 ## Snare
 
-Synthesized snare drum. Noise body with pitched transient.
+Synthesized snare drum. Noise burst with tone body.
 
 ```js
-const snare = Snare({
-  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.6,
-})
+// Standard backbeat
+Snare().volume(0.6)
+
+// Euclidean ghost notes
+Snare(3).degrade(0.3).volume(0.5)
+
+// Manual pattern
+Snare().pattern([0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0])
 ```
 
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` or `(step, bar) => number` | beats 2 and 4 | 16-step rhythm. |
-| `volume` | `number` | `0.5` | Output level 0–1. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-All props are optional.
+`Snare(hits?)` — `hits` is optional euclidean hit count. Omit for engine default (beats 2 and 4).
 
 ---
 
 ## HiHat
 
-Synthesized hi-hat. Open and closed variants via filtered noise.
+Synthesized hi-hat. Metal noise filtered to a closed or open hat timbre.
 
 ```js
-const hihat = HiHat({
-  pattern: [1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0,  1, 0, 1, 0],
-  volume: 0.25,
-  open: false,
-})
+// Straight 8th notes
+HiHat(8).volume(0.25)
+
+// Dense pattern with humanize
+HiHat(11).humanize(0.008).volume(0.2)
+
+// Open and closed hats with choke
+const closed = HiHat(8).chokeGroup('hat').volume(0.3)
+const open   = HiHat().hits(15).chokeGroup('hat').volume(0.4)
 ```
 
-### Props
+`HiHat(hits?)` — `hits` is optional euclidean hit count. Omit for engine default (every other 16th).
 
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` or `(step, bar) => number` | straight 8ths | 16-step rhythm. |
-| `volume` | `number` | `0.25` | Output level 0–1. |
-| `open` | `boolean` | `false` | `true` = open hi-hat (longer sustain). |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
+---
 
-All props are optional.
+## Kick808
+
+TR-808-style bass drum. Pure sine body with deep sub pitch fall. Sugar for `Kick().model('808')`.
+
+```js
+Kick808().volume(0.9)
+Kick808(4).decay(0.7)          // sustain the sub
+Kick808().pumpWith(kick)       // classic pump on self-reference
+```
+
+---
+
+## Kick909
+
+TR-909-style bass drum. Sine body with a short noise click transient. Sugar for `Kick().model('909')`.
+
+```js
+Kick909().volume(0.85)
+Kick909(4).reverb(0.05)
+```
+
+**808 vs 909:** Use `Kick808` for sub-heavy sustained kicks (trap, deep house). Use `Kick909` for punchy click-forward kicks (techno, house, trance).
+
+---
+
+## Snare909
+
+TR-909-style snare. Two triangle oscillators (tone) mixed with filtered white noise. Sugar for `Snare().model('909')`.
+
+```js
+Snare909().volume(0.75)
+Snare909(2).reverb(0.12)
+```
+
+---
+
+## Hihat808
+
+TR-808-style hi-hat. Six detuned square oscillators through bandpass + HPF filtering. Sugar for `HiHat().model('808')`.
+
+```js
+Hihat808(8).volume(0.5)
+Hihat808().hits(15).volume(0.4)      // open hat on last 16th
+Hihat808(8).humanize(0.01).volume(0.3)
+```
+
+Mix closed and open hats in two tracks to build classic 808 patterns.
 
 ---
 
 ## Synth
 
-Subtractive synthesizer with ADSR envelope and optional filter.
+General-purpose subtractive synth. Oscillator → ADSR envelope → optional filter.
 
 ```js
-const bass = Synth({
-  wave: 'sawtooth',
-  gain: 0.3,
-  envelope: {
-    attack: 0.005,
-    decay: 0.1,
-    sustain: 0.6,
-    release: 0.05,
-  },
-  filter: {
-    type: 'lowpass',
-    frequency: 900,
-    Q: 1.2,
-  },
-  pattern: ['A2', 0, 'A2', 0,  0, 'A2', 0, 'D3',  'E3', 0, 'E3', 0,  0, 'A3', 0, 0],
-})
+// Bass line
+Synth('sawtooth', 'A2')
+  .filter(900)
+  .notes(['A2', 'A2', 'D3', 'E3'])
+  .volume(0.3)
+
+// Pad
+Synth('triangle', 'C4')
+  .notes(['C4', 'E4', 'G4'])
+  .attack(0.4)
+  .sustain(0.8)
+  .release(0.6)
+  .reverb(0.4)
+  .volume(0.4)
+
+// Lead with delay
+Synth('sawtooth', 'E4')
+  .notes(['E4', 'D4', 'C4', 'A3'])
+  .delay(0.375, 0.35)
+  .reverb(0.15)
+  .volume(0.25)
 ```
 
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `wave` | `'sine'` \| `'square'` \| `'sawtooth'` \| `'triangle'` | `'sawtooth'` | Oscillator waveform. |
-| `frequency` | `number` | `440` | Base frequency in Hz when pattern values are `1`. |
-| `gain` | `number` | `0.25` | Output level 0–1. |
-| `pattern` | `(number\|string)[]` or `(step, bar) => string\|number` | — | Note names or Hz values. `0` = rest. |
-| `sequence` | `string[]` | — | Pre-parsed note array (output of `Sequence()`). |
-| `envelope.attack` | `number` | `0.005` | Seconds from silence to peak. Short = punchy, long = pad swell. |
-| `envelope.decay` | `number` | `0.08` | Seconds from peak to sustain level. |
-| `envelope.sustain` | `number` | `0.7` | Level held while note is active (0–1). |
-| `envelope.release` | `number` | `0.05` | Seconds to silence after note ends. |
-| `filter.type` | `'lowpass'` \| `'highpass'` \| `'bandpass'` | — | Filter shape. Omit to bypass filter. |
-| `filter.frequency` | `number` | `2000` | Filter cutoff in Hz. |
-| `filter.Q` | `number` | `1` | Resonance. Higher = more pronounced peak at cutoff. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
+`Synth(wave?, pitch?)` — `wave` is the oscillator shape, `pitch` is an optional starting note.
 
 ### Wave shapes
 
 | Wave | Character | Use for |
 |---|---|---|
-| `sine` | Pure, no harmonics | Sub-bass, soft pads |
-| `triangle` | Soft, few harmonics | Warm leads, mellow pads |
-| `square` | Hollow, odd harmonics | Bass, retro leads |
-| `sawtooth` | Bright, all harmonics | Acid bass, leads, strings |
+| `'sine'` | Pure, no harmonics | Sub-bass, soft pads |
+| `'triangle'` | Soft, few harmonics | Warm leads, mellow pads |
+| `'square'` | Hollow, odd harmonics | Bass, retro leads |
+| `'sawtooth'` | Bright, all harmonics | Acid bass, leads, strings |
+
+Default: `'sawtooth'`.
 
 ### ADSR diagram
 
@@ -145,14 +265,9 @@ sus   │  /    \____________________
            A    D        S             R
 ```
 
-- **A (attack)**: time from note-on to peak volume
-- **D (decay)**: time from peak down to sustain level
-- **S (sustain)**: level held until note-off
-- **R (release)**: time from note-off to silence
+### ADSR presets
 
-### Envelope presets
-
-| Sound | attack | decay | sustain | release |
+| Sound | `.attack()` | `.decay()` | `.sustain()` | `.release()` |
 |---|---|---|---|---|
 | Punchy bass | `0.002` | `0.05` | `0.5` | `0.03` |
 | Pad / string | `0.4` | `0.1` | `0.8` | `0.6` |
@@ -178,73 +293,199 @@ Typical ranges:
 - Mid: `A3`–`A4`
 - Lead: `A4`–`A5`
 
-### Effects on instruments
+---
+
+## SubSynth
+
+Analogue subtractive synth voice. Detuned oscillators → resonant LP filter → ADSR VCA. Juno-60 / Minimoog model. Adds `.unison()` and `.detune()` on top of the base chain methods.
 
 ```js
-import { Synth } from '@score/dsl'
-import { Delay, Reverb, Distortion } from '@score/effects'
+// Deep house bass — dual oscillator, filter sweep
+SubSynth('C2')
+  .unison(2)
+  .detune(8)
+  .filter(600, 1.2)
+  .wobble(0.5)
+  .volume(0.6)
 
-const lead = Synth({
-  wave: 'sawtooth',
-  gain: 0.2,
-  pattern: ['E4', 0, 'D4', 0,  'C4', 0, 'A3', 0],
-  effects: [
-    Distortion({ amount: 0.3 }),
-    Delay({ time: 0.375, feedback: 0.35, mix: 0.25 }),
-    Reverb({ decay: 1.5, mix: 0.15 }),
-  ],
-})
+// Reese bass — heavy detune, hard saturation
+SubSynth('A1')
+  .unison(4)
+  .detune(20)
+  .saturate(0.6)
+  .volume(0.5)
 ```
 
-Effect descriptors are pure data — no AudioContext in song files. The engine hydrates them at play time. See [EFFECTS.md](EFFECTS.md) for all available effects.
+`SubSynth(pitch?)` — optional starting pitch.
 
-### Using Sequence()
+### SubSynth-specific methods
 
-`Sequence()` parses a space-separated string of note names and rests into an array. `.` = rest.
+| Method | Description |
+|---|---|
+| `.unison(n)` | Oscillator count: `1` = mono, `2` = dual, `4` = quad. |
+| `.detune(cents)` | Detune spread in cents across oscillators. Default `8`. |
+
+### Unison and detune combinations
+
+| `.unison()` | `.detune()` | Character |
+|---|---|---|
+| `1` | `8` | Subtle, slightly warm |
+| `2` | `12` | Classic Juno-style doubling |
+| `4` | `20` | Supersaw-adjacent, very thick |
+
+---
+
+## FMSynth
+
+2-operator FM synthesis. Carrier modulated by a modulator with independent envelopes. Adds `.ratio()`, `.modIndex()`, and `.feedback()` on top of the base chain methods.
 
 ```js
-import { Synth, Sequence } from '@score/dsl'
+// DX7 Rhodes voicing — classic deep house chord
+FMSynth('A3')
+  .ratio(1.273)
+  .modIndex(3)
+  .reverb(0.3)
+  .volume(0.6)
 
-const lead = Synth({
-  wave: 'sawtooth',
-  gain: 0.2,
-  sequence: Sequence('A2 . D3 . F3 . E3 .'),
-})
+// Metallic FM lead — inharmonic ratio, high mod index
+FMSynth('C4')
+  .ratio(3.5)
+  .modIndex(6)
+  .delay(0.375, 0.4)
+  .volume(0.3)
 ```
+
+`FMSynth(pitch?)` — optional starting pitch.
+
+### FMSynth-specific methods
+
+| Method | Description |
+|---|---|
+| `.ratio(n)` | Modulator-to-carrier frequency ratio. `1.0` = harmonic. Non-integer = metallic. Default `1.273`. |
+| `.modIndex(n)` | Modulation index — how much the modulator affects the carrier. `0` = pure sine. `1–5` = Rhodes range. `8+` = metallic. |
+| `.feedback(n)` | Carrier feeds back to modulator (0–1). Adds harmonics and brightness. Default `0`. |
+
+### FM timbres
+
+| Sound | `.ratio()` | `.modIndex()` | Character |
+|---|---|---|---|
+| Rhodes / electric piano | `1.0` | `2–3` | Warm, glassy |
+| Bell / tine | `3.0` | `1.5` | Metallic, inharmonic |
+| Brass / organ | `1.0` | `5–8` | Bright, complex |
+| Techno lead | `2.0` | `6–10` | Aggressive, industrial |
+| Sub bass | `0.5` | `1` | Deep sine with weight |
+
+---
+
+## Bass303
+
+Roland TB-303 acid bass. Sawtooth/square oscillator + resonant filter with envelope. The defining voice of acid house, acid techno, and trance. Adds `.cutoff()`, `.resonance()`, `.accent()`, and `.slide()` on top of the base chain methods.
+
+```js
+// Classic acid bassline
+Bass303('C2')
+  .cutoff(600)
+  .resonance(2.0)
+  .accent([0, 4, 8])
+  .wobble(0.5)
+  .volume(0.6)
+
+// Slide phrase across a scale
+Bass303('C2')
+  .notes(['C2', 'D2', 'F2', 'G2'])
+  .slide([1, 3])
+  .cutoff(500)
+  .resonance(1.5)
+  .volume(0.55)
+```
+
+`Bass303(pitch?)` — optional starting pitch.
+
+### Bass303-specific methods
+
+| Method | Description |
+|---|---|
+| `.cutoff(freq)` | Filter cutoff in Hz. Default `400`. |
+| `.resonance(q)` | Filter resonance Q. Default `0.8`. High values → self-oscillation. |
+| `.filter(freq, q?)` | Sets cutoff + optional resonance together. |
+| `.accent(steps)` | Step indices where velocity is boosted and filter opens fully. |
+| `.slide(steps)` | Step indices with portamento (glide) to next note. |
+
+`.wobble(rate)` is especially effective on Bass303 — it sweeps the filter cutoff with an LFO, giving the classic acid wobble.
+
+---
+
+## Arp
+
+Arpeggiator. Cycles through a note list in sequence. Each step triggers the next note at the current synth voice.
+
+```js
+// Classic trance arp — up mode, triangle wave
+Arp(['C4', 'E4', 'G4', 'B4'])
+  .euclidean(8, 16)
+  .volume(0.5)
+  .delay(0.375, 0.3)
+
+// Dense 16th-note arp with reverb
+Arp(['A3', 'C4', 'E4', 'A4'])
+  .fast(2)
+  .reverb(0.25)
+  .volume(0.4)
+```
+
+`Arp(notes)` — `notes` is an ordered array of note names or MIDI pitch numbers to arpeggiate.
+
+---
+
+## Theremin
+
+Continuous pitch/volume control. Sine oscillator with LFO vibrato. Plays continuously — use `.note()` to set pitch.
+
+```js
+Theremin('A4').vibrato(5, 8).volume(0.4)
+Theremin('C4').drift(0.4).glide(0.1).volume(0.3)
+```
+
+`Theremin(pitch?)` — optional starting pitch.
+
+---
+
+## Sax
+
+Saxophone-style voice. Sawtooth through bandpass filter with ADSR envelope. Breathy, reedy character.
+
+```js
+Sax('A4')
+  .notes(['A4', 'B4', 'C5', 'D5'])
+  .dur(0.35)
+  .reverb(0.2)
+  .volume(0.4)
+```
+
+`Sax(pitch?)` — optional starting pitch.
 
 ---
 
 ## Sample
 
-Plays an audio file. Pattern and volume work the same as other instruments.
+Plays an audio file. Triggered on each pattern hit.
 
 ```js
-import { Sample } from '@score/dsl'
+// One-shot clap on beats 2 and 4
+Sample('./samples/clap.wav').hits(4, 12).volume(0.7)
 
-const rim = Sample({
-  path: './samples/rimshot.wav',
-  pattern: [0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0],
-  volume: 0.8,
-  rate: 1.0,
-})
+// Euclidean rim shot
+Sample('./samples/rim.wav').euclidean(3, 16).volume(0.5)
+
+// Looped vinyl crackle texture
+Sample('./samples/vinyl-crackle.wav')
+  .hits(0)
+  .volume(0.12)
 ```
 
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `path` | `string` | **required** | Relative path to the audio file from the song file's location. Supports `.wav`, `.mp3`, `.ogg`. |
-| `pattern` | `number[]` or `(step, bar) => number` | one hit per beat | 16-step rhythm. `1` = play, `0` = rest. |
-| `volume` | `number` | `0.8` | Output level 0–1. |
-| `rate` | `number` | `1.0` | Playback rate and pitch. `1.0` = original. `2.0` = octave up. `0.5` = octave down. `2 ** (semitones / 12)` for precise tuning. |
-| `loop` | `boolean` | `false` | Loop the sample continuously. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain — import descriptors from `@score/effects`. |
-
-All props except `path` are optional.
+`Sample(path)` — `path` is required. Relative to the song file. Supports `.wav`, `.mp3`, `.ogg`.
 
 ### Path conventions
-
-Paths resolve relative to the song file. The `samples/` directory next to your song file is the convention:
 
 ```
 my-project/
@@ -252,292 +493,30 @@ my-project/
   samples/
     kick.wav
     snare.wav
-    rimshot.wav
+    rim.wav
 ```
 
-The `samples/` directory is gitignored — each user brings their own files. See [SAMPLE.md](SAMPLE.md) for full details.
+Paths resolve relative to the song file. The `samples/` directory is gitignored — each user brings their own files. See [SAMPLE.md](SAMPLE.md) for full details.
 
 ### Pitch shifting
 
-`rate` shifts pitch proportionally. `2 ** (semitones / 12)` converts semitone offsets to rates:
+Use `.pitch(semitones)` to transpose:
 
-| Rate | Pitch |
-|---|---|
-| `0.5` | 1 octave down |
-| `1.0` | Original |
-| `2.0` | 1 octave up |
-| `2 ** (7/12)` | Perfect fifth up (~1.498) |
-
-### Examples
-
-**Rim on the offbeat:**
 ```js
-const rim = Sample({
-  path: './samples/rim.wav',
-  pattern: [0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0,  0, 0, 1, 0],
-  volume: 0.5,
-})
+// Root at A2, shift to D3 (+5 semitones)
+Sample('./samples/bass-a2.wav').pitch(5).hits(0, 4, 8, 12)
 ```
-
-**Looped vinyl crackle texture:**
-```js
-import { Sample } from '@score/dsl'
-
-const crackle = Sample({
-  path: './samples/vinyl-crackle.wav',
-  pattern: [1, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0],
-  volume: 0.12,
-  loop: true,
-})
-```
-
-**Tuned bass sample — root at A2, shifted to D3 (+5 semitones):**
-```js
-const bass = Sample({
-  path: './samples/bass-a2.wav',
-  rate: 2 ** (5 / 12),
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.85,
-})
-```
-
-See [SAMPLE.md](SAMPLE.md) for the full Sample reference including file formats, the `sounds/` directory convention, and melodic sequencing examples.
 
 ---
 
-## Kick808
+## Using Sequence()
 
-TR-808-style bass drum. Pure sine body with deep sub pitch fall — the foundation of deep house, trap, and 808-driven styles.
-
-```js
-import { Kick808 } from '@score/dsl'
-
-const kick = Kick808({
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.8,
-  startFreq: 60,
-  endFreq: 45,
-  pitchFall: 0.15,
-  decay: 0.7,
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` | four-on-the-floor | 16-step rhythm. `1` = hit, `0` = rest. |
-| `volume` | `number` | `0.85` | Output level 0–1. |
-| `startFreq` | `number` | `60` | Initial sine pitch in Hz. |
-| `endFreq` | `number` | `45` | Final pitch after fall in Hz. Deep sub. |
-| `pitchFall` | `number` | `0.15` | Duration of pitch fall in seconds. |
-| `decay` | `number` | `0.7` | Amplitude decay in seconds. Longer than Kick for that 808 sustain. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-All props are optional. The 808 decay is noticeably longer than the standard Kick — use it for sub-heavy styles (trap, deep house, afrotech).
-
----
-
-## Kick909
-
-TR-909-style bass drum. Sine body with transient noise click — the signature of techno, house, and trance.
+`Sequence()` parses a space-separated string of note names and rests into an array. `.` = rest.
 
 ```js
-import { Kick909 } from '@score/dsl'
+import { Synth, Sequence } from '@score/dsl'
 
-const kick = Kick909({
-  pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.9,
-  clickLevel: 0.25,
-  clickDecay: 0.03,
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` | four-on-the-floor | 16-step rhythm. |
-| `volume` | `number` | `0.85` | Output level 0–1. |
-| `startFreq` | `number` | `65` | Initial sine pitch in Hz. |
-| `endFreq` | `number` | `48` | Final pitch after fall in Hz. |
-| `pitchFall` | `number` | `0.12` | Duration of pitch fall in seconds. |
-| `decay` | `number` | `0.65` | Sine body decay in seconds. |
-| `clickLevel` | `number` | `0.25` | Noise click level relative to body (0–1). ≈ −12 dBFS. |
-| `clickDecay` | `number` | `0.03` | Noise click decay in seconds. Shorter = snappier attack. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-**808 vs 909:** Use `Kick808` for sub-heavy, sustained kicks (trap, deep house). Use `Kick909` for punchier, click-forward kicks (techno, house, trance).
-
----
-
-## Snare909
-
-TR-909-style snare. Pitched triangle tone layer plus white noise body — classic crisp techno snare.
-
-```js
-import { Snare909 } from '@score/dsl'
-
-const snare = Snare909({
-  pattern: [0, 0, 0, 0,  1, 0, 0, 0,  0, 0, 0, 0,  1, 0, 0, 0],
-  volume: 0.7,
-  toneNoiseRatio: 0.35,
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` | beats 2 and 4 | 16-step rhythm. |
-| `volume` | `number` | `0.6` | Output level 0–1. |
-| `toneDecay` | `number` | `0.2` | Triangle oscillator decay in seconds. |
-| `noiseDecay` | `number` | `0.3` | Noise body decay in seconds. |
-| `toneNoiseRatio` | `number` | `0.4` | Balance between tone and noise (0 = all noise, 1 = all tone). |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-Lower `toneNoiseRatio` (0.2–0.3) = snappier, noise-dominant snare. Higher (0.5–0.6) = more tonal, rimshot character.
-
----
-
-## Hihat808
-
-TR-808-style hi-hat. Six-oscillator metallic noise source with bandpass filtering — the tight, characteristic 808 hat.
-
-```js
-import { Hihat808 } from '@score/dsl'
-
-const hihat = Hihat808({
-  pattern: [1, 1, 1, 1,  1, 1, 1, 1,  1, 1, 1, 1,  1, 1, 1, 1],
-  volume: 0.3,
-  open: false,
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `number[]` | straight 16ths | 16-step rhythm. |
-| `volume` | `number` | `0.3` | Output level 0–1. |
-| `decay` | `number` | `0.06` (closed) / `0.3` (open) | Amplitude decay in seconds. |
-| `open` | `boolean` | `false` | `true` = open hi-hat (longer sustain, `0.3s` decay). |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-Mix closed (`open: false`) and open (`open: true`) variants across two tracks to build classic 808 drum machine patterns.
-
----
-
-## SubSynth
-
-Full Juno-60 / Minimoog model subtractive synthesizer. Unison oscillators, filter envelope, and ADSR amp envelope. For acid lines, Reese bass, detuned pads, and analog leads.
-
-```js
-import { SubSynth } from '@score/dsl'
-import { Reverb } from '@score/effects'
-
-const lead = SubSynth({
-  wave: 'sawtooth',
-  frequency: 220,
-  unison: 2,
-  detune: 12,
-  filter: {
-    type: 'lowpass',
-    frequency: 600,
-    Q: 3.5,
-    envDepth: 1200,
-    adsr: { attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.1 },
-  },
-  adsr: { attack: 0.008, decay: 0.15, sustain: 0.6, release: 0.08 },
-  pattern: ['A2', 0, 'A2', 0,  0, 'D3', 0, 'E3'],
-  volume: 0.5,
-  effects: [Reverb({ decay: 1.0, mix: 0.18 })],
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `(number\|string)[]` | — | Step pattern. Note names (`'A2'`) or Hz values. `0` = rest. |
-| `volume` | `number` | `0.5` | Output level 0–1. |
-| `wave` | `'sine'` \| `'square'` \| `'sawtooth'` \| `'triangle'` | `'sawtooth'` | Oscillator waveform. |
-| `frequency` | `number` | `220` | Base pitch in Hz when pattern values are `1`. |
-| `detune` | `number` | `8` | Total detune spread between oscillator pairs in cents. |
-| `unison` | `1` \| `2` \| `4` | `1` | Oscillator pairs: `1` = 2 oscs, `2` = 4, `4` = 8. More pairs = thicker. |
-| `filter.type` | `'lowpass'` \| `'highpass'` \| `'bandpass'` | `'lowpass'` | Filter shape. |
-| `filter.frequency` | `number` | `2000` | Filter cutoff in Hz. |
-| `filter.Q` | `number` | `1` | Resonance. |
-| `filter.envDepth` | `number` | `800` | How far the filter envelope opens the cutoff (Hz). |
-| `filter.adsr` | `AdsrProps` | — | Filter envelope — controls cutoff over time. |
-| `adsr` | `AdsrProps` | defaults | Amplitude envelope — controls volume over time. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-### Unison and detune
-
-`unison` + `detune` together control the chorus thickness:
-- `unison: 1, detune: 8` — subtle, slightly warm
-- `unison: 2, detune: 12` — classic Juno-style doubling
-- `unison: 4, detune: 20` — supersaw-adjacent, very thick
-
-### Filter envelope
-
-`filter.envDepth` sets how much the filter opens from `filter.frequency` when the filter ADSR hits. With `frequency: 300, envDepth: 1200`, the cutoff sweeps from 300 Hz to 1500 Hz over the filter attack.
-
----
-
-## FMSynth
-
-2-operator FM synthesizer. Carrier oscillator modulated by a modulator oscillator with independent envelopes. Covers DX7 Rhodes-style tones, electric piano, metallic leads, and bell sounds.
-
-```js
-import { FMSynth } from '@score/dsl'
-import { Reverb } from '@score/effects'
-
-const rhodes = FMSynth({
-  frequency: 261.63,
-  modRatio: 1.0,
-  modIndex: 2.5,
-  ampAdsr:  { attack: 0.005, decay: 0.4,  sustain: 0.3, release: 0.25 },
-  modAdsr:  { attack: 0.001, decay: 0.2,  sustain: 0.0, release: 0.1  },
-  gain: 0.35,
-  pattern: ['C4', 0, 0, 0,  'E4', 0, 0, 0,  'G4', 0, 0, 0,  'C5', 0, 0, 0],
-  volume: 0.6,
-  effects: [Reverb({ decay: 1.8, mix: 0.25 })],
-})
-```
-
-### Props
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `pattern` | `(number\|string)[]` | — | Step pattern. Note names or Hz values. `0` = rest. |
-| `volume` | `number` | `0.6` | Output level 0–1. |
-| `frequency` | `number` | `440` | Carrier base frequency in Hz. |
-| `modRatio` | `number` | `1.0` | Modulator-to-carrier frequency ratio. `1.0` = same pitch (harmonic). `2.0` = octave above. |
-| `modIndex` | `number` | `3.0` | Modulation index — how much the modulator affects the carrier. `0` = pure sine. `1–5` = Rhodes/DX7 range. `8+` = metallic/inharmonic. |
-| `ampAdsr` | `AdsrProps` | defaults | Amplitude envelope on the carrier output. |
-| `modAdsr` | `AdsrProps` | defaults | Envelope on the modulation depth. Controls timbre evolution over time. |
-| `gain` | `number` | `0.3` | Peak gain 0–1. |
-| `effects` | `EffectDescriptor[]` | `[]` | Effects chain. |
-
-### FM timbres
-
-The combination of `modRatio` and `modIndex` determines the timbre:
-
-| Sound | modRatio | modIndex | Character |
-|---|---|---|---|
-| Rhodes / electric piano | `1.0` | `2–3` | Warm, slightly glassy |
-| Bell / tine | `3.0` | `1.5` | Metallic, inharmonic partials |
-| Brass / organ | `1.0` | `5–8` | Bright, complex |
-| Techno lead | `2.0` | `6–10` | Aggressive, industrial |
-| Sub bass | `0.5` | `1` | Deep sine with weight |
-
-### Modulator envelope
-
-`modAdsr` controls how the timbral brightness evolves. A fast-decaying modulator envelope gives the DX7 pluck character: bright attack, darkening sustain:
-
-```js
-// Classic DX7 "E. Piano 1" timbral envelope
-modAdsr: { attack: 0.001, decay: 0.3, sustain: 0.0, release: 0.15 }
+const lead = Synth('sawtooth', 'A2')
+  .notes(Sequence('A2 . D3 . F3 . E3 .'))
+  .volume(0.2)
 ```

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -6,6 +6,24 @@ Patterns control when notes and hits play. All pattern utilities are in `@score/
 import { euclidean, fast, slow, rev, shift, degrade, every, stack, beat, scaleNotes, chordNotes } from '@score/pattern'
 ```
 
+Most pattern operations are available as **chain methods** directly on instruments — no import needed:
+
+```js
+Kick().euclidean(5, 16)         // euclidean built-in
+HiHat(8).degrade(0.3)          // degrade built-in
+Snare().shift(1)                // shift built-in
+```
+
+Import from `@score/pattern` when you need the standalone functions — for use with `.pattern()`, `.mask()`, or `.apply()`:
+
+```js
+import { euclidean, stack } from '@score/pattern'
+
+// Pass a computed pattern to .pattern()
+const groove = stack(euclidean(3, 8), euclidean(5, 8))
+Kick().pattern(groove)
+```
+
 ---
 
 ## Array patterns
@@ -14,10 +32,10 @@ The simplest pattern — a plain JavaScript array. 16 steps = one bar at 16th-no
 
 ```js
 // Rhythmic: 1 = hit, 0 = rest
-pattern: [1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0]
+Kick().pattern([1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0,  1, 0, 0, 0])
 
 // Melodic: note name or 0 (rest)
-pattern: ['A2', 0, 'D3', 0,  'E3', 0, 'A3', 0]
+Synth('sawtooth').pattern(['A2', 0, 'D3', 0,  'E3', 0, 'A3', 0])
 ```
 
 Patterns loop automatically. An 8-step array repeats every half bar.
@@ -67,21 +85,21 @@ euclidean(3, 8, 2)  // → clave rotated 2 steps right
 
 ## Function patterns
 
-A function `(step, bar) => value` is called once per step per bar.
+Pass a function `(step, bar) => value` to `.pattern()` or `.apply()` for bar-aware patterns.
 
 ```js
 // Alternate between two bass lines every bar
-pattern: (step, bar) => {
+Synth('sawtooth').pattern((step, bar) => {
   const lineA = ['A2', 0, 'D3', 0]
   const lineB = ['E2', 0, 'A2', 0]
   return (bar % 2 === 0 ? lineA : lineB)[step % 4]
-}
+})
 
 // Extra kick hit on last bar of every 4
-pattern: (step, bar) => {
-  if (bar % 4 === 3 && step === 14) return 1
-  return [1, 0, 0, 0,  1, 0, 0, 0][step % 8]
-}
+Kick().apply((p, { bar }) => {
+  if (bar % 4 === 3) { const next = [...p]; next[14] = 1; return next }
+  return p
+})
 ```
 
 - `step` — 16th-note position within the bar (0–15 for 16 steps)
@@ -93,67 +111,70 @@ All transforms return function patterns and receive `step` and `bar` at runtime.
 
 ## Transforms
 
-All transforms accept an array or function pattern and return a function pattern `(step, bar) => value`.
+These transforms are available both as **chain methods** (no import needed) and as **standalone functions** from `@score/pattern` for use with `.pattern()`.
 
-### `fast(n, pattern)`
+### `fast` / `.fast(n)`
 
-Speed up by factor `n`. `fast(2, pat)` plays the pattern twice per bar.
-
-```js
-pattern: fast(2, [1, 0, 1, 0])        // 16th-note rush
-pattern: fast(4, euclidean(3, 8))      // rapid euclidean fill
-```
-
-### `slow(n, pattern)`
-
-Slow down by factor `n`. Each step plays for `n` times as long.
+Speed up by factor `n`. Plays the pattern `n` times faster.
 
 ```js
-pattern: slow(2, [0, 0, 1, 0,  0, 0, 1, 0])  // half-time snare
+// Chain method (preferred)
+HiHat(8).fast(2)                      // 16th-note rush
+
+// Standalone — pass computed result to .pattern()
+import { fast, euclidean } from '@score/pattern'
+Kick().pattern(fast(4, euclidean(3, 8)))   // rapid euclidean fill
 ```
 
-### `rev(pattern)`
+### `slow` / `.slow(n)`
+
+Slow down by factor `n`. Each step plays `n` times as long.
+
+```js
+Snare().slow(2)                             // half-time snare
+Snare().pattern(slow(2, [0, 0, 1, 0,  0, 0, 1, 0]))  // explicit
+```
+
+### `rev` / `.rev()`
 
 Reverse the pattern — last step to first.
 
 ```js
-pattern: rev(['C4', 'E4', 'G4', 'A4'])  // retrograde melody
+Synth('sawtooth').notes(['C4', 'E4', 'G4', 'A4']).rev()   // retrograde melody
 ```
 
-### `shift(n, pattern)`
+### `shift` / `.shift(n)`
 
 Rotate by `n` steps. Positive = shift right (later), negative = shift left (earlier).
 
 ```js
-pattern: shift(1, [0, 0, 1, 0,  0, 0, 1, 0])  // snare one 16th late
-pattern: shift(-2, euclidean(3, 8))             // clave shifted left 2
+Snare().shift(1)                              // snare one 16th late
+Kick().pattern(shift(-2, euclidean(3, 8)))    // clave shifted left 2
 ```
 
-### `degrade(probability, pattern)`
+### `degrade` / `.degrade(probability)`
 
 Randomly silence hits. `probability` = chance (0–1) of dropping each active step per bar.
 
 ```js
-pattern: degrade(0.3, [1, 1, 1, 1])    // drop ~30% of hits
-pattern: degrade(0.5, euclidean(5, 8)) // sparse euclidean
+HiHat(8).degrade(0.3)                        // drop ~30% of hits
+Kick().pattern(degrade(0.5, euclidean(5, 8))) // sparse euclidean
 ```
 
-### `every(n, transform, pattern)`
+### `every` / `.every(n, fn)`
 
-Apply `transform` on every `n`th bar. Original pattern on other bars.
+Apply `fn` on every `n`th bar. Original pattern on other bars.
 
 ```js
-// Kick doubles speed every 4 bars
-pattern: every(4, p => fast(2, p), [1, 0, 0, 0])
+// Chain method
+Kick(4).every(4, p => fast(2, p))   // kick doubles speed every 4 bars
+HiHat(8).every(2, rev)              // hi-hat reverses every other bar
 
-// Hi-hat reverses every other bar
-pattern: every(2, rev, [1, 0, 1, 1])
-
-// Degrade on bars 0, 8, 16 ...
-pattern: every(8, p => degrade(0.5, p), [0, 0, 1, 0])
+// With standalone degrade
+Snare().every(8, p => degrade(0.5, p))  // drops on bars 0, 8, 16...
 ```
 
-`transform` receives the current pattern and returns a new pattern.
+`fn` receives the current pattern and returns a new pattern.
 
 ---
 
@@ -196,9 +217,9 @@ If the key contains `m` (and not `maj`), minor is used. Otherwise major.
 
 Supported scale modes: `major`, `minor`, `dorian`, `phrygian`, `lydian`, `mixolydian`, `locrian`, `pentatonic`, `blues`.
 
-Feed directly into a Synth pattern:
+Feed directly into `.notes()` or `.pattern()`:
 ```js
-const melody = Synth({ pattern: scaleNotes('Am', 3, 1) })
+const melody = Synth('sawtooth').notes(scaleNotes('Am', 3, 1))
 ```
 
 ### `chordNotes(chord, octave?)`


### PR DESCRIPTION
## Summary

- **GETTING_STARTED.md** — Remove stale "chain API pending" note (the chain API shipped). Rewrite examples to chain style (`Kick(4).volume(0.9)`). Add `Bass303` to the symbols table.
- **INSTRUMENTS.md** — Full rewrite. Drop all old `Props` tables. Document all instruments with chain factory signatures and chain method examples. Add missing `Bass303` section. Add common chain methods reference table.
- **EFFECTS.md** — Rewrite to chain methods as primary (`.reverb()`, `.delay()`, `.filter()`, `.eq()`, `.chorus()`, `.flange()`, `.bit()`, `.saturate()`, `.widen()`, `.pan()`). Keep `@score/effects` descriptor factories in an "Advanced" section for `Compressor`, `Limiter`, `Phaser`, `Gate`, `Distortion`, full `Filter` — no chain method exists for these yet.
- **PATTERNS.md** — Update intro to show chain method style as primary. Update transform examples to show chain + standalone dual usage. Update `scaleNotes` example to `.notes()` call.

## Test plan

- [ ] Docs render correctly (markdown)
- [ ] All code examples use the actual chain API (`Kick(hits?)`, `Synth(wave?, pitch?)`, etc.)
- [ ] No examples reference the old props-style constructors (`Kick({ pattern: [...] })`)
- [ ] Bass303 is documented and examples match `melodic.ts`
- [ ] Effects chain methods match `chain.ts` signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)