### PR TITLE
fix(engine): map .filter() chain method in partToInstrumentDescriptor

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -140,6 +140,12 @@ export const partToInstrumentDescriptor = (part: PartDescriptor): InstrumentDesc
     ...(part._humanize !== undefined ? { humanize: part._humanize } : {}),
     ...(part._pan      !== undefined ? { pan:      part._pan      } : {}),
     ...(part._model    !== undefined ? { model:    part._model    } : {}),
+    // Fix: map _filter chain method → props.filter (SubSynth, Synth, Pad, etc.)
+    ...(part._filter !== undefined ? { filter: part._filter } : {}),
+    // Fix: bass-303 engine reads props.cutoff/resonance not props.filter — also map for it
+    ...(part._filter !== undefined && part.instrumentType === 'bass-303'
+      ? { cutoff: part._filter.frequency, resonance: part._filter.Q ?? 1 }
+      : {}),
     ...part.props,
   },
 })

--- a/packages/cli/tests/engine-chain-hydration.test.ts
+++ b/packages/cli/tests/engine-chain-hydration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
-import { createScoreEngine } from '../src/engine.js'
+import { createScoreEngine, partToInstrumentDescriptor } from '../src/engine.js'
 import { webAudioBackend } from '@score/core'
 import { Song, Track, createPart } from '@score/dsl'
 
@@ -106,6 +106,33 @@ describe('engine — chain API hydration', () => {
     })
     expect(() => { engine.update(nextSong) }).not.toThrow()
     engine.dispose()
+  })
+
+  it('_filter chain method maps to props.filter for SubSynth (fix: was silently dropped)', () => {
+    // SubSynth('A2').filter(600, 2) sets _filter on the PartDescriptor.
+    // Before the fix, partToInstrumentDescriptor did not map _filter at all.
+    const part = createPart({
+      instrumentType: 'subsynth',
+      _filter: { frequency: 600, Q: 2 },
+      props: {},
+    })
+    const desc = partToInstrumentDescriptor(part)
+    const props = desc.props as Record<string, unknown>
+    expect(props['filter']).toEqual({ frequency: 600, Q: 2 })
+  })
+
+  it('_filter chain method maps to props.cutoff+resonance for bass-303', () => {
+    // If _filter is set on a bass-303 part, it should map to props.cutoff/resonance
+    // because the bass-303 engine reads those props, not props.filter.
+    const part = createPart({
+      instrumentType: 'bass-303',
+      _filter: { frequency: 400, Q: 4 },
+      props: {},
+    })
+    const desc = partToInstrumentDescriptor(part)
+    const props = desc.props as Record<string, unknown>
+    expect(props['cutoff']).toBe(400)
+    expect(props['resonance']).toBe(4)
   })
 
   it('t147: onStep fires with PartDescriptor-only song (cursor advance fix)', async () => {


### PR DESCRIPTION
## Summary

- `.filter(freq, q)` chain method sets `_filter` on `PartDescriptor` but `partToInstrumentDescriptor` was not mapping it — silently dropped on every call.
- Fix adds two spreads: (1) general `_filter → props.filter` for SubSynth, Synth, Pad etc. (2) `_filter → props.cutoff + props.resonance` for bass-303 (engine reads those props, not `props.filter`).
- Note: `Bass303.filter()` already overrides the base chain method to put `cutoff/resonance` in `part.props` directly, so normal Bass303 usage already worked. The new bass-303 case is defensive.

## Test plan

- [ ] `SubSynth('A2').filter(600, 2)` → `props.filter = { frequency: 600, Q: 2 }` ✓
- [ ] `Bass303('A2').filter(400, 4)` → `props.cutoff = 400, props.resonance = 4` ✓
- [ ] 102 CLI tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)