### PR TITLE
chore: add CODE_OF_CONDUCT and SECURITY policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Code of Conduct
+
+Score is an open-source EDM audio framework and a living proof-of-concept for a formal thesis on temporal architecture. This community is built around craft, rigor, and respect.
+
+---
+
+## Our Standards
+
+We expect everyone participating in this project to:
+
+- Be direct and honest — say what you mean, mean what you say
+- Respect that Score has a specific design philosophy; contributions that conflict with it will be declined without being a personal rejection
+- Give and receive constructive feedback without taking it personally
+- Credit others' ideas and work explicitly
+- Keep discussions focused on the work
+
+We do not tolerate:
+
+- Harassment, discrimination, or personal attacks of any kind
+- Dismissing contributions without explanation
+- Claiming credit for others' work
+- Publishing others' private information
+
+---
+
+## Scope
+
+This applies in all project spaces: GitHub issues, pull requests, discussions, and any communication about this project.
+
+---
+
+## Thesis Contribution and Authorship
+
+Score is part of a formal academic thesis on temporal architecture authored by **Bree Yard**. The core claims, primitives (Time, Causality, Information, Context), and theoretical framework are original to Bree Yard and are not subject to co-authorship through code contribution alone.
+
+Contribution recognition works as follows:
+
+**Acknowledgment** — All accepted contributions are acknowledged in `CONTRIBUTORS.md` and the relevant release notes. This covers: bug fixes, DSL additions, instrument implementations, effects, documentation, and tooling.
+
+**Co-authorship consideration** — Sustained, original contributions that directly advance the thesis proof — new synthesis primitives that demonstrate the four-primitive model, formal proofs of thesis claims through implementation, or significant original theoretical extensions to the codebase architecture — may be considered for co-authorship in the academic work. This is at Bree Yard's sole discretion and requires explicit written agreement. GUI contributions and general engineering work do not qualify.
+
+If you believe your contribution warrants co-authorship consideration, reach out directly at byard29@gmail.com before opening a PR.
+
+---
+
+## Enforcement
+
+Violations can be reported to **byard29@gmail.com**. Reports will be reviewed and responded to within 7 days. Maintainers reserve the right to remove comments, close issues, or ban contributors who violate these standards.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Score is pre-release software. Security fixes are applied to the `main` branch only.
+
+| Version | Supported |
+|---------|-----------|
+| `main` | ✅ |
+| older branches | ❌ |
+
+---
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Email **byard29@gmail.com** with:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- The version or commit hash where the issue exists
+- Any suggested mitigations if you have them
+
+You will receive a response within 7 days. If the vulnerability is confirmed, a fix will be prioritised and you will be credited in the release notes unless you prefer otherwise.
+
+---
+
+## Scope
+
+Areas of particular concern for Score:
+
+- **Song file evaluation** — Score evaluates user-authored `.ts` song files at runtime. Sandbox escapes, import of dangerous modules (`fs`, `child_process`, `net`), or code execution outside the intended scope are high-severity issues.
+- **Electron main process** — IPC handlers that allow renderer-to-main privilege escalation.
+- **Dependency vulnerabilities** — Known CVEs in Score's published npm packages.
+
+Out of scope: issues in development tooling only (Vitest, ESLint, TypeScript compiler errors, etc.) that do not affect the shipped application.
+
+---
+
+## Disclosure Policy
+
+Once a fix is released, vulnerabilities will be disclosed publicly in the GitHub security advisories with full credit to the reporter.


### PR DESCRIPTION
## Summary

- Adds `CODE_OF_CONDUCT.md` — contribution standards, thesis co-authorship tiers (acknowledgment for general contributions, co-authorship consideration for original thesis-advancing work), and enforcement contact
- Adds `SECURITY.md` — responsible disclosure policy, scope (song eval sandbox, Electron IPC, dep CVEs), supported versions

Fills the last two gaps on the GitHub community health checklist. All other files (LICENSE, CONTRIBUTING, issue templates, PR template, CODEOWNERS) were already in place.

## Thesis contribution tiers

The CoC explicitly distinguishes two levels:
- **Acknowledgment** — all accepted contributions (instruments, fixes, docs, tooling)
- **Co-authorship consideration** — sustained original work that directly advances the thesis proof (new synthesis primitives demonstrating the four-primitive model, formal proofs through implementation). GUI work does not qualify. Requires explicit written agreement.

## Test plan

- [ ] Visit https://github.com/bwyard/score/community — confirm all items green
- [ ] Review CoC language, especially co-authorship section
- [ ] Review SECURITY scope section (song eval sandbox + Electron IPC are the critical paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)