### PR TITLE
chore: accessibility standards in CLAUDE.md + ROADMAP.md (t355–t364)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,60 @@ export default Song({ bpm: 140, tracks: [kick, bass] })
 9. Audio scheduling always uses `audioContext.currentTime` — never `setTimeout` or `Date.now()`
 10. **All code is functional** — factory functions, `const`, arrow functions, zero classes
 11. **Every public export gets TSDoc** — `/** */` block with `@param`, `@returns`, `@example`, `@throws {ScoreError}`. Standard in `docs/spec/TSDOC_STANDARD.md`. No undocumented public exports.
+12. **Accessibility ships with the component** — every new GUI component must meet the checklist below before merging. Never backfilled. WCAG 2.1 AA is the target.
+
+## Accessibility — Required for Every New GUI Component
+
+Score Studio targets WCAG 2.1 AA. Accessibility is **non-negotiable** — it ships with the component, not as a follow-up.
+
+### Checklist (must pass before PR merges)
+
+**ARIA — every interactive element must have:**
+- `aria-label` or visible label associated via `aria-labelledby`
+- `role` attribute if the element is not a native HTML element (e.g. `<div role="button">`)
+- `aria-pressed` on toggle buttons (play/stop, mute, step cells)
+- `aria-live="polite"` on regions that update dynamically (console, status)
+- `aria-describedby` on complex widgets explaining their semantics
+
+**Keyboard — every interactive element must support:**
+- `Tab` / `Shift+Tab` to reach the element (do not suppress focus)
+- `Enter` or `Space` to activate buttons and toggles
+- `Escape` to close dialogs, panels, and pickers
+- `Arrow keys` on grids and sliders
+- Draggable panels: `Arrow keys` to move, `Shift+Arrow` to resize
+
+**Focus management — every modal/dialog must:**
+- Trap focus on open — Tab cycles only within the dialog
+- Set initial focus to the first interactive element or the dialog heading
+- Return focus to the trigger element on close
+
+**Tests — every new component test must include:**
+```ts
+import { axe } from '../setup.js'
+it('has no axe violations', async () => {
+  const { container } = render(<MyComponent />)
+  expect(await axe(container)).toHaveNoViolations()
+})
+```
+
+**Canvas elements must have:**
+- `role="img"` + `aria-label` describing what is shown
+- `aria-describedby` linking to a hidden element with full semantics
+
+### What "accessibility ships with the component" means in practice
+
+When writing a new component:
+1. Use `<button>` not `<div onClick>` — native elements give keyboard and ARIA for free
+2. If you must use a `<div>`, add `role`, `tabIndex={0}`, `onKeyDown` with Enter+Space handling
+3. Add `aria-label` to every button — never rely on icon-only labels
+4. Write the axe test before opening the PR
+
+### What is already covered
+
+`vitest-axe` is configured in `packages/gui/tests/setup.ts` — `axe` is exported and ready.
+All existing components have ARIA roles and labels. Gaps are tracked as t355–t364 in `docs/ROADMAP.md`.
+
+---
 
 ## Target Genres — Full EDM Library
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -199,6 +199,30 @@ These areas require a dedicated planning session before any window touches them:
 - t281 — Instrument panel UX + full channel strip (dockable, expandable, full ADR 014 chain method set — DAW-competitive GUI)
 - t282 — Per-instrument panel layouts (schedule with t281): Kick/Snare/HiHat/Bass303/FMSynth/SubSynth/Pad/Pluck/Rhodes each get purpose-built compact + expanded panel — progressive disclosure, instrument-aware controls
 
+### Accessibility — WCAG 2.1 AA (t355–t364)
+
+Score Studio is designed for accessibility from the ground up. All new GUI components must follow the rules in CLAUDE.md. Current tracked gaps:
+
+**Tier 1 — Critical (WCAG fail, pre-release blockers):**
+- t355 — Keyboard navigation on DraggablePanel (arrow keys move/resize, Escape closes) — WCAG 2.1.1
+- t356 — Focus trap on all modal dialogs (BugReportModal, InstrumentPicker) — WCAG 2.4.3
+- t357 — Escape key handler on all `role="dialog"` components — WCAG 2.1.1
+- t358 — Keyboard navigation on PunchcardGrid (arrow keys + Space to toggle steps) — WCAG 2.1.1
+
+**Tier 2 — Important (WCAG AA hardening):**
+- t359 — Color contrast audit of dark theme palette (target 4.5:1 text / 3:1 UI)
+- t360 — `aria-describedby` on complex widgets (PunchcardGrid loop semantics, DraggablePanel affordance)
+- t361 — `aria-keyshortcuts` on Transport buttons + keyboard help overlay (Ctrl+? or F1)
+- t362 — `axe-vitest` `toHaveNoViolations()` assertion in every component test
+- t363 — Visible focus indicators — verify `:focus` styles not hidden by inline styles
+- t364 — Canvas fallback content / `aria-describedby` on Scope, PunchcardGrid, SpectrumAnalyser
+
+**What's already good:** ARIA roles + labels throughout, `role="log"` + `aria-live` on console, `aria-pressed` on toggles, `role="toolbar"` on transport, `vitest-axe` configured in test setup.
+
+**Design rule:** Every new interactive component must ship with keyboard support and ARIA labels. See CLAUDE.md § Accessibility for the checklist.
+
+---
+
 ### Thesis Violations to Fix (tracked debt)
 - `@score/midi` — `let` violations (critical)
 - `@score/cli` play.ts — `let` violations (high)


### PR DESCRIPTION
## Summary

- **CLAUDE.md rule 12** — accessibility ships with the component (WCAG 2.1 AA). Never backfilled.
- **CLAUDE.md accessibility section** — four-part checklist every new GUI component must pass before PR merges: ARIA requirements, keyboard nav, focus management, required `axe` `toHaveNoViolations()` test pattern
- **`docs/ROADMAP.md`** — accessibility section added under Phase 13 pending work. t355–t358 Tier 1 critical (pre-release blockers). t359–t364 Tier 2 hardening.

## How this enforces standards going forward

The `axe` test requirement in CLAUDE.md means any component PR without it fails checklist review. CI catches ARIA regressions automatically. The keyboard checklist gives reviewers concrete pass/fail criteria — not vibes.

## What is already covered

`vitest-axe` is configured in `packages/gui/tests/setup.ts`. All existing components have ARIA roles and labels. Gaps tracked as t355–t364.

## Test plan

- [ ] Docs only — no code changes
- [ ] Typecheck + lint clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)