### PR TITLE
docs(readme): link CoC and SECURITY, clarify license status

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ pnpm --filter @score/gui dev
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). All contributors must agree to the [CLA](./CLA.md) before their PR can be merged.
 
+Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. To report a security issue, see [SECURITY.md](./SECURITY.md).
+
 ---
 
 ## License
 
-Open source — license TBD. Author: Bree Yard.
+Source-available — license TBD (pre-release). Author: Bree Yard.

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. To
 
 ## License
 
-Open source. Free for personal, non-commercial, and individual commercial use. Corporations distributing Score or building commercial products on top of it require a separate license — contact byard29@gmail.com. Author: Bree Yard.
+Open source. Free for personal, non-commercial, and individual commercial use. Corporations distributing Score or building commercial products on top of it require a separate license. Nonprofits may reach out for a license exception. Contact byard29@gmail.com. Author: Bree Yard.

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. To
 
 ## License
 
-Source-available — license TBD (pre-release). Author: Bree Yard.
+Open source for non-commercial use. Individual commercial use (personal projects, freelance work) is permitted. Corporate/enterprise licensing TBD. Author: Bree Yard.

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. To
 
 ## License
 
-Open source for non-commercial use. Individual commercial use (personal projects, freelance work) is permitted. Corporate/enterprise licensing TBD. Author: Bree Yard.
+Open source. Free for personal, non-commercial, and individual commercial use. Corporations distributing Score or building commercial products on top of it require a separate license — contact byard29@gmail.com. Author: Bree Yard.


### PR DESCRIPTION
## Summary

- Contributing section now links to CODE_OF_CONDUCT.md and SECURITY.md (added in #117)
- License line updated from "Open source — TBD" to "Source-available — TBD" — more accurate before a license is formally chosen

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All three links resolve (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)