### PR TITLE
feat(gui): t158 + t207 — coming-soon mode gates + panic key flash

### DIFF
--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -208,6 +208,7 @@ const panicStop = (): void => {
   slot.bars    = 0
   pushState()
   send('engine:pending', { pending: false })
+  send('engine:panic', undefined)
 }
 
 const boot = async (song: SongDefinition, barOffset = 0): Promise<void> => {

--- a/packages/gui/src/main/ipc-types.ts
+++ b/packages/gui/src/main/ipc-types.ts
@@ -83,4 +83,9 @@ export type MainToRenderer = {
   'debug:pop':       { maxDelta: number; step: number; bars: number }
   /** Sent by main on launch with the previously saved panel layout (if any). */
   'layout:load':     PanelLayoutMap
+  /**
+   * Fires when the panic key (Cmd/Ctrl+.) triggers an immediate all-stop.
+   * Renderer shows a brief transient flash to confirm the stop landed.
+   */
+  'engine:panic':    undefined
 }

--- a/packages/gui/src/renderer/components/SplashScreen.tsx
+++ b/packages/gui/src/renderer/components/SplashScreen.tsx
@@ -31,18 +31,21 @@ const MODES: readonly ModeCard[] = [
     label:       'Produce',
     description: 'Arrange tracks, automate parameters, export stems.',
     icon:        '▦',
+    disabled:    true,
   },
   {
     id:          'dj-set',
     label:       'DJ Set',
     description: 'Mix decks, manage cues, crossfade. Score is your DJ software.',
     icon:        '⊙',
+    disabled:    true,
   },
   {
     id:          'jam-session',
     label:       'Jam Session',
     description: 'Perform live with MIDI hardware. Patch anything to anything.',
     icon:        '⊕',
+    disabled:    true,
   },
 ]
 

--- a/packages/gui/src/renderer/components/shared/TransportBar.tsx
+++ b/packages/gui/src/renderer/components/shared/TransportBar.tsx
@@ -45,10 +45,20 @@ export const TransportBar = ({ hardware, onHome, onPlay, onStop, onBpmChange, ge
 
   const [localBpm, setLocalBpm]         = useState(128)
   const [bugModalOpen, setBugModalOpen] = useState(false)
+  const [panicFlash, setPanicFlash]     = useState(false)
 
   useEffect(() => {
     const off = window.scoreBridge.on('engine:state', payload => {
       setEngine(payload)
+    })
+    return off
+  }, [])
+
+  useEffect(() => {
+    const off = window.scoreBridge.on('engine:panic', () => {
+      setPanicFlash(true)
+      const timer = setTimeout(() => { setPanicFlash(false) }, 1500)
+      return () => { clearTimeout(timer) }
     })
     return off
   }, [])
@@ -91,6 +101,13 @@ export const TransportBar = ({ hardware, onHome, onPlay, onStop, onBpmChange, ge
       >
         {engine.playing ? '■' : '▶'}
       </button>
+
+      {/* Panic flash — transient 'Stopped' indicator after Ctrl+. */}
+      {panicFlash && (
+        <span role="status" aria-live="assertive" style={styles.panicFlash}>
+          ■ Stopped
+        </span>
+      )}
 
       {/* BPM */}
       <div style={styles.bpmGroup}>
@@ -272,5 +289,14 @@ const styles = {
     color:      '#6a9fff',
     border:     '1px solid #253050',
     background: '#0d1928',
+  },
+  panicFlash: {
+    fontFamily:    'system-ui, sans-serif',
+    fontSize:      '0.7rem',
+    fontWeight:    600,
+    letterSpacing: '0.08em',
+    color:         '#ff6a6a',
+    textTransform: 'uppercase' as const,
+    flexShrink:    0,
   },
 } as const

--- a/packages/gui/tests/SplashScreen.test.tsx
+++ b/packages/gui/tests/SplashScreen.test.tsx
@@ -27,16 +27,21 @@ describe('SplashScreen — rendering', () => {
   it('renders all four mode buttons', () => {
     setup()
     expect(screen.getByRole('button', { name: 'Live Code' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Produce' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'DJ Set' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Jam Session' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Produce — coming soon' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'DJ Set — coming soon' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Jam Session — coming soon' })).toBeInTheDocument()
   })
 
-  it('all mode buttons are enabled', () => {
+  it('non-live-code modes are disabled (coming soon)', () => {
     setup()
-    expect(screen.getByRole('button', { name: 'Produce' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'DJ Set' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'Jam Session' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Produce — coming soon' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'DJ Set — coming soon' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Jam Session — coming soon' })).toBeDisabled()
+  })
+
+  it('live-code mode is enabled', () => {
+    setup()
+    expect(screen.getByRole('button', { name: 'Live Code' })).toBeEnabled()
   })
 
   it('renders three hardware level buttons', () => {
@@ -79,11 +84,11 @@ describe('SplashScreen — mode selection', () => {
     expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('clicking another mode card selects it', async () => {
+  it('clicking a disabled mode card does not change selection', async () => {
     const { user } = setup()
-    await user.click(screen.getByRole('button', { name: 'Produce' }))
-    expect(screen.getByRole('button', { name: 'Produce' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'false')
+    await user.click(screen.getByRole('button', { name: 'Produce — coming soon' }))
+    // live-code remains selected — disabled card click is a no-op
+    expect(screen.getByRole('button', { name: 'Live Code' })).toHaveAttribute('aria-pressed', 'true')
   })
 })
 

--- a/packages/gui/tests/TransportBar.test.tsx
+++ b/packages/gui/tests/TransportBar.test.tsx
@@ -73,6 +73,17 @@ describe('TransportBar — IPC', () => {
   })
 })
 
+// ── Panic flash ───────────────────────────────────────────────────────────────
+
+describe('TransportBar — panic flash', () => {
+  it('shows Stopped flash when engine:panic fires', () => {
+    setup()
+    act(() => { emitBridgeEvent('engine:panic', undefined) })
+    expect(screen.getByText(/stopped/i)).toBeInTheDocument()
+  })
+
+})
+
 // ── Accessibility ─────────────────────────────────────────────────────────────
 
 describe('TransportBar — accessibility', () => {


### PR DESCRIPTION
## Summary

- **t158 — Coming-soon mode gates**: Produce, DJ Set, and Jam Session are now disabled in the SplashScreen mode picker with a "Coming soon" badge. Live Code and Performance remain fully clickable. Prevents testers hitting dead-end mode shells.
- **t207 — Panic key renderer flash**: `panicStop()` already registered `Cmd/Ctrl+.` as a global shortcut and stopped the engine. Added the missing renderer confirmation: new `engine:panic` IPC channel, `TransportBar` listens and shows a brief "■ Stopped" flash (1.5s).

## Test plan

- [ ] Launch Score Studio — Produce/DJ Set/Jam Session show greyed-out cards with "Coming soon" text; clicking does nothing
- [ ] Live Code mode still launches normally
- [ ] During playback, press `Ctrl+.` — audio stops immediately, "■ Stopped" flash appears in TransportBar then fades
- [ ] 330 GUI tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)