### PR TITLE
feat(gui): keyboard accessibility — DraggablePanel, BugReportModal, InstrumentPicker (t355-t357)

### DIFF
--- a/packages/gui/src/renderer/components/shared/BugReportModal.tsx
+++ b/packages/gui/src/renderer/components/shared/BugReportModal.tsx
@@ -10,7 +10,7 @@
 //
 // Design: zero technical jargon shown to user. "What's included" is collapsed.
 
-import { useState } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -63,6 +63,50 @@ export const BugReportModal = ({
   const [detailsOpen, setDetailsOpen] = useState(false)
   const [copied, setCopied]           = useState(false)
 
+  const cardRef     = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const handleClose = useCallback((): void => {
+    setDescription('')
+    setDetailsOpen(false)
+    setCopied(false)
+    onClose()
+  }, [onClose])
+
+  // Focus trap: keep Tab within modal; Escape dismisses; initial focus on textarea
+  useEffect(() => {
+    if (!isOpen) return
+
+    textareaRef.current?.focus()
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') { handleClose(); return }
+      if (e.key !== 'Tab') return
+
+      const card = cardRef.current
+      if (card === null) return
+
+      const focusable = Array.from(
+        card.querySelectorAll<HTMLElement>(
+          'button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      )
+      const first = focusable[0]
+      const last  = focusable[focusable.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last?.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => { document.removeEventListener('keydown', onKeyDown) }
+  }, [isOpen, handleClose])
+
   if (!isOpen) return null
 
   const buildReport = () => ({
@@ -85,19 +129,12 @@ export const BugReportModal = ({
     onClose()
   }
 
-  const handleClose = (): void => {
-    setDescription('')
-    setDetailsOpen(false)
-    setCopied(false)
-    onClose()
-  }
-
   const codePreview = getCurrentCode().split('\n').slice(0, 3).join('\n')
   const logCount    = getRecentLogs().length
 
   return (
     <div role="dialog" aria-modal="true" aria-label="Report an issue" style={styles.overlay}>
-      <div style={styles.card}>
+      <div ref={cardRef} style={styles.card}>
 
         {/* Header */}
         <div style={styles.header}>
@@ -116,6 +153,7 @@ export const BugReportModal = ({
           What happened?
         </label>
         <textarea
+          ref={textareaRef}
           id="bug-description"
           style={styles.textarea}
           rows={4}

--- a/packages/gui/src/renderer/components/shared/DraggablePanel.tsx
+++ b/packages/gui/src/renderer/components/shared/DraggablePanel.tsx
@@ -24,10 +24,11 @@ type Size = {
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
-const MIN_W = 120
-const MIN_H = 80
-const TITLE_H = 28
-const HANDLE_SIZE = 8
+const MIN_W         = 120
+const MIN_H         = 80
+const TITLE_H       = 28
+const HANDLE_SIZE   = 8
+const KEYBOARD_STEP = 10
 
 // ── Props ──────────────────────────────────────────────────────────────────────
 
@@ -153,6 +154,62 @@ export const DraggablePanel = (props: DraggablePanelProps) => {
     }
   }, [dragging, panelId, onMoved])
 
+  // ── Keyboard (title bar) — move with Arrow, resize with Shift+Arrow, close with Escape ──
+
+  const onTitleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Escape') {
+      if (onClose !== undefined) { onClose() }
+      return
+    }
+
+    if (e.shiftKey) {
+      // Shift+Arrow → resize
+      let newSize: Size | null = null
+      if (e.key === 'ArrowRight') { e.preventDefault(); newSize = { w: Math.max(MIN_W, size.w + KEYBOARD_STEP), h: size.h } }
+      if (e.key === 'ArrowLeft')  { e.preventDefault(); newSize = { w: Math.max(MIN_W, size.w - KEYBOARD_STEP), h: size.h } }
+      if (e.key === 'ArrowDown')  { e.preventDefault(); newSize = { w: size.w, h: Math.max(MIN_H, size.h + KEYBOARD_STEP) } }
+      if (e.key === 'ArrowUp')    { e.preventDefault(); newSize = { w: size.w, h: Math.max(MIN_H, size.h - KEYBOARD_STEP) } }
+      if (newSize !== null) {
+        sizeRef.current = newSize
+        setSize(newSize)
+        if (panelId !== undefined && onMoved !== undefined) {
+          onMoved(panelId, posRef.current.x, posRef.current.y, newSize.w, newSize.h)
+        }
+      }
+    } else {
+      // Arrow → move
+      let newPos: Position | null = null
+      if (e.key === 'ArrowRight') { e.preventDefault(); newPos = { x: pos.x + KEYBOARD_STEP, y: pos.y } }
+      if (e.key === 'ArrowLeft')  { e.preventDefault(); newPos = { x: pos.x - KEYBOARD_STEP, y: pos.y } }
+      if (e.key === 'ArrowDown')  { e.preventDefault(); newPos = { x: pos.x, y: pos.y + KEYBOARD_STEP } }
+      if (e.key === 'ArrowUp')    { e.preventDefault(); newPos = { x: pos.x, y: pos.y - KEYBOARD_STEP } }
+      if (newPos !== null) {
+        posRef.current = newPos
+        setPos(newPos)
+        if (panelId !== undefined && onMoved !== undefined) {
+          onMoved(panelId, newPos.x, newPos.y, sizeRef.current.w, sizeRef.current.h)
+        }
+      }
+    }
+  }
+
+  // ── Keyboard (resize handle) — Arrow keys resize ─────────────────────────────
+
+  const onResizeKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    let newSize: Size | null = null
+    if (e.key === 'ArrowRight') { e.preventDefault(); newSize = { w: Math.max(MIN_W, size.w + KEYBOARD_STEP), h: size.h } }
+    if (e.key === 'ArrowLeft')  { e.preventDefault(); newSize = { w: Math.max(MIN_W, size.w - KEYBOARD_STEP), h: size.h } }
+    if (e.key === 'ArrowDown')  { e.preventDefault(); newSize = { w: size.w, h: Math.max(MIN_H, size.h + KEYBOARD_STEP) } }
+    if (e.key === 'ArrowUp')    { e.preventDefault(); newSize = { w: size.w, h: Math.max(MIN_H, size.h - KEYBOARD_STEP) } }
+    if (newSize !== null) {
+      sizeRef.current = newSize
+      setSize(newSize)
+      if (panelId !== undefined && onMoved !== undefined) {
+        onMoved(panelId, posRef.current.x, posRef.current.y, newSize.w, newSize.h)
+      }
+    }
+  }
+
   // ── Resize (bottom-right handle) ────────────────────────────────────────────
 
   const onHandleMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
@@ -207,15 +264,17 @@ export const DraggablePanel = (props: DraggablePanelProps) => {
         height: size.h,
       }}
     >
-      {/* Title bar */}
+      {/* Title bar — Tab to focus, Arrow to move, Shift+Arrow to resize, Escape to close */}
       <div
         role="heading"
         aria-level={3}
+        tabIndex={0}
         style={{
           ...styles.titleBar,
           cursor: dragging ? 'grabbing' : 'grab',
         }}
         onMouseDown={onTitleMouseDown}
+        onKeyDown={onTitleKeyDown}
       >
         <span style={styles.titleText}>{title}</span>
 
@@ -236,12 +295,14 @@ export const DraggablePanel = (props: DraggablePanelProps) => {
         {children}
       </div>
 
-      {/* Resize handle */}
+      {/* Resize handle — Tab to focus, Arrow keys to resize */}
       <div
         aria-label="Resize panel"
         role="separator"
+        tabIndex={0}
         style={styles.resizeHandle}
         onMouseDown={onHandleMouseDown}
+        onKeyDown={onResizeKeyDown}
       />
     </div>
   )

--- a/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
+++ b/packages/gui/src/renderer/components/shared/InstrumentPicker.tsx
@@ -5,7 +5,7 @@
 //
 // No audio, no IPC — pure props in, callbacks out.
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -101,10 +101,36 @@ const styles = {
 export const InstrumentPicker = (props: InstrumentPickerProps): React.JSX.Element => {
   const { onPick, onClose } = props
 
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  // Initial focus, Escape dismiss, focus trap
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') { onClose() } }
-    window.addEventListener('keydown', handler)
-    return () => { window.removeEventListener('keydown', handler) }
+    const modal = modalRef.current
+    if (modal === null) return
+
+    modal.querySelector<HTMLButtonElement>('button')?.focus()
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') { onClose(); return }
+      if (e.key !== 'Tab') return
+
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>('button, [tabindex]:not([tabindex="-1"])')
+      )
+      const first = focusable[0]
+      const last  = focusable[focusable.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last?.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first?.focus()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => { window.removeEventListener('keydown', onKeyDown) }
   }, [onClose])
 
   const renderGroup = (entries: readonly InstrumentEntry[]) => (
@@ -124,7 +150,7 @@ export const InstrumentPicker = (props: InstrumentPickerProps): React.JSX.Elemen
 
   return (
     <div style={styles.overlay} data-testid="instrument-picker-overlay">
-      <div style={styles.modal} role="dialog" aria-label="Pick an instrument">
+      <div ref={modalRef} style={styles.modal} role="dialog" aria-modal="true" aria-label="Pick an instrument">
 
         <div style={styles.header}>
           <span style={styles.title}>Add Instrument</span>


### PR DESCRIPTION
## Summary

- **DraggablePanel** (t355): `tabIndex={0}` on title bar and resize handle. Arrow keys move panel ±10px; Shift+Arrow resizes ±10px; Escape calls `onClose`. Fires `onMoved` callback after keyboard changes.
- **BugReportModal** (t356): Focus trap (Tab cycles within card), Escape dismisses, initial focus set to textarea on open. `useCallback` on `handleClose` to keep effect deps stable.
- **InstrumentPicker** (t357): `aria-modal="true"` added, focus trap, initial focus on first instrument button. Existing Escape handler merged into single combined effect.

All 363 GUI tests passing. Typecheck clean.

## WCAG coverage

| Criterion | Before | After |
|---|---|---|
| 2.1.1 Keyboard | ✗ panels mouse-only | ✓ Arrow/Shift+Arrow/Escape |
| 2.4.3 Focus Order | ✗ no trap on modals | ✓ focus trap on BugReportModal + InstrumentPicker |
| 2.4.3 Focus Order | ✗ no initial focus | ✓ textarea / first button auto-focused on open |

## Test plan

- [ ] Tab to DraggablePanel title bar → Arrow keys move it → Shift+Arrow resizes → Escape closes
- [ ] Tab to resize handle → Arrow keys resize
- [ ] Open BugReportModal → focus lands on textarea → Tab cycles within modal → Shift+Tab wraps → Escape closes
- [ ] Open InstrumentPicker → focus lands on Kick button → Tab cycles → Escape closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)