### PR TITLE
feat(gui): add waveform trace to CodeWaveform overlay (t156)

### DIFF
--- a/packages/gui/src/renderer/components/shared/CodeWaveform.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeWaveform.tsx
@@ -16,9 +16,10 @@ type Props = {
 /**
  * Draw beat-reactive glow and step scrub bar onto the canvas.
  *
- * Replaces the oscilloscope trace with two visual elements:
+ * Draws three layered visual elements:
  *  1. **Beat-reactive background glow** — RMS-derived radial gradient.
- *  2. **Step scrub bar** — 2px bar at the top sweeping left→right.
+ *  2. **Waveform trace** — semi-transparent oscilloscope line centered vertically.
+ *  3. **Step scrub bar** — 2px bar at the top sweeping left→right.
  */
 const drawBeatViz = (
   ctx:         CanvasRenderingContext2D,
@@ -49,6 +50,28 @@ const drawBeatViz = (
     ctx.fillRect(0, 0, width, height)
   }
 
+  // Waveform trace — oscilloscope-style time-domain signal centered vertically.
+  // Drawn very subtly so the code editor text remains fully legible.
+  if (waveform.length > 1) {
+    const centerY  = height / 2
+    const stepSize = width / waveform.length
+
+    ctx.beginPath()
+    ctx.strokeStyle = 'rgba(74, 143, 255, 0.12)'
+    ctx.lineWidth   = 1.5
+
+    for (let i = 0; i < waveform.length; i++) {
+      const x = i * stepSize
+      const y = centerY - (waveform[i] ?? 0) * (height * 0.4)
+      if (i === 0) {
+        ctx.moveTo(x, y)
+      } else {
+        ctx.lineTo(x, y)
+      }
+    }
+    ctx.stroke()
+  }
+
   // Step scrub bar — 2px at top, sweeps left→right over the current bar
   if (stepCount > 0) {
     const progress = currentStep / stepCount
@@ -62,9 +85,10 @@ const drawBeatViz = (
 /**
  * Beat-reactive waveform overlay drawn behind the code editor.
  *
- * Shows an RMS-derived radial glow that pulses with the audio energy and a
- * thin step scrub bar at the top that sweeps left→right through each bar —
- * the same aesthetic as Strudl and TidalCycles editors.
+ * Shows an RMS-derived radial glow, a semi-transparent oscilloscope waveform
+ * trace centred vertically behind the code, and a thin step scrub bar at the
+ * top that sweeps left→right through each bar — the same aesthetic as Strudl
+ * and TidalCycles editors.
  *
  * Position this absolutely behind the textarea using `position: relative` on
  * the editor pane container with this canvas positioned `absolute, inset: 0`.

--- a/packages/gui/tests/CodeWaveform.test.tsx
+++ b/packages/gui/tests/CodeWaveform.test.tsx
@@ -36,4 +36,30 @@ describe('CodeWaveform', () => {
       ),
     ).not.toThrow()
   })
+
+  it('accepts a single-sample waveform without crashing', () => {
+    expect(() =>
+      render(
+        <CodeWaveform waveform={[0.5]} playing={true} currentStep={0} stepCount={4} />,
+      ),
+    ).not.toThrow()
+  })
+
+  it('accepts a full 1024-sample waveform without crashing', () => {
+    const waveform = Array.from({ length: 1024 }, (_, i) => Math.sin(i / 32))
+    expect(() =>
+      render(
+        <CodeWaveform waveform={waveform} playing={true} currentStep={7} stepCount={16} />,
+      ),
+    ).not.toThrow()
+  })
+
+  it('accepts waveform with clipped values (±1) without crashing', () => {
+    const waveform = [1, -1, 1, -1, 0.5, -0.5]
+    expect(() =>
+      render(
+        <CodeWaveform waveform={waveform} playing={true} currentStep={0} stepCount={8} />,
+      ),
+    ).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Summary
- Add semi-transparent oscilloscope waveform trace to `CodeWaveform` canvas overlay
- Drawn behind the Monaco editor at `rgba(74,143,255,0.12)` — subtle enough to keep code legible
- Gives the Strudl/TidalCycles live-coding aesthetic: audio signal visible while you type

## Canvas draw order
1. Clear
2. RMS glow (existing — radial gradient, pulses with amplitude)
3. **Waveform trace** ← new: time-domain signal centred vertically, `1.5px` stroke
4. Step scrub bar (existing — 2px at top, sweeps left→right)

## No IPC changes
`engine:analysis` already delivers the float waveform array — no new channels needed.

## Test plan
- [ ] 366 GUI tests passing
- [ ] `CodeWaveform.test.tsx` — 7 tests (3 new smoke tests for trace edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)