### PR TITLE
feat(sequencer): wire swing/humanize/degrade into StepSequencerProps + engine

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -138,6 +138,7 @@ export const partToInstrumentDescriptor = (part: PartDescriptor): InstrumentDesc
     ...(part._effects  !== undefined ? { effects:  part._effects  } : {}),
     ...(part._swing    !== undefined ? { swing:    part._swing    } : {}),
     ...(part._humanize !== undefined ? { humanize: part._humanize } : {}),
+    ...(part._degrade  !== undefined ? { degrade:  part._degrade  } : {}),
     ...(part._pan      !== undefined ? { pan:      part._pan      } : {}),
     ...(part._model    !== undefined ? { model:    part._model    } : {}),
     // Fix: map _filter chain method → props.filter (SubSynth, Synth, Pad, etc.)
@@ -148,6 +149,22 @@ export const partToInstrumentDescriptor = (part: PartDescriptor): InstrumentDesc
       : {}),
     ...part.props,
   },
+})
+
+// ── Sequencer timing helper ───────────────────────────────────────────────────
+
+// Extracts swing/humanize/degrade/seed from a hydrated instrument props object
+// and returns only the fields accepted by StepSequencerProps. These fields are
+// written by partToInstrumentDescriptor from the chain-API _degrade/_humanize/_swing
+// fields, then passed through comp.props to every createStepSequencer call site.
+const seqExtras = (
+  props: Record<string, unknown>,
+  seed?: number,
+): { swing?: number; humanize?: number; degrade?: number; seed?: number } => ({
+  ...(typeof props.swing    === 'number' ? { swing:    props.swing    } : {}),
+  ...(typeof props.humanize === 'number' ? { humanize: props.humanize } : {}),
+  ...(typeof props.degrade  === 'number' ? { degrade:  props.degrade  } : {}),
+  ...(seed !== undefined ? { seed } : {}),
 })
 
 // ── Default patterns ──────────────────────────────────────────────────────────
@@ -439,6 +456,8 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
   descriptors.forEach((comp, i) => {
     const dest = channelInputs[i]
     if (!dest) return
+    // Thread swing/humanize/degrade/seed into every createStepSequencer call for this track.
+    const timing = seqExtras(comp.props as Record<string, unknown>, song.seed)
 
     switch (comp.instrumentType) {
       case 'kick': {
@@ -448,17 +467,17 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         if (props.model === '808') {
           const kick808 = createKick808(ctx, { gain: props.volume ?? 0.85 })
           kick808.connect(dest)
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) kick808.trigger(pos.time)
           })
         } else if (props.model === '909') {
           const kick909 = createKick909(ctx, { gain: props.volume ?? 0.85 })
           kick909.connect(dest)
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) kick909.trigger(pos.time)
           })
         } else {
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) triggerKick(ctx, pos.time, props, dest)
           })
         }
@@ -471,11 +490,11 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         if (props.model === '909') {
           const snare909 = createSnare909(ctx, { gain: props.volume ?? 0.8 })
           snare909.connect(dest)
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) snare909.trigger(pos.time)
           })
         } else {
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) triggerSnare(ctx, pos.time, props, dest)
           })
         }
@@ -488,11 +507,11 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         if (props.model === '808') {
           const hat808 = createHihat808(ctx, { gain: props.volume ?? 0.4, ...(props.open !== undefined ? { open: props.open } : {}) })
           hat808.connect(dest)
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) hat808.trigger(pos.time)
           })
         } else {
-          createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+          createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
             if (hit) triggerHiHat(ctx, pos.time, props, dest)
           })
         }
@@ -502,7 +521,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const props = comp.props as SynthDSLProps
         const rawPattern = props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN
         const pattern: (number | string)[] = Array.isArray(rawPattern) ? rawPattern : DEFAULT_SYNTH_PATTERN
-        createStepSequencer(transport, { pattern, seed: song.seed }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) triggerSynth(ctx, pos.time, props, freq, dest)
         })
@@ -519,7 +538,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         })
         player.connect(dest)
         const pattern = props.pattern ?? [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        createStepSequencer(transport, { pattern, seed: song.seed }, (hit, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
           if (hit) player.start(pos.time)
         })
         break
@@ -554,7 +573,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         s.connect(dest)
         s.start()
         const rawPattern = props.pattern ?? ['A4', 0, 0, 0,  'A4', 0, 0, 0,  'A4', 0, 0, 0,  'A4', 0, 0, 0]
-        createStepSequencer(transport, { pattern: rawPattern, seed: song.seed }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern: rawPattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             s.setFrequency(freq)
@@ -572,7 +591,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const arpState = { noteIndex: 0, pingDir: 1 }
         const defaultPattern = Array.from({ length: 16 }, () => 1)
         const rawPattern = props.pattern ?? defaultPattern
-        createStepSequencer(transport, { pattern: rawPattern, seed: song.seed }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern: rawPattern, ...timing }, (val: number | string, _step, pos) => {
           const active = typeof val === 'number' ? val : resolveFreq(val)
           if (active <= 0) return
           const idx = Math.floor(arpState.noteIndex / rate) % notes.length
@@ -613,7 +632,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         })
         kick.connect(dest)
         const pattern = props.pattern ?? DEFAULT_KICK_PATTERN
-        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
           if (hit) kick.trigger(pos.time)
         })
         break
@@ -631,7 +650,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         })
         kick.connect(dest)
         const pattern = props.pattern ?? DEFAULT_KICK_PATTERN
-        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
           if (hit) kick.trigger(pos.time)
         })
         break
@@ -645,7 +664,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         })
         hat.connect(dest)
         const pattern = props.pattern ?? DEFAULT_HIHAT_PATTERN
-        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
           if (hit) hat.trigger(pos.time)
         })
         break
@@ -660,7 +679,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         })
         snare.connect(dest)
         const pattern = props.pattern ?? DEFAULT_SNARE_PATTERN
-        createStepSequencer(transport, { pattern }, (hit, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (hit, _step, pos) => {
           if (hit) snare.trigger(pos.time)
         })
         break
@@ -674,7 +693,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const decay   = adsr.decay   ?? 0.1
         const release = adsr.release ?? 0.3
         const noteDur = attack + decay + release + 0.02
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createSubtractiveSynth(ctx, {
@@ -700,7 +719,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const decay   = ampAdsr.decay   ?? 0.2
         const release = ampAdsr.release ?? 0.4
         const noteDur = attack + decay + release + 0.02
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createFMSynth(ctx, {
@@ -727,7 +746,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const decay   = adsr.decay   ?? 0.2
         const release = adsr.release ?? 1.2
         const noteDur = attack + decay + release + 0.02
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createPad(ctx, {
@@ -752,7 +771,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const decay   = ampAdsr.decay   ?? 0.9
         const release = ampAdsr.release ?? 0.5
         const noteDur = attack + decay + release + 0.02
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createRhodes(ctx, {
@@ -774,7 +793,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         // Pluck — Karplus-Strong: trigger on any non-zero note, natural decay
         const props = comp.props as { pattern?: readonly (number | string)[]; notes?: readonly (number | string)[]; feedback?: number; burstDuration?: number; volume?: number }
         const pattern = (props.pattern ?? props.notes ?? DEFAULT_SYNTH_PATTERN) as (number | string)[]
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createPluck(ctx, {
@@ -799,7 +818,7 @@ export const createScoreEngine = async (song: SongDefinition): Promise<ScoreEngi
         const decay   = ampAdsr.decay   ?? 0.2
         const release = ampAdsr.release ?? 0.1
         const noteDur = attack + decay + release + 0.02
-        createStepSequencer(transport, { pattern }, (val: number | string, _step, pos) => {
+        createStepSequencer(transport, { pattern, ...timing }, (val: number | string, _step, pos) => {
           const freq = resolveFreq(val)
           if (freq > 0) {
             const voice = createBass303(ctx, {

--- a/packages/cli/tests/engine-chain-hydration.test.ts
+++ b/packages/cli/tests/engine-chain-hydration.test.ts
@@ -135,6 +135,24 @@ describe('engine — chain API hydration', () => {
     expect(props['resonance']).toBe(4)
   })
 
+  it('partToInstrumentDescriptor maps _degrade to props.degrade', () => {
+    const part = createPart({ instrumentType: 'kick', _pattern: [1, 0, 0, 0], _degrade: 0.25, props: {} })
+    const desc = partToInstrumentDescriptor(part)
+    expect((desc.props as Record<string, unknown>).degrade).toBe(0.25)
+  })
+
+  it('partToInstrumentDescriptor maps _swing to props.swing', () => {
+    const part = createPart({ instrumentType: 'kick', _pattern: [1, 0, 0, 0], _swing: 0.6, props: {} })
+    const desc = partToInstrumentDescriptor(part)
+    expect((desc.props as Record<string, unknown>).swing).toBe(0.6)
+  })
+
+  it('partToInstrumentDescriptor maps _humanize to props.humanize', () => {
+    const part = createPart({ instrumentType: 'snare', _pattern: [0, 0, 1, 0], _humanize: 0.005, props: {} })
+    const desc = partToInstrumentDescriptor(part)
+    expect((desc.props as Record<string, unknown>).humanize).toBe(0.005)
+  })
+
   it('t147: onStep fires with PartDescriptor-only song (cursor advance fix)', async () => {
     // Before the fix, PartDescriptor tracks were dropped from descriptors in
     // createScoreEngine(), so cursorStepCount defaulted to 8 and no instruments

--- a/packages/sequencer/src/stepSequencer.ts
+++ b/packages/sequencer/src/stepSequencer.ts
@@ -3,6 +3,16 @@
 import type { PatternInput, Position } from './types.js'
 import type { Transport } from './transport.js'
 
+// Mulberry32 PRNG — inlined to avoid a cross-package dep on @score/pattern.
+// Same algorithm used in @score/pattern/transforms.ts and @prime/prime-random.
+// Returns [randomValue 0–1, nextSeed].
+const prngNext = (seed: number): [number, number] => {
+  const s = (seed + 0x6D2B79F5) >>> 0
+  let t = Math.imul(s ^ (s >>> 15), 1 | s)
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) >>> 0
+  return [((t ^ (t >>> 14)) >>> 0) / 0x100000000, s]
+}
+
 /**
  * Configuration props for {@link createStepSequencer}.
  */
@@ -13,10 +23,30 @@ export type StepSequencerProps<T = number> = {
   readonly steps?: number
   /**
    * Song seed — passed to `PatternFn` as the third argument so stochastic transforms
-   * (`degrade`, `humanize`) produce song-specific variation.
-   * Sourced from `Song({ seed })` — defaults to `Date.now()` if omitted.
+   * produce song-specific variation. Sourced from `Song({ seed })`.
    */
   readonly seed?: number
+  /**
+   * Swing amount 0–1. Odd steps are delayed by `swing × (60 / bpm / ticksPerBeat) × 0.5`
+   * seconds, producing a shuffle feel. Defaults to `0` (straight timing).
+   */
+  readonly swing?: number
+  /**
+   * Timing jitter in seconds. Each step is shifted by a seeded `±humanize` offset,
+   * creating subtle timing variation that prevents a mechanical feel. Defaults to `0`.
+   */
+  readonly humanize?: number
+  /**
+   * Per-step drop probability 0–1. When set, each step is tested against a seeded
+   * random value — if `rand < degrade`, the `onStep` callback is skipped for that step.
+   * The step counter still advances. Defaults to `0` (no drops).
+   */
+  readonly degrade?: number
+  /**
+   * Ticks per beat — used to convert BPM into a per-tick duration for the swing
+   * offset calculation. Should match the transport's `ticksPerBeat`. Defaults to `4`.
+   */
+  readonly ticksPerBeat?: number
 }
 
 /**
@@ -46,17 +76,24 @@ type SequencerState<T> = {
  * each step value via the pattern — either by index into an array or by calling the
  * generator function — before invoking `onStep`.
  *
+ * Supports optional timing controls:
+ * - `swing` — delays odd steps for a shuffle feel
+ * - `humanize` — adds seeded per-step timing jitter
+ * - `degrade` — randomly drops steps using a seeded PRNG
+ *
  * @param transport - The {@link Transport} whose tick stream drives the sequencer.
- * @param props     - Sequencer configuration: `pattern` and optional `steps` count.
- * @param onStep    - Callback invoked on every tick with the resolved step value,
- *   the current step index (0-based, wrapping at `steps`), and the transport position.
+ * @param props     - Sequencer configuration: `pattern`, optional `steps` count,
+ *   and optional timing controls (`swing`, `humanize`, `degrade`, `ticksPerBeat`).
+ * @param onStep    - Callback invoked on every (non-degraded) tick with the resolved
+ *   step value, the current step index (0-based, wrapping at `steps`), and the
+ *   transport position (with swing/humanize offsets applied to `position.time`).
  * @returns A {@link StepSequencer} instance.
  *
  * @example
  * ```ts
  * const seq = createStepSequencer(
  *   transport,
- *   { pattern: [1, 0, 1, 0, 1, 0, 1, 0] },
+ *   { pattern: [1, 0, 1, 0, 1, 0, 1, 0], swing: 0.5, humanize: 0.002 },
  *   (value, step) => { if (value) kick.start(transport.position.time) },
  * )
  * transport.play()
@@ -86,8 +123,40 @@ export const createStepSequencer = <T = number>(
 
   transport.onTick((position: Position): void => {
     const currentStepNumber = state.step % state.steps
+
+    // Degrade — seeded per-step probability drop. Step counter advances even when dropped.
+    if (props.degrade !== undefined && props.degrade > 0) {
+      const degradeSeed = ((currentStepNumber * 1237 + position.bar * 4567) ^ (props.seed ?? 0)) >>> 0
+      const [rand] = prngNext(degradeSeed)
+      if (rand < props.degrade) {
+        state.step += 1  // ADVANCE — dropped steps still count
+        return
+      }
+    }
+
     const value = resolvePattern(currentStepNumber, position.bar)
-    onStep(value, currentStepNumber, position)
+
+    // Swing — delay odd steps by a fraction of a tick duration
+    const ticksPerBeat = props.ticksPerBeat ?? 4
+    const swingOffset = (props.swing !== undefined && props.swing > 0 && currentStepNumber % 2 === 1)
+      ? props.swing * (60 / transport.bpm / ticksPerBeat) * 0.5
+      : 0
+
+    // Humanize — seeded ±humanize timing jitter in seconds
+    const humanizeOffset = (props.humanize !== undefined && props.humanize > 0)
+      ? (() => {
+          const humanizeSeed = (((currentStepNumber * 7919 + position.bar * 3571) ^ (currentStepNumber << 4)) ^ (props.seed ?? 0)) >>> 0
+          const [rand] = prngNext(humanizeSeed)
+          return (rand * 2 - 1) * props.humanize
+        })()
+      : 0
+
+    const rawTime = position.time + swingOffset + humanizeOffset
+    const adjustedPosition: Position = (swingOffset === 0 && humanizeOffset === 0)
+      ? position
+      : { ...position, time: rawTime < 0 ? 0 : rawTime }
+
+    onStep(value, currentStepNumber, adjustedPosition)
     state.step += 1  // ADVANCE — the only forward-time mutation permitted
   })
 

--- a/packages/sequencer/tests/stepSequencer.test.ts
+++ b/packages/sequencer/tests/stepSequencer.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from 'vitest'
 import { createStepSequencer } from '../src/stepSequencer.js'
 import { createTransport } from '../src/transport.js'
+import type { Transport } from '../src/transport.js'
+import type { Position } from '../src/types.js'
 import { mockContext } from './utils/harness.js'
+
+// Minimal mock transport for behavioral tick-firing tests.
+// Only implements the subset of Transport that createStepSequencer uses.
+const makeMockTransport = (bpm = 120) => {
+  const tickCallbacks: Array<(pos: Position) => void> = []
+  const transport = {
+    onTick: (cb: (pos: Position) => void) => { tickCallbacks.push(cb) },
+    onBeat: (_cb: (pos: Position) => void) => {},
+    onBar:  (_cb: (pos: Position) => void) => {},
+    play: () => {}, stop: () => {}, pause: () => {}, seek: () => {}, dispose: () => {},
+    get position() { return { bar: 0, beat: 0, tick: 0, time: 0 } },
+    get state() { return 'stopped' as const },
+    get bpm() { return bpm },
+    setBPM: () => {},
+  } as unknown as Transport
+  const fireTick = (pos: Position) => { tickCallbacks.forEach(cb => { cb(pos); }) }
+  return { transport, fireTick }
+}
 
 describe('createStepSequencer', () => {
   const makeTransport = () => createTransport(mockContext())
@@ -123,5 +143,110 @@ describe('createStepSequencer', () => {
       )
     }).not.toThrow()
     transport.dispose()
+  })
+})
+
+describe('createStepSequencer — degrade', () => {
+  it('degrade=0 fires all steps', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const steps: number[] = []
+    createStepSequencer(transport, { pattern: [1, 1, 1, 1], degrade: 0, seed: 42 },
+      (_val, step) => { steps.push(step) })
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 0.125 })
+    fireTick({ bar: 0, beat: 0, tick: 2, time: 0.25 })
+    fireTick({ bar: 0, beat: 0, tick: 3, time: 0.375 })
+    expect(steps).toEqual([0, 1, 2, 3])
+  })
+
+  it('degrade=1.0 skips all steps', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const steps: number[] = []
+    createStepSequencer(transport, { pattern: [1, 1, 1, 1], degrade: 1.0, seed: 42 },
+      (_val, step) => { steps.push(step) })
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 0.125 })
+    fireTick({ bar: 0, beat: 0, tick: 2, time: 0.25 })
+    fireTick({ bar: 0, beat: 0, tick: 3, time: 0.375 })
+    expect(steps).toEqual([])
+  })
+
+  it('degrade still advances currentStep when dropped', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const seq = createStepSequencer(transport, { pattern: [1, 1], degrade: 1.0, seed: 0 }, () => {})
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 0.125 })
+    expect(seq.currentStep).toBe(2)
+  })
+})
+
+describe('createStepSequencer — swing', () => {
+  it('swing=0 does not alter position.time', () => {
+    const { transport, fireTick } = makeMockTransport(120)
+    const times: number[] = []
+    createStepSequencer(transport, { pattern: [1, 1, 1, 1], swing: 0 },
+      (_val, _step, pos) => { times.push(pos.time) })
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 0.125 })
+    expect(times[0]).toBe(0)
+    expect(times[1]).toBe(0.125)
+  })
+
+  it('swing>0 delays odd steps and leaves even steps unchanged', () => {
+    const { transport, fireTick } = makeMockTransport(120)
+    const times: number[] = []
+    createStepSequencer(transport, { pattern: [1, 1, 1, 1], swing: 0.5, ticksPerBeat: 4 },
+      (_val, _step, pos) => { times.push(pos.time) })
+    // bpm=120, ticksPerBeat=4 → tickDur = 60/120/4 = 0.125s
+    // swing offset for odd steps = 0.5 * 0.125 * 0.5 = 0.03125s
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })      // step 0 (even)
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 0.125 })   // step 1 (odd)
+    fireTick({ bar: 0, beat: 0, tick: 2, time: 0.25 })    // step 2 (even)
+    fireTick({ bar: 0, beat: 0, tick: 3, time: 0.375 })   // step 3 (odd)
+    const expectedSwingOffset = 0.5 * (60 / 120 / 4) * 0.5
+    expect(times[0]).toBe(0)                                          // even — no offset
+    expect(times[1]).toBeCloseTo(0.125 + expectedSwingOffset)        // odd — delayed
+    expect(times[2]).toBe(0.25)                                       // even — no offset
+    expect(times[3]).toBeCloseTo(0.375 + expectedSwingOffset)        // odd — delayed
+  })
+})
+
+describe('createStepSequencer — humanize', () => {
+  it('humanize=0 preserves exact position.time', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const times: number[] = []
+    createStepSequencer(transport, { pattern: [1, 1], humanize: 0, seed: 99 },
+      (_val, _step, pos) => { times.push(pos.time) })
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0.5 })
+    fireTick({ bar: 0, beat: 0, tick: 1, time: 1.0 })
+    expect(times[0]).toBe(0.5)
+    expect(times[1]).toBe(1.0)
+  })
+
+  it('humanize>0 shifts position.time within ±humanize of base time', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const times: number[] = []
+    const amt = 0.01
+    createStepSequencer(transport, { pattern: [1, 1, 1, 1], humanize: amt, seed: 42 },
+      (_val, _step, pos) => { times.push(pos.time) })
+    const baseTimes = [0.5, 0.625, 0.75, 0.875]
+    for (const t of baseTimes) {
+      fireTick({ bar: 0, beat: 0, tick: 0, time: t })
+    }
+    for (let i = 0; i < times.length; i++) {
+      expect(times[i]).toBeGreaterThanOrEqual(0)
+      expect(times[i]).toBeGreaterThanOrEqual((baseTimes[i] ?? 0) - amt)
+      expect(times[i]).toBeLessThanOrEqual((baseTimes[i] ?? 0) + amt)
+    }
+  })
+
+  it('humanize clamps negative result to 0', () => {
+    const { transport, fireTick } = makeMockTransport()
+    const times: number[] = []
+    // Large humanize at time=0 — some steps might go negative, should clamp to 0
+    createStepSequencer(transport, { pattern: [1], humanize: 1.0, seed: 7 },
+      (_val, _step, pos) => { times.push(pos.time) })
+    fireTick({ bar: 0, beat: 0, tick: 0, time: 0 })
+    expect(times[0]).toBeGreaterThanOrEqual(0)
   })
 })


### PR DESCRIPTION
## Summary

- **`_degrade` missing from `partToInstrumentDescriptor`** — chain `.degrade()` writes `_degrade` on the part, but the engine never mapped it to `props.degrade`. Fixed.
- **`swing` / `humanize` mapped but never read** — both fields were added to `props` in `partToInstrumentDescriptor`, but `createStepSequencer` only accepted `{ pattern, steps?, seed? }` and ignored them. Fixed.
- **`seqExtras()` helper** — new engine-local helper that reads `swing`, `humanize`, `degrade` from `comp.props` and threads them into all 21 instrument `createStepSequencer` calls. Cursor sequencer is intentionally excluded.
- **Inline Mulberry32 PRNG** in `stepSequencer.ts` — same algo as `@score/pattern/transforms.ts`, kept inlined per coord guidance (no cross-dep to `@score/pattern`).

## Behaviour

- `degrade` — seeded per-step probability drop. Seed formula: `((step * 1237 + bar * 4567) ^ songSeed) >>> 0`. Step counter still advances on drops.
- `humanize` — seeded `±humanize` timing jitter added to `position.time`. Seed formula: `(((step * 7919 + bar * 3571) ^ (step << 4)) ^ songSeed) >>> 0`. Clamped to `≥ 0`.
- `swing` — odd steps delayed by `swing × (60 / bpm / ticksPerBeat) × 0.5` seconds. Even steps unchanged.

## Test plan

- [ ] `pnpm --filter='@score/sequencer' test` — 72 tests pass (9 new: degrade × 3, swing × 2, humanize × 3, mock transport)
- [ ] `pnpm --filter='@score/cli' test` — 103 tests pass (3 new: _degrade/_swing/_humanize mapping in partToInstrumentDescriptor)
- [ ] `pnpm turbo build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)