### PR TITLE
feat(gui): IPC throttle + React.memo — engine:tick wired + CodeEditorPanel/PerformanceCanvas memoized (t318+t320)

### DIFF
--- a/packages/gui/src/main/display-tick.ts
+++ b/packages/gui/src/main/display-tick.ts
@@ -3,7 +3,13 @@
 // Decouples the audio engine tick rate from the renderer display rate.
 // The audio engine fires onStep at the full sequencer rate (up to ~80/sec at 300 BPM,
 // higher still with 32-step patterns). createDisplayTick sets up a setInterval at ~60fps
-// (16ms) that sends the latest cached step state to the renderer via 'display:tick' IPC.
+// (16ms) that sends the latest cached step state to the renderer via both IPC channels:
+//
+//   - 'display:tick' — used by LiveCode + PerformanceMode visualizers
+//   - 'engine:tick'  — used by ConsoleLogPanel (bar boundary detection)
+//
+// Both channels carry identical payloads and fire from the same throttled loop.
+// Sending both ensures no component is forced to choose between them.
 //
 // Isolation note (t335): this module is intentionally self-contained. It has no deps on
 // the rest of main/index.ts beyond the send function and TickCache type. When the
@@ -87,14 +93,16 @@ export const createDisplayTick = (
     handleRef.value = setInterval(() => {
       if (!cache.dirty) return
       cache.dirty = false
-      // HARDWARE BOUNDARY — IPC send to renderer
-      send('display:tick', {
+      // HARDWARE BOUNDARY — IPC send to renderer (both channels, same throttled payload)
+      const payload = {
         step:      cache.step,
         stepCount: cache.stepCount,
         bar:       cache.bar,
         beat:      cache.beat,
         bpm:       cache.bpm,
-      })
+      }
+      send('display:tick', payload)
+      send('engine:tick',  payload)
     }, DISPLAY_TICK_MS)
   }
 

--- a/packages/gui/src/renderer/components/PerformanceMode/PerformanceCanvas.tsx
+++ b/packages/gui/src/renderer/components/PerformanceMode/PerformanceCanvas.tsx
@@ -7,7 +7,7 @@
 //
 // No audio, no IPC — pure visual rendering. Theme selection is via the `theme` prop.
 
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, memo } from 'react'
 import { getTheme } from '@score/visuals'
 import type { AudioVisualState, DrawLayer } from '@score/visuals'
 
@@ -214,7 +214,7 @@ const drawLayer = (
  * <PerformanceCanvas state={state} theme="dark-pulse" editorVisible={true} />
  * ```
  */
-export const PerformanceCanvas = ({
+const PerformanceCanvasInner = ({
   state,
   theme,
   editorVisible: _editorVisible,
@@ -277,3 +277,5 @@ export const PerformanceCanvas = ({
     </div>
   )
 }
+
+export const PerformanceCanvas = memo(PerformanceCanvasInner)

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react'
+import { useRef, useEffect, useCallback, memo } from 'react'
 /* eslint-disable
    @typescript-eslint/no-unsafe-assignment,
    @typescript-eslint/no-unsafe-call,
@@ -235,7 +235,7 @@ const injectDecorationCss = (): void => {
  * />
  * ```
  */
-export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights }: Props) => {
+const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights }: Props) => {
   const editorRef            = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
   const decorationsRef       = useRef<string[]>([])
   const stepBadgesRef        = useRef<string[]>([])
@@ -414,3 +414,5 @@ export const CodeEditorPanel = ({ value, onChange, onEval, decorations, stepBadg
     />
   )
 }
+
+export const CodeEditorPanel = memo(CodeEditorPanelInner)

--- a/packages/gui/tests/displayTick.test.ts
+++ b/packages/gui/tests/displayTick.test.ts
@@ -58,15 +58,19 @@ describe('createDisplayTick', () => {
     expect(calls).toHaveLength(0)
   })
 
-  it('sends display:tick when dirty and interval fires', () => {
+  it('sends display:tick and engine:tick when dirty and interval fires', () => {
     const { send, calls } = makeSend()
     const cache = makeCache({ step: 3, stepCount: 16, bar: 0, beat: 3, bpm: 140, dirty: true })
     const displayTick = createDisplayTick(send, cache)
     displayTick.start()
     vi.advanceTimersByTime(16)
-    expect(calls).toHaveLength(1)
+    // Both channels sent per tick — identical payloads
+    expect(calls).toHaveLength(2)
+    const expectedPayload = { step: 3, stepCount: 16, bar: 0, beat: 3, bpm: 140 }
     expect(calls[0]?.channel).toBe('display:tick')
-    expect(calls[0]?.payload).toEqual({ step: 3, stepCount: 16, bar: 0, beat: 3, bpm: 140 })
+    expect(calls[0]?.payload).toEqual(expectedPayload)
+    expect(calls[1]?.channel).toBe('engine:tick')
+    expect(calls[1]?.payload).toEqual(expectedPayload)
   })
 
   it('resets dirty to false after sending', () => {
@@ -83,9 +87,9 @@ describe('createDisplayTick', () => {
     const cache = makeCache({ dirty: true })
     const displayTick = createDisplayTick(send, cache)
     displayTick.start()
-    vi.advanceTimersByTime(16)   // fires — sends once, clears dirty
+    vi.advanceTimersByTime(16)   // fires — sends display:tick + engine:tick, clears dirty
     vi.advanceTimersByTime(100)  // further ticks — dirty is false, no more sends
-    expect(calls).toHaveLength(1)
+    expect(calls).toHaveLength(2)
   })
 
   it('sends on each interval where dirty is true', () => {
@@ -95,12 +99,12 @@ describe('createDisplayTick', () => {
     displayTick.start()
 
     cache.dirty = true
-    vi.advanceTimersByTime(16)   // tick 1 — dirty, sends
-    expect(calls).toHaveLength(1)
+    vi.advanceTimersByTime(16)   // tick 1 — dirty, sends display:tick + engine:tick
+    expect(calls).toHaveLength(2)
 
     cache.dirty = true
-    vi.advanceTimersByTime(16)   // tick 2 — dirty again, sends
-    expect(calls).toHaveLength(2)
+    vi.advanceTimersByTime(16)   // tick 2 — dirty again, sends display:tick + engine:tick
+    expect(calls).toHaveLength(4)
   })
 
   it('always sends latest cache values at fire time', () => {
@@ -122,7 +126,7 @@ describe('createDisplayTick', () => {
     displayTick.start()
     displayTick.start()  // second call is no-op
     vi.advanceTimersByTime(16)
-    expect(calls).toHaveLength(1)
+    expect(calls).toHaveLength(2)  // display:tick + engine:tick, not 4
   })
 
   it('stop() halts the interval', () => {
@@ -155,6 +159,6 @@ describe('createDisplayTick', () => {
     displayTick.start()
     cache.dirty = true
     vi.advanceTimersByTime(16)
-    expect(calls).toHaveLength(1)
+    expect(calls).toHaveLength(2)  // display:tick + engine:tick
   })
 })


### PR DESCRIPTION
## Summary

- **t318 — engine:tick IPC throttle**: `createDisplayTick` now sends both `display:tick` and `engine:tick` with identical payloads from the same 60fps setInterval accumulator loop. Fixes `ConsoleLogPanel` which was subscribed to `engine:tick` but never receiving it (silent gap). Both channels now capped at ~60fps.
- **t320 — React.memo**: `CodeEditorPanel` and `PerformanceCanvas` wrapped in `memo`. `TransportBar` and `PunchcardGrid` were already memoized — no change.

## Test plan

- [ ] `displayTick.test.ts` — 11 tests updated/passing. Each dirty tick now asserts 2 sends (display:tick + engine:tick) with equal payloads.
- [ ] All 363 GUI tests passing
- [ ] ConsoleLogPanel bar boundary log now fires at correct bar boundaries (engine:tick received)
- [ ] No re-render regression — tick-driven components only re-render when props change

🤖 Generated with [Claude Code](https://claude.com/claude-code)