### PR TITLE
feat(gui): 11b live coding visualization — beat-flash + ReferencePanel beat dot

### DIFF
--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -879,7 +879,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
               panelId="reference"
               onMoved={onPanelMoved}
             >
-              <ReferencePanel onInsert={onInsert} />
+              <ReferencePanel onInsert={onInsert} beatPulse={currentStep === 0} />
             </DraggablePanel>
           )}
         </div>

--- a/packages/gui/src/renderer/components/shared/CodeWaveform.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeWaveform.tsx
@@ -33,6 +33,12 @@ const drawBeatViz = (
   ctx.clearRect(0, 0, width, height)
   if (!playing) return
 
+  // Beat-flash: single-frame fill on bar boundary (currentStep === 0)
+  if (currentStep === 0) {
+    ctx.fillStyle = 'rgba(74, 143, 255, 0.15)'
+    ctx.fillRect(0, 0, width, height)
+  }
+
   // RMS-derived glow
   const rms = Math.sqrt(
     waveform.reduce((s, v) => s + v * v, 0) / Math.max(waveform.length, 1)

--- a/packages/gui/src/renderer/components/shared/ReferencePanel.tsx
+++ b/packages/gui/src/renderer/components/shared/ReferencePanel.tsx
@@ -6,7 +6,9 @@ type Section = {
 }
 
 type Props = {
-  readonly onInsert?: (snippet: string) => void
+  readonly onInsert?:  (snippet: string) => void
+  /** When true, the beat indicator dot pulses bright — driven by currentStep === 0. */
+  readonly beatPulse?: boolean
 }
 
 // ── Data ───────────────────────────────────────────────────────────────────────
@@ -133,10 +135,18 @@ const RefSection = ({ section, onInsert }: SectionProps) => (
  * </DraggablePanel>
  * ```
  */
-export const ReferencePanel = ({ onInsert }: Props) => (
+export const ReferencePanel = ({ onInsert, beatPulse = false }: Props) => (
   <div style={styles.root} aria-label="DSL reference panel">
     <div style={styles.header}>
       <span style={styles.headerLabel}>Score DSL</span>
+      <span
+        aria-hidden="true"
+        style={{
+          ...styles.beatDot,
+          opacity:    beatPulse ? 1 : 0.15,
+          transition: 'opacity 150ms ease-out',
+        }}
+      />
       <span style={styles.headerImport}>
         import {'{'} Song, Track, Kick, … {'}'} from '@score/dsl'
       </span>
@@ -232,5 +242,14 @@ const styles = {
     overflow:   'hidden' as const,
     whiteSpace: 'nowrap' as const,
     textOverflow: 'ellipsis' as const,
+  },
+  beatDot: {
+    display:      'inline-block' as const,
+    width:        6,
+    height:       6,
+    borderRadius: '50%',
+    background:   'rgba(74, 143, 255, 0.8)',
+    flexShrink:   0,
+    alignSelf:    'center' as const,
   },
 } as const

--- a/packages/gui/tests/CodeWaveform.test.tsx
+++ b/packages/gui/tests/CodeWaveform.test.tsx
@@ -62,4 +62,13 @@ describe('CodeWaveform', () => {
       ),
     ).not.toThrow()
   })
+
+  it('renders without crashing on beat boundary (currentStep === 0, playing)', () => {
+    const waveform = Array.from({ length: 256 }, (_, i) => Math.sin(i / 8))
+    expect(() =>
+      render(
+        <CodeWaveform waveform={waveform} playing={true} currentStep={0} stepCount={16} />,
+      ),
+    ).not.toThrow()
+  })
 })

--- a/packages/gui/tests/ReferencePanel.test.tsx
+++ b/packages/gui/tests/ReferencePanel.test.tsx
@@ -91,3 +91,15 @@ describe('ReferencePanel — shortcuts', () => {
     expect(screen.getByText('Ctrl+Enter')).toBeInTheDocument()
   })
 })
+
+describe('ReferencePanel — beat indicator', () => {
+  it('renders beat dot element', () => {
+    const { container } = render(<ReferencePanel beatPulse={true} />)
+    // aria-hidden dot is in the DOM — verify the panel still renders cleanly
+    expect(container.querySelector('[aria-label="DSL reference panel"]')).not.toBeNull()
+  })
+
+  it('renders without beatPulse prop (defaults to false)', () => {
+    expect(() => render(<ReferencePanel />)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- Beat-flash fill (`rgba(74,143,255,0.15)`) added to `CodeWaveform` canvas on `currentStep === 0` (bar boundary)
- `ReferencePanel` gains `beatPulse?: boolean` prop — 6px dot in header pulses to full opacity on bar boundary, fades via 150ms transition
- `LiveCode/index.tsx` wires `beatPulse={currentStep === 0}` from `display:tick` step

## Tests
- `CodeWaveform.test.tsx`: smoke test for beat-boundary render (currentStep===0, playing)
- `ReferencePanel.test.tsx`: beatPulse=true renders panel cleanly; no-prop renders without throw
- 416 tests passing

## Test plan
- [ ] Play a song in Live Code mode — verify blue flash on canvas each bar boundary
- [ ] Verify ReferencePanel header dot pulses bright on bar 1, fades otherwise
- [ ] Verify no regressions on existing CodeWaveform and ReferencePanel tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)