### PR TITLE
feat(gui): 13v Monaco IDE IntelliSense — setDiagnosticsOptions + URI fix

### DIFF
--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -338,11 +338,12 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     monaco.editor.setTheme('score-dark')
 
     // ── @score/dsl type stub — loads Score DSL ambient declarations into the
-    // TypeScript language service so unknown symbols get red underlines.
-    // Full IntelliSense (autocomplete + hover docs) is Phase 13v.
+    // TypeScript language service for full IntelliSense: completions, hover
+    // docs, and error underlines on unknown Score symbols (Phase 13v).
+    // URI matches the module specifier so `import { X } from '@score/dsl'` resolves.
     monaco.languages.typescript.typescriptDefaults.addExtraLib(
       SCORE_DSL_TYPES,
-      'ts:@score/dsl/index.d.ts',
+      'file:///node_modules/@score/dsl/index.d.ts',
     )
 
     // Permissive TS config — score song files are plain ESM, not strict TS projects.
@@ -354,6 +355,16 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
       strict:                  false,
       noImplicitAny:           false,
       skipLibCheck:            true,
+    })
+
+    // Suppress lib-level diagnostics that are noise in the song sandbox:
+    //   2307 — Cannot find module '@score/dsl' (module not on TS path)
+    //   2580 — Cannot find name 'process' (Node.js global not in browser lib)
+    // Semantic + syntax validation remain enabled for real user-code errors.
+    monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+      noSemanticValidation: false,
+      noSyntaxValidation:   false,
+      diagnosticCodesToIgnore: [2307, 2580],
     })
 
     // Ctrl+Enter / Cmd+Enter → onEval

--- a/packages/gui/tests/CodeEditorPanel.test.tsx
+++ b/packages/gui/tests/CodeEditorPanel.test.tsx
@@ -1,17 +1,72 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen }           from '@testing-library/react'
-import { CodeEditorPanel }           from '../src/renderer/components/shared/CodeEditorPanel.js'
-import type { EditorDecoration }    from '../src/renderer/components/shared/CodeEditorPanel.js'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen }                        from '@testing-library/react'
+import { CodeEditorPanel }                       from '../src/renderer/components/shared/CodeEditorPanel.js'
+import type { EditorDecoration }                 from '../src/renderer/components/shared/CodeEditorPanel.js'
+
+// ── Monaco mock spies (hoisted so the vi.mock factory can reference them) ──────
+
+const { addExtraLibSpy, setCompilerOptsSpy, setDiagnosticsSpy } = vi.hoisted(() => ({
+  addExtraLibSpy:     vi.fn(),
+  setCompilerOptsSpy: vi.fn(),
+  setDiagnosticsSpy:  vi.fn(),
+}))
 
 // Monaco editor renders a loader in jsdom — stub it out.
 // The real Monaco bundle requires a DOM canvas and workers; in jsdom we verify
-// the wrapper renders, exports its types, and passes props without throwing.
+// the wrapper renders, exports its types, passes props, and calls the
+// TypeScript language service APIs (addExtraLib, setCompilerOptions,
+// setDiagnosticsOptions) on mount.
 vi.mock('@monaco-editor/react', () => ({
-  default: ({ value, 'aria-label': ariaLabel }: { value?: string; 'aria-label'?: string }) => (
-    <div data-testid="monaco-editor" aria-label={ariaLabel}>
-      {value}
-    </div>
-  ),
+  default: ({
+    value,
+    'aria-label': ariaLabel,
+    onMount,
+  }: {
+    value?:        string
+    'aria-label'?: string
+    onMount?:      (editor: unknown, monaco: unknown) => void
+  }) => {
+    if (typeof onMount === 'function') {
+      const editorStub = {
+        addCommand:       () => {},
+        focus:            () => {},
+        trigger:          () => {},
+        deltaDecorations: () => [],
+        getModel:         () => ({}),
+      }
+      const monacoStub = {
+        languages: {
+          getLanguages:             () => [],
+          register:                 () => {},
+          setMonarchTokensProvider: () => {},
+          typescript: {
+            typescriptDefaults: {
+              addExtraLib:           addExtraLibSpy,
+              setCompilerOptions:    setCompilerOptsSpy,
+              setDiagnosticsOptions: setDiagnosticsSpy,
+            },
+            ScriptTarget: { ESNext: 99 },
+            ModuleKind:   { ESNext: 99 },
+          },
+        },
+        editor: {
+          defineTheme:            () => {},
+          setTheme:               () => {},
+          OverviewRulerLane:      { Left: 1 },
+          TrackedRangeStickiness: { NeverGrowsWhenTypingAtEdges: 1 },
+        },
+        Range:   class { constructor(..._args: unknown[]) {} },
+        KeyMod:  { CtrlCmd: 2048 },
+        KeyCode: { Enter: 3 },
+      }
+      onMount(editorStub, monacoStub)
+    }
+    return (
+      <div data-testid="monaco-editor" aria-label={ariaLabel}>
+        {value}
+      </div>
+    )
+  },
 }))
 
 // ── Rendering ─────────────────────────────────────────────────────────────────
@@ -136,5 +191,55 @@ describe('CodeEditorPanel — importsVisible (t220)', () => {
     expect(() => render(
       <CodeEditorPanel value="import { Song } from '@score/dsl'\nexport default Song({ bpm: 128, tracks: [] })" onChange={vi.fn()} onEval={vi.fn()} />,
     )).not.toThrow()
+  })
+})
+
+// ── 13v Monaco IntelliSense setup ─────────────────────────────────────────────
+// Verifies that the TypeScript language service is fully configured on editor
+// mount: addExtraLib (Score DSL types), setCompilerOptions (permissive),
+// setDiagnosticsOptions (suppress lib noise). Relies on the onMount-calling
+// Monaco stub above.
+
+describe('CodeEditorPanel — Monaco IntelliSense setup (13v)', () => {
+  beforeEach(() => {
+    addExtraLibSpy.mockClear()
+    setCompilerOptsSpy.mockClear()
+    setDiagnosticsSpy.mockClear()
+  })
+
+  it('addExtraLib called on mount with Score DSL type declarations', () => {
+    render(<CodeEditorPanel value="" onChange={vi.fn()} onEval={vi.fn()} />)
+    expect(addExtraLibSpy).toHaveBeenCalledWith(
+      expect.stringContaining('declare function Kick'),
+      'file:///node_modules/@score/dsl/index.d.ts',
+    )
+  })
+
+  it('setCompilerOptions called on mount with permissive TS settings', () => {
+    render(<CodeEditorPanel value="" onChange={vi.fn()} onEval={vi.fn()} />)
+    expect(setCompilerOptsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strict:        false,
+        noImplicitAny: false,
+        skipLibCheck:  true,
+      }),
+    )
+  })
+
+  it('setDiagnosticsOptions called on mount suppressing lib errors', () => {
+    render(<CodeEditorPanel value="" onChange={vi.fn()} onEval={vi.fn()} />)
+    expect(setDiagnosticsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noSemanticValidation:    false,
+        noSyntaxValidation:      false,
+        diagnosticCodesToIgnore: expect.arrayContaining([2307, 2580]),
+      }),
+    )
+  })
+
+  it('addExtraLib URI uses node_modules path for @score/dsl module resolution', () => {
+    render(<CodeEditorPanel value="" onChange={vi.fn()} onEval={vi.fn()} />)
+    const [, uri] = addExtraLibSpy.mock.calls[0] as [string, string]
+    expect(uri).toBe('file:///node_modules/@score/dsl/index.d.ts')
   })
 })

--- a/packages/gui/tests/LiveCode.integration.test.tsx
+++ b/packages/gui/tests/LiveCode.integration.test.tsx
@@ -51,8 +51,9 @@ vi.mock('@monaco-editor/react', () => ({
           ScriptTarget:       { ESNext: 99 },
           ModuleKind:         { ESNext: 99 },
           typescriptDefaults: {
-            addExtraLib:        vi.fn(),
-            setCompilerOptions: vi.fn(),
+            addExtraLib:           vi.fn(),
+            setCompilerOptions:    vi.fn(),
+            setDiagnosticsOptions: vi.fn(),
           },
         },
       },


### PR DESCRIPTION
## Summary

- Fixes `addExtraLib` URI from `'ts:@score/dsl/index.d.ts'` → `'file:///node_modules/@score/dsl/index.d.ts'` so `import { X } from '@score/dsl'` resolves correctly in the Monaco TypeScript language service
- Adds `setDiagnosticsOptions` suppressing error codes `2307` (Cannot find module) and `2580` (Cannot find name 'process') — lib noise that would appear in every Score song file
- Semantic + syntax validation remain enabled for real user-code errors
- Fixes `LiveCode.integration` monacoStub to include `setDiagnosticsOptions`

## Test plan

- Extended Monaco mock in `CodeEditorPanel.test.tsx` to call `onMount` synchronously via `vi.hoisted` spies
- 4 new tests: `addExtraLib` content/URI, `setCompilerOptions` permissive settings, `setDiagnosticsOptions` suppressing 2307+2580, URI exact match
- 417/417 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)