### PR TITLE
feat(gui): Strudl-style block highlight animation (t330)

### DIFF
--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -9,9 +9,9 @@ import { MasterLevel }                      from '../shared/MasterLevel.js'
 import { MixerStrip }                       from '../shared/MixerStrip.js'
 import { DraggablePanel }                   from '../shared/DraggablePanel.js'
 import { CodeWaveform }                     from '../shared/CodeWaveform.js'
-import { getActiveLines, getStepBadges }    from '../shared/CodeHighlight.js'
-import { CodeEditorPanel }                  from '../shared/CodeEditorPanel.js'
-import type { EditorDecoration, StepBadge } from '../shared/CodeEditorPanel.js'
+import { getActiveLines, getStepBadges, getBlockBounds, getTrackLines } from '../shared/CodeHighlight.js'
+import { CodeEditorPanel }                                              from '../shared/CodeEditorPanel.js'
+import type { EditorDecoration, StepBadge, BlockHighlight }            from '../shared/CodeEditorPanel.js'
 import { ReferencePanel }                   from '../shared/ReferencePanel.js'
 import { ConsoleLog }                       from '../shared/ConsoleLog.js'
 import type { LogEntry, LogLevel }          from '../shared/ConsoleLog.js'
@@ -207,6 +207,22 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
       ? getStepBadges(code, tracks, currentStep, currentStepCount)
       : []
   , [engineState.playing, code, tracks, currentStep, currentStepCount])
+
+  // t330 — block highlight flash: full instrument block for each track that hits this step
+  const blockHighlights = useMemo((): ReadonlyArray<BlockHighlight> => {
+    if (!engineState.playing) return []
+    return getTrackLines(code, tracks)
+      .flatMap(({ trackIndex }) => {
+        const track = tracks[trackIndex]
+        if (!track) return []
+        const len = track.pattern.length
+        if (len === 0) return []
+        const val = track.pattern[currentStep % len]
+        if (!val) return []
+        const bounds = getBlockBounds(code, trackIndex, tracks)
+        return bounds ? [bounds] : []
+      })
+  }, [engineState.playing, code, tracks, currentStep])
 
   const [panels, setPanels] = useState<PanelVisibility>({
     punchcard:  true,
@@ -677,6 +693,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
                 decorations={editorDecorations}
                 stepBadges={stepBadges}
                 importsVisible={importsVisible}
+                blockHighlights={blockHighlights}
               />
             </div>
           </div>

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -20,6 +20,17 @@ export type EditorDecoration = {
   readonly isWholeLine?: boolean
 }
 
+/**
+ * t330 — Line range for a Strudl-style block highlight.
+ * The full `const <name> = <Factory>(…)` block including chain continuations.
+ */
+export type BlockHighlight = {
+  /** 1-based start line (Monaco convention). */
+  readonly startLine: number
+  /** 1-based end line (Monaco convention), inclusive. */
+  readonly endLine:   number
+}
+
 /** One step badge to overlay on an instrument line in the editor. */
 export type StepBadge = {
   /** 1-based line number in the current code. */
@@ -49,6 +60,12 @@ type Props = {
    * Auto-inject of real imports on fold is deferred until the DSL chain API lands.
    */
   readonly importsVisible?: boolean
+  /**
+   * t330 — Strudl-style block highlights — full `const <name> = <Factory>` block
+   * ranges to flash on each engine step. Each highlight fades over ~200 ms via a
+   * CSS keyframe animation. The parent recomputes this array on every step tick.
+   */
+  readonly blockHighlights?: ReadonlyArray<BlockHighlight>
 }
 
 // ── Score DSL Token Provider ───────────────────────────────────────────────────
@@ -161,6 +178,18 @@ const injectDecorationCss = (): void => {
       background: rgba(74, 143, 255, 0.07) !important;
       border-left: 2px solid rgba(74, 143, 255, 0.4) !important;
     }
+    /* t330 — Block highlight fade animation (Strudl-style) */
+    @keyframes score-block-fade {
+      0%   { background: rgba(74, 143, 255, 0.12); border-left-color: rgba(74, 143, 255, 0.55); }
+      100% { background: transparent;              border-left-color: transparent; }
+    }
+    /* Two alternating classes so deltaDecorations triggers a DOM class-name change
+       on consecutive ticks, which restarts the CSS animation each step. */
+    .score-block-active-a,
+    .score-block-active-b {
+      animation: score-block-fade 200ms ease-out forwards;
+      border-left: 2px solid rgba(74, 143, 255, 0.55);
+    }
     /* Step badge — inline content widget gutter marker */
     .score-step-badge {
       display: inline-block;
@@ -205,11 +234,14 @@ const injectDecorationCss = (): void => {
  * />
  * ```
  */
-export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true }: Props) => {
-  const editorRef       = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
-  const decorationsRef  = useRef<string[]>([])
-  const stepBadgesRef   = useRef<string[]>([])
-  const monacoRef       = useRef<Monaco | null>(null)
+export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights }: Props) => {
+  const editorRef            = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
+  const decorationsRef       = useRef<string[]>([])
+  const stepBadgesRef        = useRef<string[]>([])
+  const blockHighlightsRef   = useRef<string[]>([])
+  // t330 — flip between -a and -b on every tick so the CSS animation restarts
+  const blockFlipRef         = useRef(false)
+  const monacoRef            = useRef<Monaco | null>(null)
 
   // Apply decorations whenever they change
   useEffect(() => {
@@ -255,6 +287,32 @@ export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadg
 
     stepBadgesRef.current = ed.deltaDecorations(stepBadgesRef.current, newBadges)
   }, [stepBadges])
+
+  // t330 — block highlight flash: full instrument block glows on each step tick
+  useEffect(() => {
+    const ed     = editorRef.current
+    const monaco = monacoRef.current
+    if (!ed || !monaco) return
+
+    const model = ed.getModel()
+    if (!model) return
+
+    // Alternate CSS class name each tick so the animation always restarts,
+    // even when the same block stays active across consecutive steps.
+    blockFlipRef.current = !blockFlipRef.current
+    const className = blockFlipRef.current ? 'score-block-active-a' : 'score-block-active-b'
+
+    const newBlocks = (blockHighlights ?? []).map(b => ({
+      range: new monaco.Range(b.startLine, 1, b.endLine, 1),
+      options: {
+        isWholeLine: true,
+        className,
+        stickiness:  monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+      },
+    }))
+
+    blockHighlightsRef.current = ed.deltaDecorations(blockHighlightsRef.current, newBlocks)
+  }, [blockHighlights])
 
   // t220 — fold / unfold the leading import block when importsVisible changes
   useEffect(() => {

--- a/packages/gui/src/renderer/components/shared/CodeHighlight.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeHighlight.tsx
@@ -131,6 +131,52 @@ export const getActiveLines = (
 }
 
 /**
+ * Returns the 1-based Monaco line range for the full instrument block at `trackIndex`.
+ *
+ * A block starts at the `const <name> = <Factory>(…)` declaration line and
+ * extends through any contiguous chain lines (`.method(…)` continuations).
+ * It ends just before the first blank line or the first line that starts a new
+ * top-level statement (`const`, `export`, `import`, `Song`).
+ *
+ * @param code       - The raw code string from the editor.
+ * @param trackIndex - Zero-based index into the tracks array.
+ * @param tracks     - Track descriptors from the last eval.
+ * @returns `{ startLine, endLine }` (both 1-based, Monaco convention), or
+ *          `null` if the track has no corresponding declaration line.
+ *
+ * @example
+ * ```ts
+ * getBlockBounds(code, 0, tracks) // → { startLine: 4, endLine: 7 }
+ * ```
+ */
+export const getBlockBounds = (
+  code:       string,
+  trackIndex: number,
+  tracks:     ReadonlyArray<TrackInfo>,
+): { readonly startLine: number; readonly endLine: number } | null => {
+  const trackLineList = getTrackLines(code, tracks)
+  const entry = trackLineList.find(t => t.trackIndex === trackIndex)
+  if (!entry) return null
+
+  const lines    = code.split('\n')
+  const startIdx = entry.lineIndex   // 0-based
+
+  // NEW_STATEMENT_RE — recognises the start of a top-level declaration that is
+  // not a chain continuation.  Blank lines also terminate the block.
+  const NEW_STATEMENT_RE = /^\s*(const|export|import|Song)\b/
+
+  let endIdx = startIdx
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === undefined || line.trim() === '') break       // blank line
+    if (NEW_STATEMENT_RE.test(line)) break                   // new statement
+    endIdx = i
+  }
+
+  return { startLine: startIdx + 1, endLine: endIdx + 1 }    // 1-based
+}
+
+/**
  * Returns step badge data for each instrument line — used to render `STEP/TOTAL`
  * pills in the Monaco editor via `after` inline decorations (t219).
  *

--- a/packages/gui/tests/CodeHighlight.test.tsx
+++ b/packages/gui/tests/CodeHighlight.test.tsx
@@ -5,6 +5,7 @@ import {
   getActiveLines,
   getTrackLines,
   getStepBadges,
+  getBlockBounds,
 } from '../src/renderer/components/shared/CodeHighlight.js'
 
 // ── getActiveLines — Track() style (legacy) ───────────────────────────────────
@@ -297,5 +298,89 @@ describe('getTrackLines — PR #74 melodic instruments', () => {
     expect(result).toHaveLength(2)
     expect(result[0]).toEqual({ lineIndex: 2, trackIndex: 0 })
     expect(result[1]).toEqual({ lineIndex: 3, trackIndex: 1 })
+  })
+})
+
+// ── getBlockBounds (t330) ──────────────────────────────────────────────────────
+
+// Single-line block: `const kick = Kick808(4)` — ends at a blank line
+const SINGLE_LINE_CODE = `import { Song, Kick808, Snare } from '@score/dsl'
+
+const kick  = Kick808(4).volume(0.8)
+const snare = Snare(2).volume(0.55)
+
+export default Song({ bpm: 128, tracks: [kick, snare] })`
+// kick  → line index 2 (0-based) → startLine 3 (1-based), endLine 3
+// snare → line index 3            → startLine 4 (1-based), endLine 4
+
+// Multi-line block: chain continues on next lines
+const MULTI_LINE_CODE = `import { Song, Bass303, Kick808 } from '@score/dsl'
+
+const bass = Bass303('A2')
+  .cutoff(600)
+  .resonance(0.4)
+  .volume(0.6)
+const kick = Kick808(4).volume(0.8)
+
+export default Song({ bpm: 128, tracks: [bass, kick] })`
+// bass → line index 2 (0-based) through line index 5 → startLine 3, endLine 6
+// kick → line index 6 (0-based) → startLine 7, endLine 7
+
+describe('getBlockBounds (t330)', () => {
+  it('returns null when tracks is empty', () => {
+    expect(getBlockBounds(SINGLE_LINE_CODE, 0, [])).toBeNull()
+  })
+
+  it('returns null when track index has no matching line', () => {
+    const tracks = [{ type: 'kick', pattern: [1, 0] }]
+    expect(getBlockBounds(SINGLE_LINE_CODE, 1, tracks)).toBeNull()
+  })
+
+  it('returns single-line bounds for a one-liner instrument block', () => {
+    const tracks = [
+      { type: 'kick',  pattern: [1, 0] },
+      { type: 'snare', pattern: [0, 1] },
+    ]
+    const result = getBlockBounds(SINGLE_LINE_CODE, 0, tracks)
+    expect(result).toEqual({ startLine: 3, endLine: 3 })
+  })
+
+  it('second single-line instrument is its own single-line block', () => {
+    const tracks = [
+      { type: 'kick',  pattern: [1, 0] },
+      { type: 'snare', pattern: [0, 1] },
+    ]
+    const result = getBlockBounds(SINGLE_LINE_CODE, 1, tracks)
+    expect(result).toEqual({ startLine: 4, endLine: 4 })
+  })
+
+  it('returns multi-line bounds for a chained block', () => {
+    const tracks = [
+      { type: 'bass303', pattern: ['A2', 0] },
+      { type: 'kick',    pattern: [1, 0] },
+    ]
+    const result = getBlockBounds(MULTI_LINE_CODE, 0, tracks)
+    // Bass block: const bass = Bass303('A2') through .volume(0.6)
+    expect(result).toEqual({ startLine: 3, endLine: 6 })
+  })
+
+  it('returns single-line bounds for a block following a multi-line block', () => {
+    const tracks = [
+      { type: 'bass303', pattern: ['A2', 0] },
+      { type: 'kick',    pattern: [1, 0] },
+    ]
+    const result = getBlockBounds(MULTI_LINE_CODE, 1, tracks)
+    expect(result).toEqual({ startLine: 7, endLine: 7 })
+  })
+
+  it('terminates block on new const statement (no blank line between)', () => {
+    // SINGLE_LINE_CODE has no blank between kick and snare
+    const tracks = [
+      { type: 'kick',  pattern: [1, 0] },
+      { type: 'snare', pattern: [0, 1] },
+    ]
+    const kickBounds = getBlockBounds(SINGLE_LINE_CODE, 0, tracks)
+    // kick is line 3 — must NOT extend to line 4 (snare's const line)
+    expect(kickBounds?.endLine).toBe(3)
   })
 })


### PR DESCRIPTION
## Summary

- **`CodeHighlight.tsx`** — `getBlockBounds(code, trackIndex, tracks)`: finds the full instrument block (declaration line + chain continuations) by scanning forward until a blank line or new `const`/`export`/`import` statement. Returns `{ startLine, endLine }` in 1-based Monaco coordinates.
- **`CodeEditorPanel.tsx`** — new `BlockHighlight` export type + `blockHighlights?` prop. `useEffect` applies `deltaDecorations` with alternating CSS class names (`score-block-active-a` / `score-block-active-b`) on each tick — the class flip restarts the `@keyframes score-block-fade` animation (blue glow → transparent, 200ms) even when the same block stays active across consecutive steps.
- **`LiveCode/index.tsx`** — `blockHighlights` useMemo: collects `getBlockBounds` results for all tracks that are hitting at `currentStep`. Wires result to `<CodeEditorPanel>`.

## Test plan

- [ ] 7 new `getBlockBounds` unit tests (single-line, multi-line, blank-line termination, new-statement termination, null cases)
- [ ] 352 total tests passing
- [ ] typecheck + lint clean
- [ ] Manually verify: start playback → active instrument blocks pulse with blue fade on each step

🤖 Generated with [Claude Code](https://claude.com/claude-code)