### PR TITLE
feat(@score/dsl): t301 — chain method input validators

### DIFF
--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -19,10 +19,11 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@score/core": "workspace:*",
+    "@score/core":        "workspace:*",
     "@score/instruments": "workspace:*",
-    "@score/math": "workspace:*",
-    "@score/pattern": "workspace:*"
+    "@score/math":        "workspace:*",
+    "@score/pattern":     "workspace:*",
+    "zod":               "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/dsl/src/chain.ts
+++ b/packages/dsl/src/chain.ts
@@ -1,366 +1,54 @@
-// chain.ts — ChainablePart type + createPart() factory
+// =============================================================================
+// @score/dsl — createPart() factory + instrument helpers
 //
 // ChainablePart is a plain immutable object (zero classes, const + arrow functions only).
 // Every method returns a NEW ChainablePart via object spread — never mutation.
-// This is the authoring layer of Score's two-layer architecture.
 //
 // Layer 1 (this file): chain/builder — reads as music
 // Layer 2 (engine):    pure data descriptors — read at play time
 //
 // The _ prefix on descriptor fields signals "data field, not chain method" — NOT private.
 // All fields are public and accessible directly by song authors.
+//
+// Types live in chain.types.ts. Validators live in validators.ts.
+// =============================================================================
 
-import type { AudioComponent, EffectDescriptor } from '@score/core'
-import type { BackendNode } from '@score/core'
-import { uid, ScoreError } from '@score/core'
-import { euclidean, fast, slow, rev, shift } from '@score/pattern'
-import type { PatternInput } from '@score/pattern'
-import { lfo, sine, ou, ramp } from './modulation.js'
-import type { ModulationDescriptor } from './modulation.js'
+import type { EffectDescriptor }                  from '@score/core'
+import type { BackendNode }                       from '@score/core'
+import { uid }                                    from '@score/core'
+import { euclidean, fast, slow, rev, shift }      from '@score/pattern'
+import type { PatternInput }                       from '@score/pattern'
+import { lfo, sine, ou, ramp }                    from './modulation.js'
+import type { ModulationDescriptor }               from './modulation.js'
+import {
+  validateSpeed,        validateSlow,         validateFast,
+  validateEuclidean,    validateShift,        validateStutter,
+  validateDegrade,      validateHumanize,     validateSwing,
+  validateEvery,        validateRepeat,       validatePattern,
+  validateStepProb,     validateStretch,      validatePhase,
+  validateBarNumber,    validateFadeBars,
+  validateNote,         validateNotes,        validateScale,
+  validatePitch,        validateOctave,       validateGlide,
+  validateDur,          validateVolume,       validateAdsrTime,
+  validateSustain,      validatePan,          validateWiden,
+  validateFilter,       validateEq,           validateBit,
+  validateSaturate,     validateReverbWet,    validateDelay,
+  validateModDepth,     validateLfoRate,      validateSwell,
+  validateSend,         validateChokeGroup,   validateModulateParam,
+  validateColor,        validateGlyph,        validateLabel,
+  validateSeed,         validateModel,
+} from './validators.js'
 
-// ── Supporting types ──────────────────────────────────────────────────────────
+export type {
+  PatternCtx,
+  SendDescriptor,
+  SidechainDescriptor,
+  PartDescriptor,
+  ChainMethods,
+  ChainablePart,
+} from './chain.types.js'
 
-/** Context passed to `.apply()` and `.mapNotes()` callbacks. Same inputs → same output. */
-export type PatternCtx = {
-  readonly bar: number
-  readonly bpm: number
-  readonly steps: number
-  readonly seed: number
-}
-
-/** A send routing entry — route to a named effect bus at a given amount. */
-export type SendDescriptor = {
-  readonly bus: string
-  readonly amount: number
-}
-
-/** Sidechain / ducking configuration. */
-export type SidechainDescriptor = {
-  readonly source: string | ChainablePart
-  readonly amount: number
-  readonly attack: number
-  readonly release: number
-  readonly mode: 'duck' | 'reverse'
-}
-
-// ── PartDescriptor — pure data shape carrying all chain state ─────────────────
-
-/**
- * Pure data record carrying all chain method state for a single instrument part.
- *
- * The engine reads these `_`-prefixed fields at play time and hydrates them into live audio.
- * Every field is optional except `_type`, `_version`, `instrumentType`, `type`, and `id`.
- *
- * Song authors never construct this directly — use the instrument factories
- * (`Kick`, `Synth`, `Arp`, etc.) which return a {@link ChainablePart} with all methods attached.
- *
- * @see {@link ChainablePart} — adds fluent chain methods on top of this descriptor
- * @see {@link createPart} — factory that produces a `ChainablePart` from a partial descriptor
- */
-export type PartDescriptor = {
-  readonly _type: 'ChainablePart'
-  readonly _version: 1
-  readonly instrumentType: string
-  /** Alias for instrumentType — satisfies AudioComponent.type contract. */
-  readonly type: string
-  readonly id: string
-  /** Human-readable label — GUI mixer name, codePatcher correlation. */
-  readonly _name?: string
-  /** Per-part stochastic seed. Overrides song-level seed for this part only. */
-  readonly _seed?: number
-  /** Model variant — percussion only: '808' | '909' | 'hard' | 'generic' etc. */
-  readonly _model?: string
-  // ── Pattern ──────────────────────────────────────────────────────────────
-  readonly _pattern?: PatternInput
-  readonly _speed?: number
-  readonly _degrade?: number
-  readonly _humanize?: number
-  readonly _swing?: number
-  readonly _stutter?: number
-  readonly _palindrome?: boolean
-  readonly _mask?: PatternInput
-  readonly _repeat?: number
-  readonly _stepProb?: ReadonlyArray<number>
-  readonly _applyFn?: (p: number[], ctx: PatternCtx) => number[]
-  readonly _mapNotesFn?: (notes: (string | number)[], ctx: PatternCtx) => (string | number)[]
-  readonly _every?: { readonly n: number; readonly fn: (p: number[]) => number[] }
-  readonly _stretch?: number
-  readonly _phase?: number
-  readonly _fromBar?: number
-  readonly _untilBar?: number
-  readonly _fadeInBars?: number
-  readonly _fadeOutBars?: number
-  // ── Pitch / notes ────────────────────────────────────────────────────────
-  readonly _notes?: ReadonlyArray<string | number>
-  readonly _scale?: { readonly name: string; readonly root: string }
-  readonly _pitchOffset?: number
-  readonly _octave?: number
-  readonly _glide?: number
-  readonly _dur?: number
-  // ── Amplitude ────────────────────────────────────────────────────────────
-  readonly _volume?: number
-  readonly _pan?: number
-  readonly _adsr?: {
-    readonly attack?: number
-    readonly decay?: number
-    readonly sustain?: number
-    readonly release?: number
-  }
-  readonly _sidechain?: SidechainDescriptor
-  // ── Tone ─────────────────────────────────────────────────────────────────
-  readonly _filter?: { readonly frequency: number; readonly Q?: number }
-  readonly _eq?: { readonly lo: number; readonly mid: number; readonly hi: number }
-  // ── Effects chain ────────────────────────────────────────────────────────
-  readonly _effects?: ReadonlyArray<EffectDescriptor>
-  // ── Routing ──────────────────────────────────────────────────────────────
-  readonly _sends?: ReadonlyArray<SendDescriptor>
-  readonly _mute?: boolean
-  readonly _solo?: boolean
-  readonly _chokeGroup?: string
-  readonly _layers?: ReadonlyArray<PartDescriptor>
-  // ── Modulations ──────────────────────────────────────────────────────────
-  readonly _modulations?: ReadonlyArray<{
-    readonly param: string
-    readonly source: ModulationDescriptor
-  }>
-  // ── Visual — per-track visual override (no @score/visuals dep — plain object) ──
-  // @score/visuals reads this from TrackVisualState and merges over InstrumentVisualMap defaults.
-  readonly _visual?: {
-    /** CSS hex color override for Monaco arcs, PunchcardGrid, and PerformanceCanvas. */
-    readonly color?:   string
-    /** Inline glyph kind for the Monaco editor. */
-    readonly glyph?:   string
-    /** Human-readable label override (defaults to track variable name). */
-    readonly label?:   string
-    /** Opacity override 0–1. */
-    readonly opacity?: number
-  }
-  // ── Props — for engine backwards compat during transition ────────────────
-  readonly props: Record<string, unknown>
-  // ── AudioComponent stubs — satisfied by createPart(), replaced by engine ─
-  readonly connect: (destination: BackendNode) => AudioComponent
-  readonly disconnect: () => AudioComponent
-  readonly dispose: () => void
-}
-
-// ── ChainMethods<T> — all fluent chain methods, generic over return type ──────
-
-/**
- * All fluent chain methods for a part — generic over `T`, the return type of every method.
- *
- * `ChainablePart` uses `ChainMethods<ChainablePart>`.
- * Sub-types declare `PartDescriptor & ChainMethods<Self> & Extras`
- * so every chain method preserves the sub-type through composition.
- *
- * Thesis: functional composition preserves identity.
- * A `Bass303Part` through `.volume()` is still a `Bass303Part`.
- */
-export type ChainMethods<T> = {
-  // ── Pattern ──────────────────────────────────────────────────────────────
-  /** Speed multiplier. `n > 1` = fast, `n < 1` = slow, `n < 0` = reverse. */
-  readonly speed: (n: number) => T
-  /** Sugar: `speed(1/n)` — play n times slower. */
-  readonly slow: (n: number) => T
-  /** Sugar: `speed(n)` — play n times faster. */
-  readonly fast: (n: number) => T
-  /** Sugar: reverse the pattern. */
-  readonly rev: () => T
-  /** Sugar: half-time feel. */
-  readonly halfTime: () => T
-  /** Sugar: double-time feel. */
-  readonly doubleTime: () => T
-  /** Sugar: triplet feel (3 against 2). */
-  readonly tripletTime: () => T
-  /** Classical term: reverse. Alias for `.rev()`. */
-  readonly retrograde: () => T
-  /** Classical: lengthen by factor n. Sugar for `slow(n)`. */
-  readonly augment: (n?: number) => T
-  /** Classical: shorten by factor n. Sugar for `fast(n)`. */
-  readonly diminish: (n?: number) => T
-  /** Replace pattern with euclidean(hits, steps). Default steps = 16. */
-  readonly euclidean: (hits: number, steps?: number) => T
-  /** Rotate pattern n steps. Negative = shift left. */
-  readonly shift: (n: number) => T
-  /** Flip 1s and 0s. */
-  readonly invert: () => T
-  /** Mute steps where mask = 0. */
-  readonly mask: (pattern: PatternInput) => T
-  /** Stutter — repeat last hit n times. n = 0 is a no-op. */
-  readonly stutter: (n: number) => T
-  /** Palindrome — pattern + reversed pattern (exclusive center). */
-  readonly palindrome: () => T
-  /** Drop hits at probability p (0 = never, 1 = always silence). */
-  readonly degrade: (p: number) => T
-  /** Timing jitter in seconds. */
-  readonly humanize: (amt: number) => T
-  /** Swing offset on off-beats (0–1). */
-  readonly swing: (amount: number) => T
-  /** Apply fn every n cycles. fn receives current pattern. */
-  readonly every: (n: number, fn: (p: number[]) => number[]) => T
-  /** Custom pattern transform: `(pattern, ctx) => pattern`. */
-  readonly apply: (fn: (p: number[], ctx: PatternCtx) => number[]) => T
-  /** Play pattern n times per cycle. */
-  readonly repeat: (n: number) => T
-  /** Hit on specific step indices. `.hits(0, 4, 8)` or `.hits(0, 4, { of: 14 })`. */
-  readonly hits: (...args: (number | { of: number })[]) => T
-  /**
-   * Set a combined pitch+rhythm pattern directly.
-   * String values are note names; `0` = rest. Equivalent to calling `.notes()` for
-   * pitch and providing a matching hit pattern.
-   *
-   * @example
-   * ```ts
-   * Bass303('A2').cutoff(600).pattern(['A2', 0, 0, 0, 'D3', 0, 0, 0])
-   * ```
-   */
-  readonly pattern: (pat: (string | number)[]) => T
-  /** Per-step fire probability array. Engine applies with seeded PRNG. */
-  readonly stepProb: (probs: number[]) => T
-  /** Fit pattern into exactly n bars. */
-  readonly stretch: (bars: number) => T
-  /** 0-1 offset through pattern (`.phase(0.5)` starts halfway). */
-  readonly phase: (amount: number) => T
-  /** Start playing at bar n. */
-  readonly fromBar: (n: number) => T
-  /** Stop playing at bar n. */
-  readonly untilBar: (n: number) => T
-  /** Fade in over n bars. */
-  readonly fadeIn: (bars: number) => T
-  /** Fade out over n bars. */
-  readonly fadeOut: (bars: number) => T
-  // ── Pitch / notes ────────────────────────────────────────────────────────
-  /** Set a single pitch, e.g. `'C3'`. */
-  readonly note: (pitch: string) => T
-  /** Set a note/chord sequence. `'R'` = rest. */
-  readonly notes: (arr: (string | number)[]) => T
-  /** Constrain notes to scale. */
-  readonly scale: (name: string, root: string) => T
-  /** Transpose ±n semitones. */
-  readonly pitch: (semitones: number) => T
-  /** Shift octave by n (n = 1 → one octave up). */
-  readonly octave: (n: number) => T
-  /** Portamento / glide time in seconds. */
-  readonly glide: (time: number) => T
-  /** Note duration in seconds. */
-  readonly dur: (time: number) => T
-  /** Custom note sequence transform: `(notes, ctx) => notes`. */
-  readonly mapNotes: (fn: (notes: (string | number)[], ctx: PatternCtx) => (string | number)[]) => T
-  // ── Amplitude ────────────────────────────────────────────────────────────
-  /** Output gain 0–1. */
-  readonly volume: (v: number) => T
-  /** ADSR attack in seconds. */
-  readonly attack: (s: number) => T
-  /** ADSR decay in seconds. */
-  readonly decay: (s: number) => T
-  /** ADSR sustain level 0–1. */
-  readonly sustain: (v: number) => T
-  /** ADSR release in seconds. */
-  readonly release: (s: number) => T
-  /** Duck gain when source part hits. */
-  readonly duckWith: (source: string | ChainablePart, opts?: { amount?: number; attack?: number; release?: number }) => T
-  /** EDM pump effect — alias for `.duckWith()`. */
-  readonly pumpWith: (source: string | ChainablePart, release?: number) => T
-  /** Rise on trigger — reverse sidechain. */
-  readonly swellWith: (source: string | ChainablePart) => T
-  /** Full sidechain control — escape hatch. */
-  readonly sidechain: (source: string | ChainablePart, opts?: Partial<Omit<SidechainDescriptor, 'source'>>) => T
-  // ── Tone ─────────────────────────────────────────────────────────────────
-  /** Lowpass filter: cutoff freq (Hz) + optional resonance Q. */
-  readonly filter: (freq: number, q?: number) => T
-  /** 3-band EQ: low, mid, high in dB. */
-  readonly eq: (low: number, mid: number, high: number) => T
-  /** Bit crusher — reduce bit depth (4–16). */
-  readonly bit: (bits: number) => T
-  /** Overdrive / saturation warmth (0–1). */
-  readonly saturate: (amt: number) => T
-  // ── Space ────────────────────────────────────────────────────────────────
-  /** Stereo position -1 (left) to 1 (right). */
-  readonly pan: (v: number) => T
-  /** Stereo width via StereoWidener (0–2, 1 = unity). */
-  readonly widen: (amt: number) => T
-  /** Add reverb. `wet` = 0–1. */
-  readonly reverb: (wet: number, opts?: Record<string, unknown>) => T
-  /** Add delay. `time` in seconds or note value ('1/8d'). `feedback` = 0–1. */
-  readonly delay: (time: number | string, feedback?: number) => T
-  /** Chorus / ensemble detune. `depth` = 0–1. */
-  readonly chorus: (depth?: number) => T
-  /** Flanger sweep. `depth` = 0–1. */
-  readonly flange: (depth?: number) => T
-  // ── Routing ──────────────────────────────────────────────────────────────
-  /** Send to named effect bus at given amount (0–1). */
-  readonly send: (bus: string, amount?: number) => T
-  /** Silence this part. */
-  readonly mute: () => T
-  /** Solo this part (silence all others). */
-  readonly solo: () => T
-  /** Assign to choke group — hits cut each other off. */
-  readonly chokeGroup: (name: string) => T
-  /** Layer additional parts under this one. */
-  readonly layer: (...parts: ChainablePart[]) => T
-  // ── Modulation (musical names) ────────────────────────────────────────────
-  /** LFO on volume — rate Hz, depth 0–1. */
-  readonly tremolo: (rate: number, depth?: number) => T
-  /** Sine on pitch (vibrato) — rate Hz, depth Hz. */
-  readonly vibrato: (rate: number, depth?: number) => T
-  /** LFO on filter cutoff (wobble / acid / dubstep) — rate Hz. */
-  readonly wobble: (rate: number, depth?: number) => T
-  /** LFO on pan (stereo movement). */
-  readonly autopan: (rate: number, depth?: number) => T
-  /** Fast LFO on volume (flute flutter, organ tremolo). */
-  readonly flutter: (rate?: number) => T
-  /** Slow LFO on volume (pad breathe). */
-  readonly breathe: (rate?: number) => T
-  /** OU process on pitch (analog warmth drift). */
-  readonly drift: (amt?: number) => T
-  /** Ramp on volume — swell build over n bars. */
-  readonly swell: (bars: number) => T
-  /** Power escape hatch — modulate any param with any modulation source. */
-  readonly modulate: (param: string, source: ModulationDescriptor) => T
-  // ── Meta ─────────────────────────────────────────────────────────────────
-  /** Per-part stochastic seed — overrides song-level seed. */
-  readonly seed: (n: number) => T
-  /** Human-readable label for GUI mixer and codePatcher. */
-  readonly name: (label: string) => T
-  /** Model variant (percussion only): '808' | '909' | 'hard'. */
-  readonly model: (variant: string) => T
-  // ── Visual chain methods ──────────────────────────────────────────────────
-  /**
-   * Set all visual override fields at once.
-   * Merges with any existing `_visual` — fields not provided are preserved.
-   */
-  readonly visual: (override: NonNullable<PartDescriptor['_visual']>) => T
-  /** Shorthand: set the track color (CSS hex). Fast to type mid-set. */
-  readonly color:  (hex: string) => T
-  /** Shorthand: set the inline glyph kind. Fast to type mid-set. */
-  readonly glyph:  (kind: string) => T
-  /** Shorthand: set the display label. Fast to type mid-set. */
-  readonly label:  (text: string) => T
-}
-
-// ── ChainablePart — PartDescriptor + all chain methods ───────────────────────
-
-/**
- * Immutable fluent builder for a single instrument part.
- *
- * Every chain method returns a **new** `ChainablePart` — the original is never mutated.
- * The `_` prefixed fields are data from {@link PartDescriptor}; the named methods
- * are fluent sugar that produce new instances via `createPart`.
- *
- * Declared as an interface (not a type alias) so that TypeScript can resolve the
- * self-referential generic `ChainMethods<ChainablePart>` without a circular type error.
- *
- * @example
- * ```ts
- * const kick = Kick().volume(0.9).reverb(0.15).swing(0.1)
- * const bass = Bass303('C2').cutoff(600).resonance(0.8).pattern([1,0,1,0])
- * export default Song({ bpm: 128, tracks: [kick, bass] })
- * ```
- *
- * @see {@link PartDescriptor} — the underlying data shape read by the engine
- * @see {@link createPart} — factory used internally by all chain methods
- */
- 
-export interface ChainablePart extends PartDescriptor, ChainMethods<ChainablePart> {}
+import type { PartDescriptor, ChainablePart } from './chain.types.js'
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -376,7 +64,11 @@ const appendFx = (desc: PartDescriptor, effect: EffectDescriptor): Partial<PartD
   _effects: [...(desc._effects ?? []), effect],
 })
 
-const appendMod = (desc: PartDescriptor, param: string, source: ModulationDescriptor): Partial<PartDescriptor> => ({
+const appendMod = (
+  desc:   PartDescriptor,
+  param:  string,
+  source: ModulationDescriptor,
+): Partial<PartDescriptor> => ({
   _modulations: [...(desc._modulations ?? []), { param, source }],
 })
 
@@ -391,23 +83,24 @@ const appendMod = (desc: PartDescriptor, param: string, source: ModulationDescri
  * Song authors can call `createPart()` directly to build custom instruments or compose parts
  * with plain functions. The chain is sugar; the descriptor is always accessible.
  *
- * @param init - Descriptor object. Only `instrumentType` is required.
+ * @param init           - Descriptor object. Only `instrumentType` is required.
+ * @param buildExtensions - Optional: sub-type re-attachment hook (used by extendPart).
  * @returns A `ChainablePart` with all chain methods attached.
  *
  * @example
  * ```ts
- * // Custom instrument — works identically to built-ins
  * const myKick = createPart({ instrumentType: 'my-synth' })
  * myKick.volume(0.8).reverb(0.1)
  *
- * // Descriptor fields are directly accessible
  * const kick = Kick(4).volume(0.9)
  * kick._volume  // → 0.9
  * kick._pattern // → euclidean(4, 16) result
  * ```
  *
+ * @throws ScoreError when any chain method receives an out-of-range or invalid argument.
+ *
  * @see {@link defineInstrument} — define a reusable custom instrument factory
- * @see {@link extendPart} — add custom chain methods that survive through all chain calls
+ * @see {@link extendPart}       — add custom chain methods that survive through all chain calls
  */
 export const createPart = (
   init: Partial<PartDescriptor> & { readonly instrumentType: string },
@@ -416,16 +109,16 @@ export const createPart = (
   buildExtensions: (p: ChainablePart) => ChainablePart = (p) => p,
 ): ChainablePart => {
   const desc: PartDescriptor = {
-    _type: 'ChainablePart',
+    _type:    'ChainablePart',
     _version: 1,
-    id: init.id ?? uid(init.instrumentType),
-    type: init.instrumentType,
-    props: init.props ?? {},
+    id:       init.id ?? uid(init.instrumentType),
+    type:     init.instrumentType,
+    props:    init.props ?? {},
     ...init,
     // Stubs are always re-bound to `part` via closure below
-    connect: undefined as unknown as PartDescriptor['connect'],
+    connect:    undefined as unknown as PartDescriptor['connect'],
     disconnect: undefined as unknown as PartDescriptor['disconnect'],
-    dispose: undefined as unknown as PartDescriptor['dispose'],
+    dispose:    undefined as unknown as PartDescriptor['dispose'],
   }
 
   // Shorthand: build a new part from updated descriptor and re-apply buildExtensions.
@@ -434,41 +127,53 @@ export const createPart = (
 
   const part: ChainablePart = {
     ...desc,
-    connect: (_dest: BackendNode) => part,
+    connect:    (_dest: BackendNode) => part,
     disconnect: () => part,
-    dispose: () => undefined,
+    dispose:    () => undefined,
 
-    // ── Pattern ────────────────────────────────────────────────────────────
+    // ── Pattern ──────────────────────────────────────────────────────────────
     speed: (n) => {
-      if (n === 0) throw ScoreError('.speed(0) is not valid — use .mute() to silence', { received: n, fix: 'Use a non-zero speed value', docs: '' })
+      const validated = validateSpeed(n)
       const base = desc._pattern ?? DEFAULT_PATTERN
-      if (n < 0) return cp({ ...desc, _speed: n, _pattern: rev(fast(Math.abs(n), base)) })
-      if (n === 1) return cp({ ...desc, _speed: n })
-      return cp({ ...desc, _speed: n, _pattern: n > 1 ? fast(n, base) : slow(1 / n, base) })
+      if (validated < 0) return cp({ ...desc, _speed: validated, _pattern: rev(fast(Math.abs(validated), base)) })
+      if (validated === 1) return cp({ ...desc, _speed: validated })
+      return cp({ ...desc, _speed: validated, _pattern: validated > 1 ? fast(validated, base) : slow(1 / validated, base) })
     },
-    slow: (n) => cp({ ...desc, _speed: 1 / n, _pattern: slow(n, desc._pattern ?? DEFAULT_PATTERN) }),
-    fast: (n) => cp({ ...desc, _speed: n, _pattern: fast(n, desc._pattern ?? DEFAULT_PATTERN) }),
-    rev: () => cp({ ...desc, _speed: -1, _pattern: rev(desc._pattern ?? DEFAULT_PATTERN) }),
-    halfTime: () => cp({ ...desc, _speed: 0.5, _pattern: slow(2, desc._pattern ?? DEFAULT_PATTERN) }),
-    doubleTime: () => cp({ ...desc, _speed: 2, _pattern: fast(2, desc._pattern ?? DEFAULT_PATTERN) }),
-    tripletTime: () => cp({ ...desc, _speed: 2 / 3, _pattern: fast(2 / 3, desc._pattern ?? DEFAULT_PATTERN) }),
-    retrograde: () => cp({ ...desc, _speed: -1, _pattern: rev(desc._pattern ?? DEFAULT_PATTERN) }),
-    augment: (n = 2) => cp({ ...desc, _speed: 1 / n, _pattern: slow(n, desc._pattern ?? DEFAULT_PATTERN) }),
-    diminish: (n = 2) => cp({ ...desc, _speed: n, _pattern: fast(n, desc._pattern ?? DEFAULT_PATTERN) }),
-    euclidean: (hits, steps = 16) => cp({ ...desc, _pattern: euclidean(hits, steps) }),
-    shift: (n) => cp({ ...desc, _pattern: shift(n, desc._pattern ?? DEFAULT_PATTERN) }),
+    slow: (n) => {
+      const validated = validateSlow(n)
+      return cp({ ...desc, _speed: 1 / validated, _pattern: slow(validated, desc._pattern ?? DEFAULT_PATTERN) })
+    },
+    fast: (n) => {
+      const validated = validateFast(n)
+      return cp({ ...desc, _speed: validated, _pattern: fast(validated, desc._pattern ?? DEFAULT_PATTERN) })
+    },
+    rev:         () => cp({ ...desc, _speed: -1, _pattern: rev(desc._pattern ?? DEFAULT_PATTERN) }),
+    halfTime:    () => cp({ ...desc, _speed: 0.5,     _pattern: slow(2,     desc._pattern ?? DEFAULT_PATTERN) }),
+    doubleTime:  () => cp({ ...desc, _speed: 2,       _pattern: fast(2,     desc._pattern ?? DEFAULT_PATTERN) }),
+    tripletTime: () => cp({ ...desc, _speed: 2 / 3,   _pattern: fast(2 / 3, desc._pattern ?? DEFAULT_PATTERN) }),
+    retrograde:  () => cp({ ...desc, _speed: -1,      _pattern: rev(desc._pattern ?? DEFAULT_PATTERN) }),
+    augment:     (n = 2) => cp({ ...desc, _speed: 1 / n, _pattern: slow(n, desc._pattern ?? DEFAULT_PATTERN) }),
+    diminish:    (n = 2) => cp({ ...desc, _speed: n,     _pattern: fast(n, desc._pattern ?? DEFAULT_PATTERN) }),
+    euclidean: (hits, steps = 16) => {
+      const validated = validateEuclidean(hits, steps)
+      return cp({ ...desc, _pattern: euclidean(validated.hits, validated.steps) })
+    },
+    shift: (n) => {
+      const validated = validateShift(n)
+      return cp({ ...desc, _pattern: shift(validated, desc._pattern ?? DEFAULT_PATTERN) })
+    },
     invert: () => {
       const base = desc._pattern
       if (Array.isArray(base)) {
         return cp({ ...desc, _pattern: (base as number[]).map((v) => (v ? 0 : 1)) })
       }
-      return cp({ ...desc }) // non-array pattern: no-op
+      return cp({ ...desc })
     },
-    mask: (pattern) => cp({ ...desc, _mask: pattern }),
+    mask:       (pattern) => cp({ ...desc, _mask: pattern }),
     stutter: (n) => {
-      if (n < 0) throw ScoreError('.stutter(n) requires n >= 0', { received: n, fix: 'Use a non-negative stutter count', docs: '' })
-      if (n === 0) return cp({ ...desc })
-      return cp({ ...desc, _stutter: n })
+      const validated = validateStutter(n)
+      if (validated === 0) return cp({ ...desc })
+      return cp({ ...desc, _stutter: validated })
     },
     palindrome: () => {
       const base = desc._pattern
@@ -478,125 +183,136 @@ export const createPart = (
       }
       return cp({ ...desc, _palindrome: true })
     },
-    degrade: (p) => {
-      if (p < 0) throw ScoreError('.degrade(p) requires p >= 0', { received: p, fix: 'Use 0 (keep all) to 1 (silence all)', docs: '' })
-      return cp({ ...desc, _degrade: p })
+    degrade:    (p) => cp({ ...desc, _degrade:   validateDegrade(p) }),
+    humanize:   (amt) => cp({ ...desc, _humanize: validateHumanize(amt) }),
+    swing:      (amount) => cp({ ...desc, _swing:   validateSwing(amount) }),
+    every: (n, fn) => {
+      const validated = validateEvery(n)
+      return cp({ ...desc, _every: { n: validated, fn } })
     },
-    humanize: (amt) => cp({ ...desc, _humanize: amt }),
-    swing: (amount) => cp({ ...desc, _swing: amount }),
-    every: (n, fn) => cp({ ...desc, _every: { n, fn } }),
-    apply: (fn) => cp({ ...desc, _applyFn: fn }),
+    apply:      (fn) => cp({ ...desc, _applyFn: fn }),
     repeat: (n) => {
-      if (n <= 0) throw ScoreError('.repeat(n) requires n > 0', { received: n, fix: 'Use a positive repeat count', docs: '' })
-      return cp({ ...desc, _repeat: n })
+      const validated = validateRepeat(n)
+      return cp({ ...desc, _repeat: validated })
     },
     hits: (...args) => {
-      const opts = args.find((a): a is { of: number } => typeof a === 'object' && 'of' in (a as object))
+      const opts  = args.find((a): a is { of: number } => typeof a === 'object' && 'of' in (a as object))
       const steps = args.filter((a): a is number => typeof a === 'number')
       const total = opts?.of ?? 16
       return cp({ ...desc, _pattern: Array.from({ length: total }, (_, i) => steps.includes(i) ? 1 : 0) })
     },
     pattern: (pat) => {
-      // Split combined pitch+rhythm pattern: strings/non-zero numbers are notes, 0 = rest.
-      const notePat = pat.map((v) => (v === 0 ? 0 : 1))
-      const noteSeq = pat.filter((v): v is string | number => v !== 0)
+      const validated = validatePattern(pat)
+      const notePat   = validated.map((v) => (v === 0 ? 0 : 1))
+      const noteSeq   = validated.filter((v): v is string | number => v !== 0)
       return cp({ ...desc, _pattern: notePat, _notes: noteSeq })
     },
-    stepProb: (probs) => cp({ ...desc, _stepProb: probs }),
-    stretch: (bars) => cp({ ...desc, _stretch: bars }),
-    phase: (amount) => cp({ ...desc, _phase: amount }),
-    fromBar: (n) => cp({ ...desc, _fromBar: n }),
-    untilBar: (n) => cp({ ...desc, _untilBar: n }),
-    fadeIn: (bars) => cp({ ...desc, _fadeInBars: bars }),
-    fadeOut: (bars) => cp({ ...desc, _fadeOutBars: bars }),
+    stepProb:   (probs)  => cp({ ...desc, _stepProb: validateStepProb(probs) }),
+    stretch:    (bars)   => cp({ ...desc, _stretch:  validateStretch(bars) }),
+    phase:      (amount) => cp({ ...desc, _phase:    validatePhase(amount) }),
+    fromBar:    (n)      => cp({ ...desc, _fromBar:  validateBarNumber(n, 'fromBar') }),
+    untilBar:   (n)      => cp({ ...desc, _untilBar: validateBarNumber(n, 'untilBar') }),
+    fadeIn:     (bars)   => cp({ ...desc, _fadeInBars:  validateFadeBars(bars, 'fadeIn') }),
+    fadeOut:    (bars)   => cp({ ...desc, _fadeOutBars: validateFadeBars(bars, 'fadeOut') }),
 
-    // ── Pitch / notes ──────────────────────────────────────────────────────
-    note: (pitch) => cp({ ...desc, _notes: [pitch] }),
-    notes: (arr) => cp({ ...desc, _notes: arr }),
-    scale: (name, root) => cp({ ...desc, _scale: { name, root } }),
-    pitch: (semitones) => cp({ ...desc, _pitchOffset: semitones }),
-    octave: (n) => cp({ ...desc, _octave: n }),
-    glide: (time) => cp({ ...desc, _glide: time }),
-    dur: (time) => cp({ ...desc, _dur: time }),
-    mapNotes: (fn) => cp({ ...desc, _mapNotesFn: fn }),
+    // ── Pitch / notes ─────────────────────────────────────────────────────────
+    note:       (pitch)      => cp({ ...desc, _notes:       [validateNote(pitch)] }),
+    notes:      (arr)        => cp({ ...desc, _notes:       validateNotes(arr) }),
+    scale:      (name, root) => cp({ ...desc, _scale:       validateScale(name, root) }),
+    pitch:      (semitones)  => cp({ ...desc, _pitchOffset: validatePitch(semitones) }),
+    octave:     (n)          => cp({ ...desc, _octave:      validateOctave(n) }),
+    glide:      (time)       => cp({ ...desc, _glide:       validateGlide(time) }),
+    dur:        (time)       => cp({ ...desc, _dur:         validateDur(time) }),
+    mapNotes:   (fn)         => cp({ ...desc, _mapNotesFn:  fn }),
 
-    // ── Amplitude ──────────────────────────────────────────────────────────
-    volume: (v) => cp({ ...desc, _volume: v }),
-    attack: (s) => cp({ ...desc, _adsr: { ...desc._adsr, attack: s } }),
-    decay: (s) => cp({ ...desc, _adsr: { ...desc._adsr, decay: s } }),
-    sustain: (v) => cp({ ...desc, _adsr: { ...desc._adsr, sustain: v } }),
-    release: (s) => cp({ ...desc, _adsr: { ...desc._adsr, release: s } }),
+    // ── Amplitude ─────────────────────────────────────────────────────────────
+    volume:  (v) => cp({ ...desc, _volume: validateVolume(v) }),
+    attack:  (s) => cp({ ...desc, _adsr: { ...desc._adsr, attack:  validateAdsrTime(s, 'attack') } }),
+    decay:   (s) => cp({ ...desc, _adsr: { ...desc._adsr, decay:   validateAdsrTime(s, 'decay') } }),
+    sustain: (v) => cp({ ...desc, _adsr: { ...desc._adsr, sustain: validateSustain(v) } }),
+    release: (s) => cp({ ...desc, _adsr: { ...desc._adsr, release: validateAdsrTime(s, 'release') } }),
     duckWith: (source, opts) => cp({ ...desc, _sidechain: {
       source,
-      amount: opts?.amount ?? 0.8,
-      attack: opts?.attack ?? 0.001,
+      amount:  opts?.amount  ?? 0.8,
+      attack:  opts?.attack  ?? 0.001,
       release: opts?.release ?? 0.3,
-      mode: 'duck',
+      mode:    'duck',
     } }),
     pumpWith: (source, release = 0.3) => cp({ ...desc, _sidechain: {
       source,
-      amount: 0.8,
-      attack: 0.001,
+      amount:  0.8,
+      attack:  0.001,
       release,
-      mode: 'duck',
+      mode:    'duck',
     } }),
     swellWith: (source) => cp({ ...desc, _sidechain: {
       source,
-      amount: 0.8,
-      attack: 0.001,
+      amount:  0.8,
+      attack:  0.001,
       release: 0.3,
-      mode: 'reverse',
+      mode:    'reverse',
     } }),
     sidechain: (source, opts) => cp({ ...desc, _sidechain: {
       source,
-      amount: opts?.amount ?? 0.8,
-      attack: opts?.attack ?? 0.001,
+      amount:  opts?.amount  ?? 0.8,
+      attack:  opts?.attack  ?? 0.001,
       release: opts?.release ?? 0.3,
-      mode: opts?.mode ?? 'duck',
+      mode:    opts?.mode    ?? 'duck',
     } }),
 
-    // ── Tone ──────────────────────────────────────────────────────────────
-    filter: (freq, q) => cp({ ...desc, _filter: { frequency: freq, ...(q !== undefined ? { Q: q } : {}) } }),
-    eq: (low, mid, high) => cp({ ...desc, _eq: { lo: low, mid, hi: high } }),
-    bit: (bits) => cp({ ...desc, ...appendFx(desc, makeFx('bitcrusher', { bits })) }),
-    saturate: (amt) => cp({ ...desc, ...appendFx(desc, makeFx('saturation', { drive: amt })) }),
+    // ── Tone ──────────────────────────────────────────────────────────────────
+    filter:   (freq, q)          => cp({ ...desc, _filter: validateFilter(freq, q) }),
+    eq:       (low, mid, high)   => cp({ ...desc, _eq:     validateEq(low, mid, high) }),
+    bit:      (bits)             => cp({ ...desc, ...appendFx(desc, makeFx('bitcrusher',  { bits:  validateBit(bits) })) }),
+    saturate: (amt)              => cp({ ...desc, ...appendFx(desc, makeFx('saturation',  { drive: validateSaturate(amt) })) }),
 
-    // ── Space ──────────────────────────────────────────────────────────────
-    pan: (v) => cp({ ...desc, _pan: v }),
-    widen: (amt) => cp({ ...desc, ...appendFx(desc, makeFx('stereo-widener', { width: amt })) }),
-    reverb: (wet, opts = {}) => cp({ ...desc, ...appendFx(desc, makeFx('reverb', { wet, ...opts })) }),
-    delay: (time, feedback) => cp({ ...desc, ...appendFx(desc, makeFx('delay', feedback !== undefined ? { time, feedback } : { time })) }),
-    chorus: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('chorus', { depth })) }),
-    flange: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('flanger', { depth })) }),
+    // ── Space ─────────────────────────────────────────────────────────────────
+    pan:    (v)          => cp({ ...desc, _pan: validatePan(v) }),
+    widen:  (amt)        => cp({ ...desc, ...appendFx(desc, makeFx('stereo-widener', { width: validateWiden(amt) })) }),
+    reverb: (wet, opts = {}) => cp({ ...desc, ...appendFx(desc, makeFx('reverb', { wet: validateReverbWet(wet), ...opts })) }),
+    delay:  (time, feedback) => {
+      const validated = validateDelay(time, feedback)
+      return cp({ ...desc, ...appendFx(desc, makeFx('delay', validated.feedback !== undefined
+        ? { time: validated.time, feedback: validated.feedback }
+        : { time: validated.time })) })
+    },
+    chorus: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('chorus',  { depth: validateModDepth(depth,  'chorus') })) }),
+    flange: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('flanger', { depth: validateModDepth(depth,  'flange') })) }),
 
-    // ── Routing ────────────────────────────────────────────────────────────
-    send: (bus, amount = 1) => cp({ ...desc, _sends: [...(desc._sends ?? []), { bus, amount }] }),
-    mute: () => cp({ ...desc, _mute: true }),
-    solo: () => cp({ ...desc, _solo: true }),
-    chokeGroup: (name) => cp({ ...desc, _chokeGroup: name }),
-    layer: (...parts) => cp({ ...desc, _layers: [...(desc._layers ?? []), ...(parts as PartDescriptor[])] }),
+    // ── Routing ───────────────────────────────────────────────────────────────
+    send: (bus, amount = 1) => {
+      const validated = validateSend(bus, amount)
+      return cp({ ...desc, _sends: [...(desc._sends ?? []), validated] })
+    },
+    mute:       () => cp({ ...desc, _mute:       true }),
+    solo:       () => cp({ ...desc, _solo:       true }),
+    chokeGroup: (name)       => cp({ ...desc, _chokeGroup: validateChokeGroup(name) }),
+    layer:      (...parts)   => cp({ ...desc, _layers:     [...(desc._layers ?? []), ...(parts as PartDescriptor[])] }),
 
-    // ── Modulation (musical names) ─────────────────────────────────────────
-    tremolo: (rate, depth = 0.8) => cp({ ...desc, ...appendMod(desc, 'volume', lfo(rate, depth)) }),
-    vibrato: (rate, depth = 8) => cp({ ...desc, ...appendMod(desc, 'pitch', sine(rate, depth)) }),
-    wobble: (rate, depth = 1) => cp({ ...desc, ...appendMod(desc, 'filter', lfo(rate, depth)) }),
-    autopan: (rate, depth = 0.8) => cp({ ...desc, ...appendMod(desc, 'pan', lfo(rate, depth)) }),
-    flutter: (rate = 12) => cp({ ...desc, ...appendMod(desc, 'volume', lfo(rate, 0.5)) }),
-    breathe: (rate = 0.3) => cp({ ...desc, ...appendMod(desc, 'volume', lfo(rate, 0.4)) }),
-    drift: (amt = 0.3) => cp({ ...desc, ...appendMod(desc, 'pitch', ou(amt)) }),
-    swell: (bars) => cp({ ...desc, ...appendMod(desc, 'volume', ramp(bars)) }),
-    modulate: (param, source) => cp({ ...desc, ...appendMod(desc, param, source) }),
+    // ── Modulation ────────────────────────────────────────────────────────────
+    tremolo: (rate, depth = 0.8) => cp({ ...desc, ...appendMod(desc, 'volume', lfo(validateLfoRate(rate, 'tremolo'), validateModDepth(depth, 'tremolo'))) }),
+    vibrato: (rate, depth = 8)   => cp({ ...desc, ...appendMod(desc, 'pitch',  sine(validateLfoRate(rate, 'vibrato'), depth)) }),
+    wobble:  (rate, depth = 1)   => cp({ ...desc, ...appendMod(desc, 'filter', lfo(validateLfoRate(rate, 'wobble'),  validateModDepth(depth, 'wobble'))) }),
+    autopan: (rate, depth = 0.8) => cp({ ...desc, ...appendMod(desc, 'pan',    lfo(validateLfoRate(rate, 'autopan'), validateModDepth(depth, 'autopan'))) }),
+    flutter: (rate = 12)         => cp({ ...desc, ...appendMod(desc, 'volume', lfo(validateLfoRate(rate, 'flutter'), 0.5)) }),
+    breathe: (rate = 0.3)        => cp({ ...desc, ...appendMod(desc, 'volume', lfo(validateLfoRate(rate, 'breathe'), 0.4)) }),
+    drift:   (amt = 0.3)         => cp({ ...desc, ...appendMod(desc, 'pitch',  ou(amt)) }),
+    swell:   (bars)              => cp({ ...desc, ...appendMod(desc, 'volume', ramp(validateSwell(bars))) }),
+    modulate: (param, source) => {
+      const validatedParam = validateModulateParam(param)
+      return cp({ ...desc, ...appendMod(desc, validatedParam, source) })
+    },
 
-    // ── Meta ──────────────────────────────────────────────────────────────
-    seed: (n) => cp({ ...desc, _seed: n }),
-    name: (label) => cp({ ...desc, _name: label }),
-    model: (variant) => cp({ ...desc, _model: variant }),
+    // ── Meta ──────────────────────────────────────────────────────────────────
+    seed:  (n)       => cp({ ...desc, _seed:  validateSeed(n) }),
+    name:  (label)   => cp({ ...desc, _name:  validateLabel(label, 'name') }),
+    model: (variant) => cp({ ...desc, _model: validateModel(variant) }),
 
-    // ── Visual ────────────────────────────────────────────────────────────
+    // ── Visual ────────────────────────────────────────────────────────────────
     visual: (override) => cp({ ...desc, _visual: { ...desc._visual, ...override } }),
-    color:  (hex)  => cp({ ...desc, _visual: { ...desc._visual, color: hex } }),
-    glyph:  (kind) => cp({ ...desc, _visual: { ...desc._visual, glyph: kind } }),
-    label:  (text) => cp({ ...desc, _visual: { ...desc._visual, label: text } }),
+    color:  (hex)  => cp({ ...desc, _visual: { ...desc._visual, color: validateColor(hex) } }),
+    glyph:  (kind) => cp({ ...desc, _visual: { ...desc._visual, glyph: validateGlyph(kind) } }),
+    label:  (text) => cp({ ...desc, _visual: { ...desc._visual, label: validateLabel(text, 'label') } }),
   }
 
   return part
@@ -612,7 +328,7 @@ export const createPart = (
  * third-party packages publish custom instruments that work identically to built-ins.
  *
  * @param _typeName - Stable kebab-case instrument type identifier, e.g. `'reese-bass'`.
- * @param factory - Function that creates the initial `ChainablePart`.
+ * @param factory   - Function that creates the initial `ChainablePart`.
  * @returns A factory function producing `ChainablePart`.
  *
  * @example
@@ -626,7 +342,7 @@ export const createPart = (
  */
 export const defineInstrument = <Args extends unknown[], T extends ChainablePart = ChainablePart>(
   _typeName: string,
-  factory: (...args: Args) => T,
+  factory:   (...args: Args) => T,
 ): ((...args: Args) => T) => factory
 
 // ── extendPart ────────────────────────────────────────────────────────────────
@@ -644,13 +360,12 @@ export const defineInstrument = <Args extends unknown[], T extends ChainablePart
  * - Each call to a base chain method produces a new part and re-calls `buildExtensions`.
  * - Extensions compose via spread — no `Object.assign`, no mutation.
  *
- * @param instrumentType - The instrument type identifier (e.g. `'kick'`, `'reese-bass'`)
+ * @param instrumentType  - The instrument type identifier (e.g. `'kick'`, `'reese-bass'`)
  * @param buildExtensions - Called with the current part; returns extra methods to spread
  * @returns A no-arg factory function returning `ChainablePart & Ext`
  *
  * @example
  * ```ts
- * // Add convenience aliases to Kick
  * const MyKick = extendPart('kick', (part) => ({
  *   quiet: () => part.volume(0.2),
  *   loud:  () => part.volume(0.95),
@@ -661,10 +376,10 @@ export const defineInstrument = <Args extends unknown[], T extends ChainablePart
  * ```
  *
  * @see {@link defineInstrument} — define a reusable custom instrument factory
- * @see {@link createPart} — low-level factory used internally
+ * @see {@link createPart}       — low-level factory used internally
  */
 export const extendPart = <Ext extends Record<string, unknown>>(
-  instrumentType: string,
+  instrumentType:  string,
   buildExtensions: (part: ChainablePart) => Ext,
 ): (() => ChainablePart & Ext) => {
   const attachExtensions = (base: ChainablePart): ChainablePart & Ext => ({

--- a/packages/dsl/src/chain.types.ts
+++ b/packages/dsl/src/chain.types.ts
@@ -1,0 +1,355 @@
+// =============================================================================
+// @score/dsl — chain types
+// PartDescriptor, ChainMethods, and ChainablePart type definitions.
+//
+// Kept separate from chain.ts (factory implementation) so consumers can import
+// types without pulling in the full createPart() factory and all validators.
+// =============================================================================
+
+import type { AudioComponent, EffectDescriptor } from '@score/core'
+import type { BackendNode }                       from '@score/core'
+import type { PatternInput }                       from '@score/pattern'
+import type { ModulationDescriptor }               from './modulation.js'
+
+// ── Supporting types ──────────────────────────────────────────────────────────
+
+/** Context passed to `.apply()` and `.mapNotes()` callbacks. Same inputs → same output. */
+export type PatternCtx = {
+  readonly bar:   number
+  readonly bpm:   number
+  readonly steps: number
+  readonly seed:  number
+}
+
+/** A send routing entry — route to a named effect bus at a given amount. */
+export type SendDescriptor = {
+  readonly bus:    string
+  readonly amount: number
+}
+
+/** Sidechain / ducking configuration. */
+export type SidechainDescriptor = {
+  readonly source:  string | ChainablePart
+  readonly amount:  number
+  readonly attack:  number
+  readonly release: number
+  readonly mode:    'duck' | 'reverse'
+}
+
+// ── PartDescriptor — pure data shape carrying all chain state ─────────────────
+
+/**
+ * Pure data record carrying all chain method state for a single instrument part.
+ *
+ * The engine reads these `_`-prefixed fields at play time and hydrates them into live audio.
+ * Every field is optional except `_type`, `_version`, `instrumentType`, `type`, and `id`.
+ *
+ * Song authors never construct this directly — use the instrument factories
+ * (`Kick`, `Synth`, `Arp`, etc.) which return a {@link ChainablePart} with all methods attached.
+ *
+ * @see {@link ChainablePart} — adds fluent chain methods on top of this descriptor
+ * @see {@link createPart}    — factory that produces a `ChainablePart` from a partial descriptor
+ */
+export type PartDescriptor = {
+  readonly _type:           'ChainablePart'
+  readonly _version:        1
+  readonly instrumentType:  string
+  /** Alias for instrumentType — satisfies AudioComponent.type contract. */
+  readonly type:            string
+  readonly id:              string
+  /** Human-readable label — GUI mixer name, codePatcher correlation. */
+  readonly _name?:          string
+  /** Per-part stochastic seed. Overrides song-level seed for this part only. */
+  readonly _seed?:          number
+  /** Model variant — percussion only: '808' | '909' | 'hard' | 'generic' etc. */
+  readonly _model?:         string
+  // ── Pattern ────────────────────────────────────────────────────────────────
+  readonly _pattern?:       PatternInput
+  readonly _speed?:         number
+  readonly _degrade?:       number
+  readonly _humanize?:      number
+  readonly _swing?:         number
+  readonly _stutter?:       number
+  readonly _palindrome?:    boolean
+  readonly _mask?:          PatternInput
+  readonly _repeat?:        number
+  readonly _stepProb?:      ReadonlyArray<number>
+  readonly _applyFn?:       (p: number[], ctx: PatternCtx) => number[]
+  readonly _mapNotesFn?:    (notes: (string | number)[], ctx: PatternCtx) => (string | number)[]
+  readonly _every?:         { readonly n: number; readonly fn: (p: number[]) => number[] }
+  readonly _stretch?:       number
+  readonly _phase?:         number
+  readonly _fromBar?:       number
+  readonly _untilBar?:      number
+  readonly _fadeInBars?:    number
+  readonly _fadeOutBars?:   number
+  // ── Pitch / notes ──────────────────────────────────────────────────────────
+  readonly _notes?:         ReadonlyArray<string | number>
+  readonly _scale?:         { readonly name: string; readonly root: string }
+  readonly _pitchOffset?:   number
+  readonly _octave?:        number
+  readonly _glide?:         number
+  readonly _dur?:           number
+  // ── Amplitude ──────────────────────────────────────────────────────────────
+  readonly _volume?:        number
+  readonly _pan?:           number
+  readonly _adsr?: {
+    readonly attack?:   number
+    readonly decay?:    number
+    readonly sustain?:  number
+    readonly release?:  number
+  }
+  readonly _sidechain?:     SidechainDescriptor
+  // ── Tone ───────────────────────────────────────────────────────────────────
+  readonly _filter?: { readonly frequency: number; readonly Q?: number }
+  readonly _eq?:     { readonly lo: number; readonly mid: number; readonly hi: number }
+  // ── Effects chain ──────────────────────────────────────────────────────────
+  readonly _effects?:       ReadonlyArray<EffectDescriptor>
+  // ── Routing ────────────────────────────────────────────────────────────────
+  readonly _sends?:         ReadonlyArray<SendDescriptor>
+  readonly _mute?:          boolean
+  readonly _solo?:          boolean
+  readonly _chokeGroup?:    string
+  readonly _layers?:        ReadonlyArray<PartDescriptor>
+  // ── Modulations ────────────────────────────────────────────────────────────
+  readonly _modulations?:   ReadonlyArray<{
+    readonly param:  string
+    readonly source: ModulationDescriptor
+  }>
+  // ── Visual — per-track visual override ─────────────────────────────────────
+  // @score/visuals reads this from TrackVisualState and merges over InstrumentVisualMap defaults.
+  readonly _visual?: {
+    /** CSS hex color override for Monaco arcs, PunchcardGrid, and PerformanceCanvas. */
+    readonly color?:   string
+    /** Inline glyph kind for the Monaco editor. */
+    readonly glyph?:   string
+    /** Human-readable label override (defaults to track variable name). */
+    readonly label?:   string
+    /** Opacity override 0–1. */
+    readonly opacity?: number
+  }
+  // ── Props — for engine backwards compat during transition ──────────────────
+  readonly props: Record<string, unknown>
+  // ── AudioComponent stubs — satisfied by createPart(), replaced by engine ───
+  readonly connect:    (destination: BackendNode) => AudioComponent
+  readonly disconnect: () => AudioComponent
+  readonly dispose:    () => void
+}
+
+// ── ChainMethods<T> — all fluent chain methods, generic over return type ──────
+
+/**
+ * All fluent chain methods for a part — generic over `T`, the return type of every method.
+ *
+ * `ChainablePart` uses `ChainMethods<ChainablePart>`.
+ * Sub-types declare `PartDescriptor & ChainMethods<Self> & Extras`
+ * so every chain method preserves the sub-type through composition.
+ *
+ * Thesis: functional composition preserves identity.
+ * A `Bass303Part` through `.volume()` is still a `Bass303Part`.
+ */
+export type ChainMethods<T> = {
+  // ── Pattern ──────────────────────────────────────────────────────────────
+  /** Speed multiplier. `n > 1` = fast, `n < 1` = slow, `n < 0` = reverse. */
+  readonly speed:       (n: number) => T
+  /** Sugar: `speed(1/n)` — play n times slower. */
+  readonly slow:        (n: number) => T
+  /** Sugar: `speed(n)` — play n times faster. */
+  readonly fast:        (n: number) => T
+  /** Sugar: reverse the pattern. */
+  readonly rev:         () => T
+  /** Sugar: half-time feel. */
+  readonly halfTime:    () => T
+  /** Sugar: double-time feel. */
+  readonly doubleTime:  () => T
+  /** Sugar: triplet feel (3 against 2). */
+  readonly tripletTime: () => T
+  /** Classical term: reverse. Alias for `.rev()`. */
+  readonly retrograde:  () => T
+  /** Classical: lengthen by factor n. Sugar for `slow(n)`. */
+  readonly augment:     (n?: number) => T
+  /** Classical: shorten by factor n. Sugar for `fast(n)`. */
+  readonly diminish:    (n?: number) => T
+  /** Replace pattern with euclidean(hits, steps). Default steps = 16. */
+  readonly euclidean:   (hits: number, steps?: number) => T
+  /** Rotate pattern n steps. Negative = shift left. */
+  readonly shift:       (n: number) => T
+  /** Flip 1s and 0s. */
+  readonly invert:      () => T
+  /** Mute steps where mask = 0. */
+  readonly mask:        (pattern: PatternInput) => T
+  /** Stutter — repeat last hit n times. n = 0 is a no-op. */
+  readonly stutter:     (n: number) => T
+  /** Palindrome — pattern + reversed pattern (exclusive center). */
+  readonly palindrome:  () => T
+  /** Drop hits at probability p (0 = never, 1 = always silence). */
+  readonly degrade:     (p: number) => T
+  /** Timing jitter in seconds. */
+  readonly humanize:    (amt: number) => T
+  /** Swing offset on off-beats (0–1). */
+  readonly swing:       (amount: number) => T
+  /** Apply fn every n cycles. fn receives current pattern. */
+  readonly every:       (n: number, fn: (p: number[]) => number[]) => T
+  /** Custom pattern transform: `(pattern, ctx) => pattern`. */
+  readonly apply:       (fn: (p: number[], ctx: PatternCtx) => number[]) => T
+  /** Play pattern n times per cycle. */
+  readonly repeat:      (n: number) => T
+  /** Hit on specific step indices. `.hits(0, 4, 8)` or `.hits(0, 4, { of: 14 })`. */
+  readonly hits:        (...args: (number | { of: number })[]) => T
+  /**
+   * Set a combined pitch+rhythm pattern directly.
+   * String values are note names; `0` = rest. Equivalent to calling `.notes()` for
+   * pitch and providing a matching hit pattern.
+   *
+   * @example
+   * ```ts
+   * Bass303('A2').cutoff(600).pattern(['A2', 0, 0, 0, 'D3', 0, 0, 0])
+   * ```
+   */
+  readonly pattern:     (pat: (string | number)[]) => T
+  /** Per-step fire probability array. Engine applies with seeded PRNG. */
+  readonly stepProb:    (probs: number[]) => T
+  /** Fit pattern into exactly n bars. */
+  readonly stretch:     (bars: number) => T
+  /** 0-1 offset through pattern (`.phase(0.5)` starts halfway). */
+  readonly phase:       (amount: number) => T
+  /** Start playing at bar n. */
+  readonly fromBar:     (n: number) => T
+  /** Stop playing at bar n. */
+  readonly untilBar:    (n: number) => T
+  /** Fade in over n bars. */
+  readonly fadeIn:      (bars: number) => T
+  /** Fade out over n bars. */
+  readonly fadeOut:     (bars: number) => T
+  // ── Pitch / notes ────────────────────────────────────────────────────────
+  /** Set a single pitch, e.g. `'C3'`. */
+  readonly note:        (pitch: string) => T
+  /** Set a note/chord sequence. `'R'` = rest. */
+  readonly notes:       (arr: (string | number)[]) => T
+  /** Constrain notes to scale. */
+  readonly scale:       (name: string, root: string) => T
+  /** Transpose ±n semitones. */
+  readonly pitch:       (semitones: number) => T
+  /** Shift octave by n (n = 1 → one octave up). */
+  readonly octave:      (n: number) => T
+  /** Portamento / glide time in seconds. */
+  readonly glide:       (time: number) => T
+  /** Note duration in seconds. */
+  readonly dur:         (time: number) => T
+  /** Custom note sequence transform: `(notes, ctx) => notes`. */
+  readonly mapNotes:    (fn: (notes: (string | number)[], ctx: PatternCtx) => (string | number)[]) => T
+  // ── Amplitude ────────────────────────────────────────────────────────────
+  /** Output gain 0–2. */
+  readonly volume:      (v: number) => T
+  /** ADSR attack in seconds. */
+  readonly attack:      (s: number) => T
+  /** ADSR decay in seconds. */
+  readonly decay:       (s: number) => T
+  /** ADSR sustain level 0–1. */
+  readonly sustain:     (v: number) => T
+  /** ADSR release in seconds. */
+  readonly release:     (s: number) => T
+  /** Duck gain when source part hits. */
+  readonly duckWith:    (source: string | ChainablePart, opts?: { amount?: number; attack?: number; release?: number }) => T
+  /** EDM pump effect — alias for `.duckWith()`. */
+  readonly pumpWith:    (source: string | ChainablePart, release?: number) => T
+  /** Rise on trigger — reverse sidechain. */
+  readonly swellWith:   (source: string | ChainablePart) => T
+  /** Full sidechain control — escape hatch. */
+  readonly sidechain:   (source: string | ChainablePart, opts?: Partial<Omit<SidechainDescriptor, 'source'>>) => T
+  // ── Tone ─────────────────────────────────────────────────────────────────
+  /** Lowpass filter: cutoff freq (Hz) + optional resonance Q. */
+  readonly filter:      (freq: number, q?: number) => T
+  /** 3-band EQ: low, mid, high in dB. */
+  readonly eq:          (low: number, mid: number, high: number) => T
+  /** Bit crusher — reduce bit depth (1–32). */
+  readonly bit:         (bits: number) => T
+  /** Overdrive / saturation warmth (0–1). */
+  readonly saturate:    (amt: number) => T
+  // ── Space ────────────────────────────────────────────────────────────────
+  /** Stereo position -1 (left) to 1 (right). */
+  readonly pan:         (v: number) => T
+  /** Stereo width via StereoWidener (0–1). */
+  readonly widen:       (amt: number) => T
+  /** Add reverb. `wet` = 0–1. */
+  readonly reverb:      (wet: number, opts?: Record<string, unknown>) => T
+  /** Add delay. `time` in seconds or note value ('8n'). `feedback` = 0–0.99. */
+  readonly delay:       (time: number | string, feedback?: number) => T
+  /** Chorus / ensemble detune. `depth` = 0–1. */
+  readonly chorus:      (depth?: number) => T
+  /** Flanger sweep. `depth` = 0–1. */
+  readonly flange:      (depth?: number) => T
+  // ── Routing ──────────────────────────────────────────────────────────────
+  /** Send to named effect bus at given amount (0–1). */
+  readonly send:        (bus: string, amount?: number) => T
+  /** Silence this part. */
+  readonly mute:        () => T
+  /** Solo this part (silence all others). */
+  readonly solo:        () => T
+  /** Assign to choke group — hits cut each other off. */
+  readonly chokeGroup:  (name: string) => T
+  /** Layer additional parts under this one. */
+  readonly layer:       (...parts: ChainablePart[]) => T
+  // ── Modulation (musical names) ────────────────────────────────────────────
+  /** LFO on volume — rate Hz, depth 0–1. */
+  readonly tremolo:     (rate: number, depth?: number) => T
+  /** Sine on pitch (vibrato) — rate Hz, depth Hz. */
+  readonly vibrato:     (rate: number, depth?: number) => T
+  /** LFO on filter cutoff (wobble / acid / dubstep) — rate Hz. */
+  readonly wobble:      (rate: number, depth?: number) => T
+  /** LFO on pan (stereo movement). */
+  readonly autopan:     (rate: number, depth?: number) => T
+  /** Fast LFO on volume (flute flutter, organ tremolo). */
+  readonly flutter:     (rate?: number) => T
+  /** Slow LFO on volume (pad breathe). */
+  readonly breathe:     (rate?: number) => T
+  /** OU process on pitch (analog warmth drift). */
+  readonly drift:       (amt?: number) => T
+  /** Ramp on volume — swell build over n bars. */
+  readonly swell:       (bars: number) => T
+  /** Power escape hatch — modulate any param with any modulation source. */
+  readonly modulate:    (param: string, source: ModulationDescriptor) => T
+  // ── Meta ─────────────────────────────────────────────────────────────────
+  /** Per-part stochastic seed — overrides song-level seed. */
+  readonly seed:        (n: number) => T
+  /** Human-readable label for GUI mixer and codePatcher. */
+  readonly name:        (label: string) => T
+  /** Model variant (percussion only): '808' | '909' | 'hard'. */
+  readonly model:       (variant: string) => T
+  // ── Visual chain methods ──────────────────────────────────────────────────
+  /**
+   * Set all visual override fields at once.
+   * Merges with any existing `_visual` — fields not provided are preserved.
+   */
+  readonly visual:      (override: NonNullable<PartDescriptor['_visual']>) => T
+  /** Shorthand: set the track color (CSS hex). Fast to type mid-set. */
+  readonly color:       (hex: string) => T
+  /** Shorthand: set the inline glyph kind. Fast to type mid-set. */
+  readonly glyph:       (kind: string) => T
+  /** Shorthand: set the display label. Fast to type mid-set. */
+  readonly label:       (text: string) => T
+}
+
+// ── ChainablePart — PartDescriptor + all chain methods ───────────────────────
+
+/**
+ * Immutable fluent builder for a single instrument part.
+ *
+ * Every chain method returns a **new** `ChainablePart` — the original is never mutated.
+ * The `_` prefixed fields are data from {@link PartDescriptor}; the named methods
+ * are fluent sugar that produce new instances via `createPart`.
+ *
+ * Declared as an interface (not a type alias) so that TypeScript can resolve the
+ * self-referential generic `ChainMethods<ChainablePart>` without a circular type error.
+ *
+ * @example
+ * ```ts
+ * const kick = Kick().volume(0.9).reverb(0.15).swing(0.1)
+ * const bass = Bass303('C2').cutoff(600).resonance(0.8).pattern([1,0,1,0])
+ * export default Song({ bpm: 128, tracks: [kick, bass] })
+ * ```
+ *
+ * @see {@link PartDescriptor} — the underlying data shape read by the engine
+ * @see {@link createPart}    — factory used internally by all chain methods
+ */
+export interface ChainablePart extends PartDescriptor, ChainMethods<ChainablePart> {}

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -10,8 +10,27 @@ export { chord, scale, progression, Scale, Progression } from './theory.js'
 export type { ScaleObject, ProgressionObject } from './theory.js'
 export { defineGenre, DEFAULT_REGISTRY, Techno, House, DeepHouse, DnB, Dubstep, Hardstyle, Trance, FutureBass, Trap, Psytrance, IDM, Ambient, Synthwave, LoFi, MinimalTechno, AcidHouse } from './genre.js'
 export { defineGroove, GrooveStraight, GrooveShuffle, GrooveSwing16, GrooveHipHop, GrooveLatin, GrooveMPC } from './groove.js'
-export type { PartDescriptor, ChainablePart, ChainMethods } from './chain.js'
+export type { PartDescriptor, ChainablePart, ChainMethods, PatternCtx, SendDescriptor, SidechainDescriptor } from './chain.js'
 export { createPart, defineInstrument, extendPart } from './chain.js'
+export {
+  validateSpeed,        validateSlow,         validateFast,
+  validateEuclidean,    validateShift,        validateStutter,
+  validateDegrade,      validateHumanize,     validateSwing,
+  validateEvery,        validateRepeat,       validatePattern,
+  validateStepProb,     validateStretch,      validatePhase,
+  validateBarNumber,    validateFadeBars,
+  validateNote,         validateNotes,        validateScale,
+  validatePitch,        validateOctave,       validateGlide,
+  validateDur,          validateVolume,       validateAdsrTime,
+  validateSustain,      validatePan,          validateWiden,
+  validateFilter,       validateEq,           validateBit,
+  validateSaturate,     validateReverbWet,    validateDelay,
+  validateModDepth,     validateLfoRate,      validateSwell,
+  validateSend,         validateChokeGroup,   validateModulateParam,
+  validateColor,        validateGlyph,        validateLabel,
+  validateSeed,         validateModel,        validateOpacity,
+  validateGain,         validateBarCount,
+} from './validators.js'
 export { noteHz, resolveFreq } from './notes.js'
 export { drift, keepFor } from './modifiers.js'
 export { lfo, sine, ramp, lorenz, ou, logistic } from './modulation.js'

--- a/packages/dsl/src/validators.ts
+++ b/packages/dsl/src/validators.ts
@@ -1,0 +1,355 @@
+// =============================================================================
+// @score/dsl — validators
+// Runtime input validators for all ChainMethods. Each validator is a pure
+// function that throws ScoreError with a fix hint on invalid input.
+//
+// Grouped by domain — ~10 schema groups covering all ~50 chain methods.
+// Zod schemas are used internally; the public API is the validate* functions.
+// =============================================================================
+
+import { z }          from 'zod'
+import { ScoreError } from '@score/core'
+
+// ── Internal schema definitions ───────────────────────────────────────────────
+
+const schemaSpeedMultiplier = z.number().refine(n => n !== 0, { message: 'Speed multiplier cannot be 0.' })
+
+const schemaProbability     = z.number().min(0).max(1)
+
+const schemaTimingSeconds   = z.number().min(0)
+
+const schemaBarCount        = z.number().int().min(1)
+
+const schemaBars            = z.number().min(0)
+
+const schemaVolume          = z.number().min(0).max(2)
+
+const schemaPan             = z.number().min(-1).max(1)
+
+const schemaWiden           = z.number().min(0).max(1)
+
+const schemaFrequency       = z.number().min(20).max(20000)
+
+const schemaFilterQ         = z.number().min(0.1).max(30)
+
+const schemaGain            = z.number().min(0).max(2)
+
+const schemaEqBand          = z.number().min(-40).max(40)
+
+const schemaBitDepth        = z.number().int().min(1).max(32)
+
+const schemaSaturation      = z.number().min(0).max(1)
+
+const schemaEuclideanHits   = z.number().int().min(0)
+
+const schemaEuclideanSteps  = z.number().int().min(1).max(128)
+
+const schemaShiftSteps      = z.number().int()
+
+const schemaStutterCount    = z.number().int().min(0).max(32)
+
+const schemaRepeatCount     = z.number().int().min(1)
+
+const schemaSemitones       = z.number().int().min(-48).max(48)
+
+const schemaOctave          = z.number().int().min(-4).max(4)
+
+const schemaSendBus         = z.string().min(1)
+
+const schemaSendAmount      = z.number().min(0).max(1)
+
+const schemaChokeGroup      = z.string().min(1)
+
+const schemaModulationParam = z.string().min(1)
+
+const schemaLfoRate         = z.number().min(0.01).max(50)
+
+const schemaLfoDepth        = z.number().min(0).max(1)
+
+const schemaEveryN          = z.number().int().min(1)
+
+const schemaPhaseAmount     = z.number().min(-1).max(1)
+
+const schemaSwellBars       = z.number().min(0)
+
+const schemaHexColor        = z.string().regex(/^#[0-9a-fA-F]{3,8}$/, 'Color must be a CSS hex value e.g. #ff3366.')
+
+const schemaNoteString      = z.string().min(1)
+
+const schemaNotesArray      = z.array(z.union([z.string(), z.number()])).min(1)
+
+const schemaPatternArray    = z.array(z.union([z.number(), z.string()])).min(1)
+
+const schemaScaleName       = z.string().min(1)
+
+const schemaScaleRoot       = z.string().min(1)
+
+const schemaStepProbArray   = z.array(z.number().min(0).max(1)).min(1)
+
+const schemaSeedValue       = z.number().int().min(0)
+
+const schemaNameLabel       = z.string().min(1)
+
+const schemaGlyphKind       = z.string().min(1)
+
+const schemaOpacity         = z.number().min(0).max(1)
+
+const schemaDelayTime       = z.union([
+  z.string().regex(/^\d+(\.\d+)?(n|t|\.)?$/, 'Delay time must be a seconds number or note value e.g. "8n", "4t".'),
+  z.number().min(0).max(10),
+])
+
+const schemaFeedback        = z.number().min(0).max(0.99)
+
+const schemaDurTime         = z.number().min(0).max(60)
+
+const schemaGlideTime       = z.number().min(0).max(10)
+
+// ── Internal parse helper ─────────────────────────────────────────────────────
+
+const parse = <T>(
+  schema:    z.ZodType<T>,
+  value:     unknown,
+  method:    string,
+  fixHint:   string,
+): T => {
+  const result = schema.safeParse(value)
+  if (!result.success) {
+    const issue = result.error.issues[0]?.message ?? 'Invalid value.'
+    throw ScoreError(`${method}() — ${issue} ${fixHint}`, { received: value, fix: fixHint, docs: '' })
+  }
+  return result.data
+}
+
+// =============================================================================
+// Public validator functions — one per chain method (or closely related group).
+// Each throws ScoreError with a fix hint on invalid input.
+// =============================================================================
+
+// ── Pattern ───────────────────────────────────────────────────────────────────
+
+/** `.speed(n)` — non-zero number. */
+export const validateSpeed = (n: unknown): number =>
+  parse(schemaSpeedMultiplier, n, 'speed', 'Use a non-zero number e.g. .speed(0.5) or .speed(2).')
+
+/** `.slow(n)` / `.augment(n)` — positive number. */
+export const validateSlow = (n: unknown): number =>
+  parse(z.number().positive(), n, 'slow', 'Use a positive number e.g. .slow(2).')
+
+/** `.fast(n)` / `.diminish(n)` — positive number. */
+export const validateFast = (n: unknown): number =>
+  parse(z.number().positive(), n, 'fast', 'Use a positive number e.g. .fast(2).')
+
+/** `.euclidean(hits, steps)` — hits: non-negative integer, steps: 1–128. */
+export const validateEuclidean = (hits: unknown, steps: unknown): { hits: number; steps: number } => ({
+  hits:  parse(schemaEuclideanHits,  hits,  'euclidean', 'hits must be a non-negative integer e.g. .euclidean(3, 8).'),
+  steps: parse(schemaEuclideanSteps, steps, 'euclidean', 'steps must be 1–128 e.g. .euclidean(3, 8).'),
+})
+
+/** `.shift(n)` — integer (positive or negative). */
+export const validateShift = (n: unknown): number =>
+  parse(schemaShiftSteps, n, 'shift', 'Use an integer e.g. .shift(2) or .shift(-1).')
+
+/** `.stutter(n)` — integer 0–32. */
+export const validateStutter = (n: unknown): number =>
+  parse(schemaStutterCount, n, 'stutter', 'Use an integer 0–32 e.g. .stutter(3).')
+
+/** `.degrade(p)` — probability 0–1. */
+export const validateDegrade = (p: unknown): number =>
+  parse(schemaProbability, p, 'degrade', 'Use a number between 0 and 1 e.g. .degrade(0.3).')
+
+/** `.humanize(amt)` — seconds &gt;= 0. */
+export const validateHumanize = (amt: unknown): number =>
+  parse(schemaTimingSeconds, amt, 'humanize', 'Use a non-negative number in seconds e.g. .humanize(0.01).')
+
+/** `.swing(amount)` — 0–1. */
+export const validateSwing = (amount: unknown): number =>
+  parse(schemaProbability, amount, 'swing', 'Use a number between 0 and 1 e.g. .swing(0.5).')
+
+/** `.every(n, fn)` — n: positive integer. */
+export const validateEvery = (n: unknown): number =>
+  parse(schemaEveryN, n, 'every', 'Use a positive integer e.g. .every(4, p => p.reverse()).')
+
+/** `.repeat(n)` — positive integer. */
+export const validateRepeat = (n: unknown): number =>
+  parse(schemaRepeatCount, n, 'repeat', 'Use a positive integer e.g. .repeat(2).')
+
+/** `.pattern(pat)` — non-empty array. */
+export const validatePattern = (pat: unknown): (string | number)[] =>
+  parse(schemaPatternArray, pat, 'pattern', 'Use a non-empty array e.g. .pattern([1, 0, 1, 0]).')
+
+/** `.stepProb(probs)` — array of probabilities 0–1. */
+export const validateStepProb = (probs: unknown): number[] =>
+  parse(schemaStepProbArray, probs, 'stepProb', 'Use an array of numbers 0–1 e.g. .stepProb([1, 0.5, 0.8, 1]).')
+
+/** `.stretch(bars)` — positive number of bars. */
+export const validateStretch = (bars: unknown): number =>
+  parse(z.number().positive(), bars, 'stretch', 'Use a positive number e.g. .stretch(2).')
+
+/** `.phase(amount)` — -1 to 1. */
+export const validatePhase = (amount: unknown): number =>
+  parse(schemaPhaseAmount, amount, 'phase', 'Use a number between -1 and 1 e.g. .phase(0.5).')
+
+/** `.fromBar(n)` / `.untilBar(n)` — non-negative integer bar number. */
+export const validateBarNumber = (n: unknown, method: string): number =>
+  parse(z.number().int().min(0), n, method, `Use a non-negative integer e.g. .${method}(4).`)
+
+/** `.fadeIn(bars)` / `.fadeOut(bars)` — non-negative number of bars. */
+export const validateFadeBars = (bars: unknown, method: string): number =>
+  parse(schemaBars, bars, method, `Use a non-negative number e.g. .${method}(2).`)
+
+// ── Pitch / notes ─────────────────────────────────────────────────────────────
+
+/** `.note(pitch)` — non-empty note string e.g. "C4". */
+export const validateNote = (pitch: unknown): string =>
+  parse(schemaNoteString, pitch, 'note', 'Use a note string e.g. .note("C4") or .note("A3").')
+
+/** `.notes(arr)` — non-empty array of note strings or MIDI numbers. */
+export const validateNotes = (arr: unknown): (string | number)[] =>
+  parse(schemaNotesArray, arr, 'notes', 'Use a non-empty array e.g. .notes(["C4","E4","G4"]).')
+
+/** `.scale(name, root)` — non-empty strings. */
+export const validateScale = (name: unknown, root: unknown): { name: string; root: string } => ({
+  name: parse(schemaScaleName, name, 'scale', 'Use a scale name e.g. .scale("minor", "C").'),
+  root: parse(schemaScaleRoot, root, 'scale', 'Use a root note e.g. .scale("minor", "C").'),
+})
+
+/** `.pitch(semitones)` — integer -48 to +48. */
+export const validatePitch = (semitones: unknown): number =>
+  parse(schemaSemitones, semitones, 'pitch', 'Use an integer semitone offset -48 to +48 e.g. .pitch(-12).')
+
+/** `.octave(n)` — integer -4 to +4. */
+export const validateOctave = (n: unknown): number =>
+  parse(schemaOctave, n, 'octave', 'Use an integer -4 to +4 e.g. .octave(-1).')
+
+/** `.glide(time)` — seconds 0–10. */
+export const validateGlide = (time: unknown): number =>
+  parse(schemaGlideTime, time, 'glide', 'Use a number in seconds 0–10 e.g. .glide(0.05).')
+
+/** `.dur(time)` — seconds 0–60. */
+export const validateDur = (time: unknown): number =>
+  parse(schemaDurTime, time, 'dur', 'Use a note duration in seconds 0–60 e.g. .dur(0.25).')
+
+// ── Amplitude ─────────────────────────────────────────────────────────────────
+
+/** `.volume(v)` — 0–2. Values above 1 amplify. */
+export const validateVolume = (v: unknown): number =>
+  parse(schemaVolume, v, 'volume', 'Use a number 0–2 e.g. .volume(0.8). Values above 1 amplify.')
+
+/** `.attack(s)` / `.decay(s)` / `.release(s)` — seconds &gt;= 0. */
+export const validateAdsrTime = (s: unknown, method: string): number =>
+  parse(schemaTimingSeconds, s, method, `Use a non-negative number in seconds e.g. .${method}(0.01).`)
+
+/** `.sustain(v)` — 0–1. */
+export const validateSustain = (v: unknown): number =>
+  parse(schemaProbability, v, 'sustain', 'Use a number 0–1 e.g. .sustain(0.7).')
+
+/** `.pan(v)` — -1 (left) to 1 (right). */
+export const validatePan = (v: unknown): number =>
+  parse(schemaPan, v, 'pan', 'Use a number -1 to 1 e.g. .pan(-0.5) for left, .pan(0.5) for right.')
+
+/** `.widen(amt)` — 0–1. */
+export const validateWiden = (amt: unknown): number =>
+  parse(schemaWiden, amt, 'widen', 'Use a number 0–1 e.g. .widen(0.5).')
+
+// ── Tone / filter ─────────────────────────────────────────────────────────────
+
+/** `.filter(freq, q?)` — freq: 20–20000 Hz, Q: 0.1–30. */
+export const validateFilter = (freq: unknown, q: unknown): { frequency: number; Q?: number } => {
+  const frequency = parse(schemaFrequency, freq, 'filter', 'Use a frequency 20–20000 Hz e.g. .filter(800).')
+  const Q         = q === undefined ? undefined : parse(schemaFilterQ, q, 'filter', 'Use a Q value 0.1–30 e.g. .filter(800, 2).')
+  return Q === undefined ? { frequency } : { frequency, Q }
+}
+
+/** `.eq(low, mid, high)` — each -40 to +40 dB. */
+export const validateEq = (low: unknown, mid: unknown, high: unknown): { lo: number; mid: number; hi: number } => ({
+  lo:  parse(schemaEqBand, low,  'eq', 'Use dB values -40 to +40 e.g. .eq(3, 0, -2).'),
+  mid: parse(schemaEqBand, mid,  'eq', 'Use dB values -40 to +40 e.g. .eq(3, 0, -2).'),
+  hi:  parse(schemaEqBand, high, 'eq', 'Use dB values -40 to +40 e.g. .eq(3, 0, -2).'),
+})
+
+/** `.bit(bits)` — integer 1–32. */
+export const validateBit = (bits: unknown): number =>
+  parse(schemaBitDepth, bits, 'bit', 'Use an integer 1–32 e.g. .bit(8).')
+
+/** `.saturate(amt)` — 0–1. */
+export const validateSaturate = (amt: unknown): number =>
+  parse(schemaSaturation, amt, 'saturate', 'Use a number 0–1 e.g. .saturate(0.4).')
+
+// ── Effects ───────────────────────────────────────────────────────────────────
+
+/** `.reverb(wet)` — 0–1. */
+export const validateReverbWet = (wet: unknown): number =>
+  parse(schemaProbability, wet, 'reverb', 'Use a wet amount 0–1 e.g. .reverb(0.3).')
+
+/** `.delay(time, feedback?)` — time: seconds or note value string, feedback: 0–0.99. */
+export const validateDelay = (time: unknown, feedback: unknown): { time: string | number; feedback?: number } => ({
+  time: parse(schemaDelayTime, time, 'delay', 'Use seconds or note value e.g. .delay(0.375) or .delay("8n").'),
+  ...(feedback !== undefined
+    ? { feedback: parse(schemaFeedback, feedback, 'delay', 'Use a feedback value 0–0.99 e.g. .delay("8n", 0.4).') }
+    : {}),
+})
+
+/** `.chorus(depth?)` / `.flange(depth?)` / `.wobble(depth)` — 0–1. */
+export const validateModDepth = (depth: unknown, method: string): number =>
+  parse(schemaLfoDepth, depth, method, `Use a depth 0–1 e.g. .${method}(0.5).`)
+
+/** `.tremolo(rate, depth?)` / `.vibrato(rate, depth?)` / `.autopan(rate, depth?)` / `.flutter(rate?)` / `.breathe(rate?)` — rate: 0.01–50 Hz. */
+export const validateLfoRate = (rate: unknown, method: string): number =>
+  parse(schemaLfoRate, rate, method, `Use a rate 0.01–50 Hz e.g. .${method}(4).`)
+
+/** `.swell(bars)` — non-negative number of bars. */
+export const validateSwell = (bars: unknown): number =>
+  parse(schemaSwellBars, bars, 'swell', 'Use a non-negative number e.g. .swell(2).')
+
+// ── Routing ───────────────────────────────────────────────────────────────────
+
+/** `.send(bus, amount?)` — bus: non-empty string, amount: 0–1. */
+export const validateSend = (bus: unknown, amount: unknown): { bus: string; amount: number } => ({
+  bus:    parse(schemaSendBus,    bus,    'send', 'Use a bus name string e.g. .send("reverb", 0.3).'),
+  amount: parse(schemaSendAmount, amount, 'send', 'Use an amount 0–1 e.g. .send("reverb", 0.3).'),
+})
+
+/** `.chokeGroup(name)` — non-empty string. */
+export const validateChokeGroup = (name: unknown): string =>
+  parse(schemaChokeGroup, name, 'chokeGroup', 'Use a group name string e.g. .chokeGroup("hats").')
+
+// ── Modulation ────────────────────────────────────────────────────────────────
+
+/** `.modulate(param, source)` — param: non-empty string. */
+export const validateModulateParam = (param: unknown): string =>
+  parse(schemaModulationParam, param, 'modulate', 'Use a param name string e.g. .modulate("frequency", lfo(2)).')
+
+// ── Visual / metadata ─────────────────────────────────────────────────────────
+
+/** `.color(hex)` — CSS hex color. */
+export const validateColor = (hex: unknown): string =>
+  parse(schemaHexColor, hex, 'color', 'Use a CSS hex color e.g. .color("#ff3366").')
+
+/** `.glyph(kind)` — non-empty string. */
+export const validateGlyph = (kind: unknown): string =>
+  parse(schemaGlyphKind, kind, 'glyph', 'Use a glyph kind string e.g. .glyph("kick").')
+
+/** `.label(text)` / `.name(label)` — non-empty string. */
+export const validateLabel = (text: unknown, method: string): string =>
+  parse(schemaNameLabel, text, method, `Use a non-empty string e.g. .${method}("kick").`)
+
+/** `.seed(n)` — non-negative integer. */
+export const validateSeed = (n: unknown): number =>
+  parse(schemaSeedValue, n, 'seed', 'Use a non-negative integer e.g. .seed(42).')
+
+/** Visual `.opacity(v)` override — 0–1. */
+export const validateOpacity = (v: unknown): number =>
+  parse(schemaOpacity, v, 'opacity', 'Use a number 0–1 e.g. .opacity(0.8).')
+
+/** `.gain(v)` on effects — 0–2. */
+export const validateGain = (v: unknown): number =>
+  parse(schemaGain, v, 'gain', 'Use a number 0–2 e.g. .gain(0.8).')
+
+/** `.model(variant)` — non-empty string. */
+export const validateModel = (variant: unknown): string =>
+  parse(z.string().min(1), variant, 'model', 'Use a variant string e.g. .model("909").')
+
+/** `.stretch(bars)` bar count for integer bar counts — positive integer. */
+export const validateBarCount = (n: unknown): number =>
+  parse(schemaBarCount, n, 'bars', 'Use a positive integer e.g. 4.')

--- a/packages/gui/src/renderer/components/visualizer/PunchcardGrid.tsx
+++ b/packages/gui/src/renderer/components/visualizer/PunchcardGrid.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useState } from 'react'
+import { memo, useRef, useEffect, useState, useId, useCallback } from 'react'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -6,6 +6,11 @@ export type PunchcardTrack = {
   readonly name:    string
   readonly type:    string
   readonly pattern: ReadonlyArray<number | string>
+}
+
+type ActiveCell = {
+  readonly track: number
+  readonly step:  number
 }
 
 type Props = {
@@ -73,6 +78,7 @@ const drawGrid = (
   height:        number,
   flash:         boolean,
   selectedTrack: number | null | undefined,
+  activeCell:    ActiveCell | null,
 ): void => {
   // Background
   ctx.fillStyle = BG_COLOR
@@ -153,6 +159,28 @@ const drawGrid = (
 
   ctx.fillStyle = flash ? CURSOR_OVERLAY_FLASH : CURSOR_OVERLAY
   ctx.fillRect(cursorX, 0, cellWidth, totalHeight)
+
+  // Active keyboard cell — bright outline for keyboard focus navigation
+  if (activeCell !== null && activeCell.track < tracks.length) {
+    const activeCellRowY = activeCell.track * (ROW_HEIGHT + ROW_GAP)
+    const activeCellX    = LABEL_WIDTH + activeCell.step * (cellWidth + CELL_GAP)
+    ctx.strokeStyle      = '#ffffff'
+    ctx.lineWidth        = 1.5
+    ctx.strokeRect(activeCellX + 0.75, activeCellRowY + 0.75, cellWidth - 1.5, ROW_HEIGHT - 1.5)
+  }
+}
+
+// ── Visually-hidden style (screen reader only) ─────────────────────────────────
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width:    1,
+  height:   1,
+  padding:  0,
+  margin:   -1,
+  overflow: 'hidden',
+  clip:     'rect(0,0,0,0)',
+  border:   0,
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -160,6 +188,8 @@ const drawGrid = (
 /**
  * Canvas-based punchcard grid visualizer for Score Studio.
  * Renders one row per track, with step cells and a playhead cursor column.
+ * Fully keyboard-navigable: arrow keys move the active cell, Space/Enter
+ * toggle the selected step, Escape returns focus to the parent.
  *
  * @param tracks      - Array of tracks to display, each with a step pattern.
  * @param currentStep - Zero-based index of the currently playing step.
@@ -175,8 +205,10 @@ const drawGrid = (
  * ```
  */
 const PunchcardGridInner = ({ tracks, currentStep, stepCount, onStepClick, onLabelClick, selectedTrack }: Props) => {
-  const canvasRef         = useRef<HTMLCanvasElement>(null)
-  const [flash, setFlash] = useState(false)
+  const canvasRef                     = useRef<HTMLCanvasElement>(null)
+  const [flash,      setFlash]        = useState(false)
+  const [activeCell, setActiveCell]   = useState<ActiveCell | null>(null)
+  const descId                        = useId()
 
   // Beat flash: pulse on step 0
   useEffect(() => {
@@ -202,8 +234,8 @@ const PunchcardGridInner = ({ tracks, currentStep, stepCount, onStepClick, onLab
     if (ctx === null) return
 
     ctx.scale(dpr, dpr)
-    drawGrid(ctx, tracks, currentStep, stepCount, width, height, flash, selectedTrack)
-  }, [tracks, currentStep, stepCount, flash, selectedTrack])
+    drawGrid(ctx, tracks, currentStep, stepCount, width, height, flash, selectedTrack, activeCell)
+  }, [tracks, currentStep, stepCount, flash, selectedTrack, activeCell])
 
   const handleClick = (e: React.MouseEvent<HTMLCanvasElement>): void => {
     const canvas = canvasRef.current
@@ -234,23 +266,129 @@ const PunchcardGridInner = ({ tracks, currentStep, stepCount, onStepClick, onLab
     onStepClick(trackIndex, stepIndex)
   }
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLCanvasElement>): void => {
+    if (tracks.length === 0) return
+
+    // Initialise active cell on first keypress if none is set
+    const current: ActiveCell = activeCell ?? { track: 0, step: 0 }
+
+    switch (e.key) {
+      case 'ArrowRight': {
+        e.preventDefault()
+        const rightTrack    = tracks[current.track]
+        const rightTrackLen = rightTrack
+          ? (rightTrack.pattern.length > 0 ? rightTrack.pattern.length : stepCount)
+          : stepCount
+        setActiveCell({ track: current.track, step: (current.step + 1) % rightTrackLen })
+        break
+      }
+      case 'ArrowLeft': {
+        e.preventDefault()
+        const leftTrack    = tracks[current.track]
+        const leftTrackLen = leftTrack
+          ? (leftTrack.pattern.length > 0 ? leftTrack.pattern.length : stepCount)
+          : stepCount
+        setActiveCell({ track: current.track, step: (current.step - 1 + leftTrackLen) % leftTrackLen })
+        break
+      }
+      case 'ArrowDown': {
+        e.preventDefault()
+        const nextTrack     = Math.min(current.track + 1, tracks.length - 1)
+        const nextTrackData = tracks[nextTrack]
+        const nextLen       = nextTrackData
+          ? (nextTrackData.pattern.length > 0 ? nextTrackData.pattern.length : stepCount)
+          : stepCount
+        setActiveCell({ track: nextTrack, step: Math.min(current.step, nextLen - 1) })
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prevTrack     = Math.max(current.track - 1, 0)
+        const prevTrackData = tracks[prevTrack]
+        const prevLen       = prevTrackData
+          ? (prevTrackData.pattern.length > 0 ? prevTrackData.pattern.length : stepCount)
+          : stepCount
+        setActiveCell({ track: prevTrack, step: Math.min(current.step, prevLen - 1) })
+        break
+      }
+      case 'Home': {
+        e.preventDefault()
+        setActiveCell({ track: current.track, step: 0 })
+        break
+      }
+      case 'End': {
+        e.preventDefault()
+        const endTrack    = tracks[current.track]
+        const endTrackLen = endTrack
+          ? (endTrack.pattern.length > 0 ? endTrack.pattern.length : stepCount)
+          : stepCount
+        setActiveCell({ track: current.track, step: endTrackLen - 1 })
+        break
+      }
+      case ' ':
+      case 'Enter': {
+        e.preventDefault()
+        if (onStepClick) {
+          onStepClick(current.track, current.step)
+        }
+        break
+      }
+      case 'Escape': {
+        setActiveCell(null)
+        canvasRef.current?.blur()
+        break
+      }
+      default:
+        break
+    }
+  }, [activeCell, tracks, stepCount, onStepClick])
+
+  const handleFocus = useCallback((): void => {
+    if (activeCell === null && tracks.length > 0) {
+      setActiveCell({ track: 0, step: 0 })
+    }
+  }, [activeCell, tracks.length])
+
+  const handleBlur = useCallback((): void => {
+    setActiveCell(null)
+  }, [])
+
   const canvasHeight =
     tracks.length === 0
       ? 60
       : tracks.length * (ROW_HEIGHT + ROW_GAP) - ROW_GAP
 
+  const ariaLabel =
+    tracks.length === 0
+      ? 'Punchcard sequencer grid, empty'
+      : `Punchcard sequencer grid, ${String(tracks.length)} tracks, ${String(stepCount)} steps`
+
   return (
-    <canvas
-      ref={canvasRef}
-      onClick={onStepClick ?? onLabelClick ? handleClick : undefined}
-      style={{
-        width:          '100%',
-        height:         `${String(canvasHeight)}px`,
-        display:        'block',
-        imageRendering: 'pixelated',
-        cursor:         onStepClick ? 'pointer' : 'default',
-      }}
-    />
+    <div style={{ display: 'contents' }}>
+      <canvas
+        ref={canvasRef}
+        role="application"
+        aria-label={ariaLabel}
+        aria-describedby={descId}
+        tabIndex={0}
+        onClick={onStepClick ?? onLabelClick ? handleClick : undefined}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        style={{
+          width:          '100%',
+          height:         `${String(canvasHeight)}px`,
+          display:        'block',
+          imageRendering: 'pixelated',
+          cursor:         onStepClick ? 'pointer' : 'default',
+        }}
+      />
+      <span id={descId} style={srOnlyStyle}>
+        Use arrow keys to navigate steps. Space or Enter to toggle a step.
+        Home moves to the first step, End to the last.
+        Escape returns focus to the main content.
+      </span>
+    </div>
   )
 }
 

--- a/packages/gui/tests/PunchcardGrid.test.tsx
+++ b/packages/gui/tests/PunchcardGrid.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi }  from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe }                       from './setup.js'
+import { PunchcardGrid }             from '../src/renderer/components/visualizer/PunchcardGrid.js'
+import type { PunchcardTrack }       from '../src/renderer/components/visualizer/PunchcardGrid.js'
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ONE_TRACK: ReadonlyArray<PunchcardTrack> = [
+  { name: 'Kick', type: 'kick', pattern: [1, 0, 0, 0, 1, 0, 0, 0] },
+]
+
+const TWO_TRACKS: ReadonlyArray<PunchcardTrack> = [
+  { name: 'Kick',  type: 'kick',  pattern: [1, 0, 0, 0, 1, 0, 0, 0] },
+  { name: 'Snare', type: 'snare', pattern: [0, 0, 1, 0, 0, 0, 1, 0] },
+]
+
+const setup = (
+  tracks:      ReadonlyArray<PunchcardTrack> = ONE_TRACK,
+  onStepClick?: (t: number, s: number) => void,
+) => render(
+  <PunchcardGrid
+    tracks={tracks}
+    currentStep={0}
+    stepCount={8}
+    {...(onStepClick !== undefined ? { onStepClick } : {})}
+  />,
+)
+
+const getGrid = () => screen.getByRole('application')
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('PunchcardGrid — rendering', () => {
+  it('renders a canvas with application role', () => {
+    setup()
+    expect(getGrid()).toBeInTheDocument()
+  })
+
+  it('has aria-label describing track and step count', () => {
+    setup(TWO_TRACKS)
+    expect(getGrid()).toHaveAttribute('aria-label', 'Punchcard sequencer grid, 2 tracks, 8 steps')
+  })
+
+  it('empty grid aria-label says empty', () => {
+    setup([])
+    expect(getGrid()).toHaveAttribute('aria-label', 'Punchcard sequencer grid, empty')
+  })
+
+  it('has aria-describedby linking to usage instructions', () => {
+    setup()
+    const descId = getGrid().getAttribute('aria-describedby')
+    expect(descId).toBeTruthy()
+    const desc = document.getElementById(descId!)
+    expect(desc).toBeInTheDocument()
+    expect(desc?.textContent).toMatch(/arrow keys/i)
+    expect(desc?.textContent).toMatch(/space or enter/i)
+    expect(desc?.textContent).toMatch(/escape/i)
+  })
+
+  it('is Tab-focusable (tabIndex 0)', () => {
+    setup()
+    expect(getGrid()).toHaveAttribute('tabindex', '0')
+  })
+})
+
+// ── Keyboard navigation ───────────────────────────────────────────────────────
+
+describe('PunchcardGrid — keyboard navigation', () => {
+  it('ArrowRight calls onStepClick at step 1 after two presses then Space', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'ArrowRight' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    // Active cell started at 0 on focus, moved to 1 via ArrowRight
+    expect(onStepClick).toHaveBeenCalledWith(0, 1)
+  })
+
+  it('Space at default position (0,0) fires onStepClick(0, 0)', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: ' ' })
+    expect(onStepClick).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('Enter at default position fires onStepClick(0, 0)', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'Enter' })
+    expect(onStepClick).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('ArrowDown moves to second track, Space fires onStepClick(1, 0)', () => {
+    const onStepClick = vi.fn()
+    setup(TWO_TRACKS, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'ArrowDown' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    expect(onStepClick).toHaveBeenCalledWith(1, 0)
+  })
+
+  it('ArrowUp does not go below track 0', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'ArrowUp' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    // Should still be track 0
+    expect(onStepClick).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('ArrowLeft wraps from step 0 to last step', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'ArrowLeft' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    // Wrap: step 0 - 1 → step 7 (pattern length 8)
+    expect(onStepClick).toHaveBeenCalledWith(0, 7)
+  })
+
+  it('ArrowRight wraps from last step to step 0', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    // Move to last step (7) then one more right → wraps to 0
+    for (let i = 0; i < 8; i++) fireEvent.keyDown(grid, { key: 'ArrowRight' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    expect(onStepClick).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('Home moves to step 0', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'ArrowRight' })
+    fireEvent.keyDown(grid, { key: 'ArrowRight' })
+    fireEvent.keyDown(grid, { key: 'Home' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    expect(onStepClick).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('End moves to last step', () => {
+    const onStepClick = vi.fn()
+    setup(ONE_TRACK, onStepClick)
+    const grid = getGrid()
+    grid.focus()
+    fireEvent.keyDown(grid, { key: 'End' })
+    fireEvent.keyDown(grid, { key: ' ' })
+    expect(onStepClick).toHaveBeenCalledWith(0, 7)
+  })
+
+  it('Space does nothing when no onStepClick provided', () => {
+    // Should not throw
+    setup(ONE_TRACK, undefined)
+    const grid = getGrid()
+    grid.focus()
+    expect(() => { fireEvent.keyDown(grid, { key: ' ' }) }).not.toThrow()
+  })
+
+  it('keyboard events on empty grid do not throw', () => {
+    setup([])
+    const grid = getGrid()
+    grid.focus()
+    expect(() => {
+      fireEvent.keyDown(grid, { key: 'ArrowRight' })
+      fireEvent.keyDown(grid, { key: ' ' })
+    }).not.toThrow()
+  })
+})
+
+// ── Accessibility ─────────────────────────────────────────────────────────────
+
+describe('PunchcardGrid — accessibility', () => {
+  it('has no axe violations (with tracks)', async () => {
+    const { container } = setup(TWO_TRACKS)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations (empty)', async () => {
+    const { container } = setup([])
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/gui/tests/setup.ts
+++ b/packages/gui/tests/setup.ts
@@ -18,7 +18,7 @@ export const axe = configureAxe({
 // jsdom does not implement canvas. Stub getContext so canvas components mount
 // without throwing "Not implemented: HTMLCanvasElement.prototype.getContext".
 HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-  clearRect: vi.fn(), fillRect: vi.fn(), fillText: vi.fn(),
+  clearRect: vi.fn(), fillRect: vi.fn(), strokeRect: vi.fn(), fillText: vi.fn(),
   scale: vi.fn(), setTransform: vi.fn(), transform: vi.fn(),
   save: vi.fn(), restore: vi.fn(),
   beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@score/pattern':
         specifier: workspace:*
         version: link:../pattern
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -268,10 +271,10 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0)(jsdom@25.0.1)(terser@5.46.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0)(jsdom@29.0.1)(terser@5.46.1))
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@25.5.0)(jsdom@25.0.1)(terser@5.46.1)
+        version: 2.1.9(@types/node@25.5.0)(jsdom@29.0.1)(terser@5.46.1)
 
   packages/math:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds runtime input validators for ~50 chain methods using Zod schemas
- Grouped by domain (timing, volume, pitch, rhythm, fx) with `ScoreError` + fix hints on bad input
- Extracts `chain.types.ts` — ChainMethod type definitions in their own file for cleaner separation
- Wires `validateChainInput` at chain entry points so invalid params throw early with actionable messages

Also includes t358 PunchcardGrid keyboard accessibility (rebased in from a prior branch).

## Test plan

- [ ] CI typecheck + lint + test all green
- [ ] Passing an out-of-range `volume()` call throws `ScoreError` with a fix hint
- [ ] Passing an invalid timing value throws `ScoreError`
- [ ] All existing chain tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)