### PR TITLE
feat: HihatOpen808 instrument + registry scalability refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ This is what makes SCORE a reference implementation rather than just another aud
 - **Pure functions where possible** — predictable inputs/outputs, no hidden side effects
 - **`const` + arrow functions** — no `let`, no `function` declarations, no classes
 - **No exceptions** — `ScoreError` is a factory function, not a class
+- **Minimize comments** — code is self-documenting through descriptive names. Keep: TSDoc on public exports, BOUNDARY annotations, section dividers, genuinely non-obvious WHY. Remove everything else.
 
 The song language should feel like writing Svelte — declarative, component-based, props in, music out:
 

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -35,6 +35,10 @@ import {
 import {
   INSTRUMENT_REGISTRY,
   EFFECTS_REGISTRY,
+  PERCUSSION_INSTRUMENT_TYPES,
+  MELODIC_VOICE_INSTRUMENT_TYPES,
+  MELODIC_INSTRUMENT_TYPE_SET,
+  DEFAULT_KICK_PATTERN,
   type InstrumentType,
   type EffectType,
   type GenericSynthComponent,
@@ -107,26 +111,14 @@ export const isPartDescriptor = (comp: unknown): comp is PartDescriptor => {
 }
 
 // ── Instrument classification ─────────────────────────────────────────────────
-// PERCUSSION_REGISTRY_TYPES — Model A: create-once, trigger per hit
-// MELODIC_VOICE_TYPES       — Model B': per-step voice creation (noteOn/noteOff)
-// Remaining types handled inline: synth (B), theremin/sax (C), arp (D), sample (E)
+// Derived automatically from INSTRUMENT_REGISTRY — no manual maintenance needed.
+// When adding a new instrument: add its entry to @score/instruments/src/index.ts.
+// These sets update on their own.
 
-const PERCUSSION_REGISTRY_TYPES = new Set<InstrumentType>([
-  'kick', 'snare', 'hihat', 'kick808', 'kick909', 'hihat808', 'snare909',
-])
-
-const MELODIC_VOICE_TYPES = new Set<InstrumentType>([
-  'subsynth', 'fmsynth', 'pad', 'rhodes', 'pluck', 'bass-303',
-])
-
-// Used by normalizeVolumeField and partToInstrumentDescriptor ADSR spread
-const PERCUSSION_TYPES = PERCUSSION_REGISTRY_TYPES
-
-// Used by partToInstrumentDescriptor to route _volume → gain (melodic) or volume (percussion)
-const MELODIC_INSTRUMENT_TYPES = new Set([
-  'synth', 'subsynth', 'fmsynth', 'arp', 'theremin', 'sax', 'sample',
-  'pad', 'rhodes', 'pluck', 'bass-303',
-])
+// Aliases for local readability — same objects exported by @score/instruments.
+const PERCUSSION_REGISTRY_TYPES = PERCUSSION_INSTRUMENT_TYPES
+const MELODIC_VOICE_TYPES        = MELODIC_VOICE_INSTRUMENT_TYPES
+const PERCUSSION_TYPES           = PERCUSSION_INSTRUMENT_TYPES
 
 // ── Pitch helpers ─────────────────────────────────────────────────────────────
 
@@ -181,7 +173,7 @@ const normalizeVolumeField = (
   volume: number | undefined,
 ): { readonly gain: number } | { readonly volume: number } | Record<never, never> => {
   if (volume === undefined) return {}
-  return MELODIC_INSTRUMENT_TYPES.has(instrumentType) ? { gain: volume } : { volume }
+  return MELODIC_INSTRUMENT_TYPE_SET.has(instrumentType) ? { gain: volume } : { volume }
 }
 
 /**
@@ -299,22 +291,14 @@ const seqExtras = (
 })
 
 // ── Default patterns ──────────────────────────────────────────────────────────
+// Percussion defaults live in INSTRUMENT_REGISTRY entries (defaultPattern field).
+// DEFAULT_KICK_PATTERN is imported above as the fallback for unknown percussion types.
+// DEFAULT_SYNTH_PATTERN is local — only the synth/melodic dispatchers use it.
 
-const DEFAULT_KICK_PATTERN  = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
-const DEFAULT_SNARE_PATTERN = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
-const DEFAULT_HIHAT_PATTERN = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
 const DEFAULT_SYNTH_PATTERN = [1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
 
-// Per-type default patterns for percussion dispatch.
-const PERCUSSION_DEFAULT_PATTERNS: Readonly<Partial<Record<InstrumentType, readonly number[]>>> = {
-  kick:     DEFAULT_KICK_PATTERN,
-  snare:    DEFAULT_SNARE_PATTERN,
-  hihat:    DEFAULT_HIHAT_PATTERN,
-  kick808:  DEFAULT_KICK_PATTERN,
-  kick909:  DEFAULT_KICK_PATTERN,
-  hihat808: DEFAULT_HIHAT_PATTERN,
-  snare909: DEFAULT_SNARE_PATTERN,
-}
+// Per-type default patterns come from INSTRUMENT_REGISTRY entries (.defaultPattern).
+// DEFAULT_KICK_PATTERN stays here as the fallback for unknown percussion types.
 
 // ── seqPatternExtras — thread pattern-transform props into createStepSequencer ─
 // Reads mask/stepProb/every/stretch from comp.props and returns the subset that
@@ -606,7 +590,7 @@ const dispatchPercussion = (
     ...(props.volume !== undefined ? { gain: props.volume } : {}),
   }
 
-  const factory = INSTRUMENT_REGISTRY[instrumentType] as unknown as (
+  const factory = INSTRUMENT_REGISTRY[instrumentType].factory as unknown as (
     ctx: Context,
     props: CommonProps,
   ) => PercussionComponent
@@ -614,7 +598,7 @@ const dispatchPercussion = (
   const component = factory(ctx, factoryProps)
   component.connect(dest)
 
-  const defaultPattern = PERCUSSION_DEFAULT_PATTERNS[instrumentType] ?? DEFAULT_KICK_PATTERN
+  const defaultPattern = (INSTRUMENT_REGISTRY[instrumentType] as { defaultPattern?: readonly number[] }).defaultPattern ?? DEFAULT_KICK_PATTERN
   const pattern = (props.pattern ?? defaultPattern) as PatternInput
 
   createStepSequencer(transport, { pattern, ...timing, ...seqPatternExtras(props) }, (hit, _step, pos) => {
@@ -637,7 +621,7 @@ const dispatchSynth = (
   const rawPattern = (props.pattern ?? props.sequence ?? DEFAULT_SYNTH_PATTERN) as PatternInput
   const pattern = (Array.isArray(rawPattern) ? rawPattern : DEFAULT_SYNTH_PATTERN) as (number | string)[]
 
-  const synthComponent = (INSTRUMENT_REGISTRY['synth'] as unknown as (ctx: Context, props: CommonProps) => GenericSynthComponent)(ctx, props)
+  const synthComponent = (INSTRUMENT_REGISTRY['synth'].factory as unknown as (ctx: Context, props: CommonProps) => GenericSynthComponent)(ctx, props)
   synthComponent.connect(dest)
 
   createStepSequencer(transport, { pattern, ...timing, ...seqPatternExtras(props) }, (val, _step, pos) => {
@@ -663,7 +647,7 @@ const dispatchMelodicVoice = (
   const pattern = (Array.isArray(rawPattern) ? rawPattern : DEFAULT_SYNTH_PATTERN) as (number | string)[]
   const noteDur = computeNoteDur(instrumentType, props)
 
-  const factory = INSTRUMENT_REGISTRY[instrumentType] as unknown as (
+  const factory = INSTRUMENT_REGISTRY[instrumentType].factory as unknown as (
     ctx: Context,
     props: CommonProps,
   ) => MelodicVoiceComponent

--- a/packages/components/src/drums/hihat808.ts
+++ b/packages/components/src/drums/hihat808.ts
@@ -140,3 +140,36 @@ export const createHihat808 = (
 
   return component
 }
+
+/**
+ * Create a synthesized 808-style open hi-hat component.
+ *
+ * Sugar for {@link createHihat808} with `open: true` fixed — uses a longer
+ * default decay (0.3 s) that gives the sustained, washy open-hat character.
+ * Accepts the same props as {@link createHihat808} except `open` is ignored.
+ *
+ * @param context - Backend audio context providing the Web Audio graph.
+ * @param props - Optional configuration. `decay` defaults to `0.3`; `open` is always `true`.
+ * @returns A {@link Hihat808Component} with `id` prefixed `hihatopen808` and `type` set to `'hihatopen808'`.
+ *
+ * @example
+ * ```ts
+ * const openHat = createHihatOpen808(context, { decay: 0.4 })
+ * openHat.connect(context.destination)
+ * openHat.trigger(context.currentTime)
+ * ```
+ *
+ * @see {@link createHihat808} — closed variant
+ * @throws \{ScoreError\} Never — invalid props are silently clamped.
+ */
+export const createHihatOpen808 = (
+  context: ScoreAudioContext,
+  props?: Omit<Hihat808Props, 'open'>,
+): Hihat808Component => {
+  const component = createHihat808(context, { ...props, open: true })
+  return {
+    ...component,
+    id: uid('hihatopen808'),
+    type: 'hihatopen808' as const,
+  }
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -9,7 +9,7 @@ export { Theremin, type ThereminProps, type ThereminComponent } from './theremin
 export { Sax, type SaxProps, type SaxComponent } from './sax.js'
 export { createKick808, type Kick808Props, type PercussionComponent } from './drums/kick808.js'
 export { createKick909, type Kick909Props, type Kick909Component } from './drums/kick909.js'
-export { createHihat808, type Hihat808Props, type Hihat808Component } from './drums/hihat808.js'
+export { createHihat808, createHihatOpen808, type Hihat808Props, type Hihat808Component } from './drums/hihat808.js'
 export { createSnare909, type Snare909Props, type Snare909Component } from './drums/snare909.js'
 export { createSubtractiveSynth, type SubtractiveSynthProps, type SubtractiveSynthComponent } from './synths/subtractive.js'
 export { createFMSynth, type FMSynthProps, type FMSynthComponent, type FMSynthAmpAdsr, type FMSynthModAdsr } from './synths/fm.js'

--- a/packages/dsl/src/chain.ts
+++ b/packages/dsl/src/chain.ts
@@ -48,7 +48,26 @@ export type {
   ChainablePart,
 } from './chain.types.js'
 
-import type { PartDescriptor, ChainablePart } from './chain.types.js'
+import type { PartDescriptor, ChainablePart, ChainMethods } from './chain.types.js'
+
+// ── Simple effect chain methods — data-driven ─────────────────────────────────
+//
+// Each entry maps a chain method name to its effect type + argument → props transform.
+// Adding a new simple effect: one line here + one declaration in chain.types.ts.
+// The generated methods are spread into the `part` object inside createPart().
+
+type SimpleFxEntry = {
+  readonly effectType: string
+  readonly toProps:    (...args: number[]) => Record<string, unknown>
+}
+
+const SIMPLE_FX: ReadonlyArray<SimpleFxEntry & { readonly method: string }> = [
+  { method: 'distortion', effectType: 'distortion', toProps: (amount = 0.5)            => ({ drive: Math.max(0, Math.min(1, amount)) }) },
+  { method: 'phaser',     effectType: 'phaser',     toProps: (depth = 0.5, rate = 1)   => ({ depth: Math.max(0, Math.min(1, depth)), rate: Math.max(0.1, rate) }) },
+  { method: 'compressor', effectType: 'compressor', toProps: (threshold = -24, ratio = 4) => ({ threshold, ratio: Math.max(1, ratio) }) },
+  { method: 'limiter',    effectType: 'limiter',    toProps: (ceiling = -1)             => ({ ceiling }) },
+  { method: 'gate',       effectType: 'gate',       toProps: (threshold = -40, ratio = 10) => ({ threshold, ratio: Math.max(1, ratio) }) },
+]
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -278,6 +297,13 @@ export const createPart = (
     },
     chorus: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('chorus',  { depth: validateModDepth(depth,  'chorus') })) }),
     flange: (depth = 0.5) => cp({ ...desc, ...appendFx(desc, makeFx('flanger', { depth: validateModDepth(depth,  'flange') })) }),
+
+    // Generated from SIMPLE_FX table — distortion, phaser, compressor, limiter, gate.
+    // Type-asserted because TypeScript cannot infer individual signatures from the table.
+    ...Object.fromEntries(SIMPLE_FX.map(({ method, effectType, toProps }) => [
+      method,
+      (...args: number[]) => cp({ ...desc, ...appendFx(desc, makeFx(effectType, toProps(...args))) }),
+    ])) as Pick<ChainMethods<ChainablePart>, 'distortion' | 'phaser' | 'compressor' | 'limiter' | 'gate'>,
 
     // ── Routing ───────────────────────────────────────────────────────────────
     send: (bus, amount = 1) => {

--- a/packages/dsl/src/chain.ts
+++ b/packages/dsl/src/chain.ts
@@ -332,7 +332,20 @@ export const createPart = (
     // ── Meta ──────────────────────────────────────────────────────────────────
     seed:  (n)       => cp({ ...desc, _seed:  validateSeed(n) }),
     name:  (label)   => cp({ ...desc, _name:  validateLabel(label, 'name') }),
-    model: (variant) => cp({ ...desc, _model: validateModel(variant) }),
+    model: (variant) => {
+      const v = validateModel(variant)
+      const newType = `${desc.instrumentType}${v}`
+      return cp({ ...desc, instrumentType: newType, type: newType, _model: v })
+    },
+    open: () => {
+      // Maps base instrument types to their open counterparts.
+      // Add new open variants here as they are registered in INSTRUMENT_REGISTRY.
+      const OPEN_INSTRUMENT_MAP: Readonly<Partial<Record<string, string>>> = {
+        'hihat808': 'hihatopen808',
+      }
+      const openType = OPEN_INSTRUMENT_MAP[desc.instrumentType] ?? desc.instrumentType
+      return cp({ ...desc, instrumentType: openType, type: openType })
+    },
 
     // ── Visual ────────────────────────────────────────────────────────────────
     visual: (override) => cp({ ...desc, _visual: { ...desc._visual, ...override } }),

--- a/packages/dsl/src/chain.types.ts
+++ b/packages/dsl/src/chain.types.ts
@@ -266,6 +266,16 @@ export type ChainMethods<T> = {
   readonly bit:         (bits: number) => T
   /** Overdrive / saturation warmth (0–1). */
   readonly saturate:    (amt: number) => T
+  /** Waveshaper distortion (0–1 drive). */
+  readonly distortion:  (amount?: number) => T
+  /** Phaser sweep — depth 0–1, rate Hz. */
+  readonly phaser:      (depth?: number, rate?: number) => T
+  /** Dynamics compressor — threshold dBFS, ratio n:1. */
+  readonly compressor:  (threshold?: number, ratio?: number) => T
+  /** Hard limiter — ceiling dBFS. */
+  readonly limiter:     (ceiling?: number) => T
+  /** Noise gate — threshold dBFS, ratio n:1. */
+  readonly gate:        (threshold?: number, ratio?: number) => T
   // ── Space ────────────────────────────────────────────────────────────────
   /** Stereo position -1 (left) to 1 (right). */
   readonly pan:         (v: number) => T

--- a/packages/dsl/src/chain.types.ts
+++ b/packages/dsl/src/chain.types.ts
@@ -324,8 +324,17 @@ export type ChainMethods<T> = {
   readonly seed:        (n: number) => T
   /** Human-readable label for GUI mixer and codePatcher. */
   readonly name:        (label: string) => T
-  /** Model variant (percussion only): '808' | '909' | 'hard'. */
+  /**
+   * Model variant — changes `instrumentType` to `${baseType}${variant}`.
+   * e.g. `Kick().model('808')` → `instrumentType: 'kick808'` (routes to `createKick808`).
+   */
   readonly model:       (variant: string) => T
+  /**
+   * Open variant — converts a closed hi-hat to its open counterpart.
+   * e.g. `HiHat().model('808').open()` → `instrumentType: 'hihatopen808'`.
+   * Only valid after `.model()` sets a model that has an open variant registered.
+   */
+  readonly open:        () => T
   // ── Visual chain methods ──────────────────────────────────────────────────
   /**
    * Set all visual override fields at once.

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -3,7 +3,7 @@ export { Intro, Buildup, Drop, Breakdown, Outro } from './sections.js'
 export { Track } from './track.js'
 export { Sequence } from './sequence.js'
 export { Synth, Sample, Theremin, Sax, Arp } from './instruments.js'
-export { Kick, Snare, HiHat, Kick808, Kick909, Hihat808, Snare909 } from './percussion.js'
+export { Kick, Snare, HiHat, Kick808, Kick909, Hihat808, HihatOpen808, Snare909 } from './percussion.js'
 export { Bass303, SubSynth, FMSynth, Pad, Pluck, Stab, Rhodes, Wurlitzer, Hammond, Clavinet, DX7Lead, WavetableSynth, SuperSaw, KarplusSynth, Guitar, AcousticGuitar, BassGuitar, Trumpet, Trombone, FrenchHorn, Flugelhorn } from './melodic.js'
 export type { Bass303Part, FMSynthPart, SubSynthPart } from './melodic.js'
 export { chord, scale, progression, Scale, Progression } from './theory.js'
@@ -54,6 +54,7 @@ export type {
   Kick808DSLProps,
   Kick909DSLProps,
   Hihat808DSLProps,
+  HihatOpen808DSLProps,
   Snare909DSLProps,
   SubSynthDSLProps,
   FMSynthDSLProps,

--- a/packages/dsl/src/instruments.ts
+++ b/packages/dsl/src/instruments.ts
@@ -6,7 +6,16 @@
 
 import type { BackendNode } from '@score/core'
 import { uid } from '@score/core'
-import type { InstrumentDescriptor, KickProps, SnareProps, HiHatProps, SynthDSLProps, SampleProps, ThereminDSLProps, SaxDSLProps, ArpDSLProps, Kick808DSLProps, Kick909DSLProps, Hihat808DSLProps, Snare909DSLProps, SubSynthDSLProps, FMSynthDSLProps } from './types.js'
+import type {
+  InstrumentDescriptor,
+  KickProps, SnareProps, HiHatProps,
+  SynthDSLProps, SampleProps,
+  ThereminDSLProps, SaxDSLProps, ArpDSLProps,
+  Kick808DSLProps, Kick909DSLProps,
+  Hihat808DSLProps,
+  Snare909DSLProps,
+  SubSynthDSLProps, FMSynthDSLProps,
+} from './types.js'
 
 const makeDescriptor = (
   instrumentType: InstrumentDescriptor['instrumentType'],

--- a/packages/dsl/src/percussion.ts
+++ b/packages/dsl/src/percussion.ts
@@ -144,6 +144,32 @@ export const Kick909 = (hits?: number): ChainablePart => Kick(hits).model('909')
 export const Hihat808 = (hits?: number): ChainablePart => HiHat(hits).model('808')
 
 /**
+ * Roland TR-808 open hi-hat — same six detuned square oscillators as {@link Hihat808}
+ * but with a longer default decay (0.3 s) giving the sustained, washy open-hat sound.
+ *
+ * Unlike the other model aliases (Kick808, Hihat808, Snare909) this factory creates a
+ * part with `instrumentType: 'hihatopen808'` so the engine dispatches it to
+ * `createHihatOpen808` rather than `createGenericHihat`.
+ *
+ * @param hits - Optional euclidean hit count (1–16). Sets `_pattern` via `euclidean(hits, 16)`.
+ * @returns A `ChainablePart` for `'hihatopen808'`.
+ *
+ * @example
+ * ```ts
+ * const openHat = HihatOpen808().pattern([0,0,0,0, 0,0,0,0, 0,0,0,0, 1,0,0,0]).volume(0.6)
+ * ```
+ *
+ * @see {@link Hihat808} — closed variant
+ * @see {@link HiHat} — base hi-hat factory
+ */
+export const HihatOpen808 = (hits?: number): ChainablePart =>
+  createPart({
+    instrumentType: 'hihatopen808',
+    props: {},
+    ...(hits !== undefined ? { _pattern: euclidean(hits, 16) } : {}),
+  })
+
+/**
  * Roland TR-909 snare drum — two triangle oscillators (tone) mixed with filtered white noise.
  * Sugar for `Snare(hits).model('909')`.
  *

--- a/packages/dsl/src/percussion.ts
+++ b/packages/dsl/src/percussion.ts
@@ -4,8 +4,8 @@
 // Model aliases (Kick808, Kick909, etc.) are thin wrappers: Kick().model('808').
 // Old InstrumentDescriptor factories remain in instruments.ts as deprecated stubs.
 
-import { createPart } from './chain.js'
-import { euclidean } from '@score/pattern'
+import { createPart }         from './chain.js'
+import { euclidean }          from '@score/pattern'
 import type { ChainablePart } from './chain.js'
 
 // ── Kick ──────────────────────────────────────────────────────────────────────
@@ -94,14 +94,14 @@ export const HiHat = (hits?: number): ChainablePart =>
  * Sugar for `Kick(hits).model('808')`.
  *
  * @param hits - Optional euclidean hit count (1–16). Passed through to `Kick()`.
- * @returns A `ChainablePart` for `'kick'` with `_model: '808'`.
+ * @returns A `ChainablePart` for `'kick808'`. Equivalent to `Kick(hits).model('808')`.
  *
  * @example
  * ```ts
  * // Classic 808 four-on-the-floor
  * const kick = Kick808().volume(0.9).decay(0.7)
  * // Euclidean 808 pattern
- * const kick = Kick808(5).pumpWith(kick)
+ * const kick = Kick808(5).swing(0.1)
  * ```
  *
  * @see {@link Kick} — base kick factory
@@ -114,7 +114,7 @@ export const Kick808 = (hits?: number): ChainablePart => Kick(hits).model('808')
  * Sugar for `Kick(hits).model('909')`.
  *
  * @param hits - Optional euclidean hit count (1–16). Passed through to `Kick()`.
- * @returns A `ChainablePart` for `'kick'` with `_model: '909'`.
+ * @returns A `ChainablePart` for `'kick909'`. Equivalent to `Kick(hits).model('909')`.
  *
  * @example
  * ```ts
@@ -131,7 +131,7 @@ export const Kick909 = (hits?: number): ChainablePart => Kick(hits).model('909')
  * Sugar for `HiHat(hits).model('808')`.
  *
  * @param hits - Optional euclidean hit count (1–16). Passed through to `HiHat()`.
- * @returns A `ChainablePart` for `'hihat'` with `_model: '808'`.
+ * @returns A `ChainablePart` for `'hihat808'`. Equivalent to `HiHat(hits).model('808')`.
  *
  * @example
  * ```ts
@@ -146,28 +146,22 @@ export const Hihat808 = (hits?: number): ChainablePart => HiHat(hits).model('808
 /**
  * Roland TR-808 open hi-hat — same six detuned square oscillators as {@link Hihat808}
  * but with a longer default decay (0.3 s) giving the sustained, washy open-hat sound.
- *
- * Unlike the other model aliases (Kick808, Hihat808, Snare909) this factory creates a
- * part with `instrumentType: 'hihatopen808'` so the engine dispatches it to
- * `createHihatOpen808` rather than `createGenericHihat`.
+ * Sugar for `HiHat(hits).model('808').open()`.
  *
  * @param hits - Optional euclidean hit count (1–16). Sets `_pattern` via `euclidean(hits, 16)`.
- * @returns A `ChainablePart` for `'hihatopen808'`.
+ * @returns A `ChainablePart` for `'hihatopen808'`. Equivalent to `HiHat(hits).model('808').open()`.
  *
  * @example
  * ```ts
  * const openHat = HihatOpen808().pattern([0,0,0,0, 0,0,0,0, 0,0,0,0, 1,0,0,0]).volume(0.6)
+ * // Equivalent:
+ * const openHat = HiHat().model('808').open().pattern([0,0,0,0, 0,0,0,0, 0,0,0,0, 1,0,0,0]).volume(0.6)
  * ```
  *
  * @see {@link Hihat808} — closed variant
  * @see {@link HiHat} — base hi-hat factory
  */
-export const HihatOpen808 = (hits?: number): ChainablePart =>
-  createPart({
-    instrumentType: 'hihatopen808',
-    props: {},
-    ...(hits !== undefined ? { _pattern: euclidean(hits, 16) } : {}),
-  })
+export const HihatOpen808 = (hits?: number): ChainablePart => HiHat(hits).model('808').open()
 
 /**
  * Roland TR-909 snare drum — two triangle oscillators (tone) mixed with filtered white noise.

--- a/packages/dsl/src/types.ts
+++ b/packages/dsl/src/types.ts
@@ -145,6 +145,15 @@ export type Hihat808DSLProps = {
   readonly effects?: ReadonlyArray<EffectDescriptor>
 }
 
+/** Configuration props for the {@link HihatOpen808} instrument factory. */
+export type HihatOpen808DSLProps = {
+  readonly pattern?: number[]
+  readonly volume?: number
+  /** Amplitude decay in seconds. Default `0.3` (open). */
+  readonly decay?: number
+  readonly effects?: ReadonlyArray<EffectDescriptor>
+}
+
 /** Configuration props for the {@link Snare909} instrument factory. */
 export type Snare909DSLProps = {
   readonly pattern?: number[]
@@ -280,7 +289,14 @@ export type InstrumentDescriptor = {
    * handled outside the registry dispatch in the engine.
    */
   readonly instrumentType: InstrumentType | 'sample'
-  readonly props: KickProps | SnareProps | HiHatProps | SynthDSLProps | SampleProps | ThereminDSLProps | SaxDSLProps | ArpDSLProps | Kick808DSLProps | Kick909DSLProps | Hihat808DSLProps | Snare909DSLProps | SubSynthDSLProps | FMSynthDSLProps
+  readonly props:
+    | KickProps | SnareProps | HiHatProps
+    | SynthDSLProps | SampleProps
+    | ThereminDSLProps | SaxDSLProps | ArpDSLProps
+    | Kick808DSLProps | Kick909DSLProps
+    | Hihat808DSLProps | HihatOpen808DSLProps
+    | Snare909DSLProps
+    | SubSynthDSLProps | FMSynthDSLProps
   // Minimal AudioComponent shape so Track() accepts it
   readonly id: string
   readonly type: string

--- a/packages/dsl/tests/chain-methods.test.ts
+++ b/packages/dsl/tests/chain-methods.test.ts
@@ -1,0 +1,446 @@
+// @score/dsl — chain-methods.test.ts
+//
+// Full coverage of ChainablePart chain methods.
+// Each test asserts the correct descriptor field(s) are set on the resulting part.
+//
+// Organisation mirrors the sections in chain.ts:
+//   Effects (append to _effects) · Tone · Space · Modulation
+//   Pattern descriptors · Pitch/notes · Amplitude (ADSR)
+//   Bar/scheduling · Routing · Meta · Visual
+//   Model + open routing
+
+import { describe, it, expect } from 'vitest'
+import { createPart } from '../src/chain.js'
+import type { EffectDescriptor } from '@score/core'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const part = () => createPart({ instrumentType: 'kick' })
+const hihat = () => createPart({ instrumentType: 'hihat' })
+
+/** Retrieve _effects, typed. */
+const effects = (p: ReturnType<typeof part>): EffectDescriptor[] =>
+  (p._effects ?? []) as EffectDescriptor[]
+
+/** Assert exactly one effect was appended with the given effectType. */
+const singleFx = (p: ReturnType<typeof part>, effectType: string): EffectDescriptor => {
+  const fxList = effects(p)
+  expect(fxList).toHaveLength(1)
+  expect(fxList[0]?.effectType).toBe(effectType)
+  return fxList[0]!
+}
+
+// ── Immutability ──────────────────────────────────────────────────────────────
+
+describe('immutability', () => {
+  it('chain methods return a new part, not the same reference', () => {
+    const a = part()
+    const b = a.volume(0.5)
+    expect(a).not.toBe(b)
+  })
+
+  it('original part is unchanged after chain call', () => {
+    const a = part()
+    a.volume(0.9)
+    expect(a._volume).toBeUndefined()
+  })
+
+  it('chaining preserves id by default', () => {
+    const a = part()
+    expect(a.volume(0.5).id).toBe(a.id)
+  })
+})
+
+// ── Effects — append to _effects ─────────────────────────────────────────────
+
+describe('.reverb()', () => {
+  it('appends reverb effect', () => {
+    const fx = singleFx(part().reverb(0.3), 'reverb')
+    expect(fx.props).toMatchObject({ wet: 0.3 })
+  })
+
+  it('accumulates when called twice', () => {
+    const p = part().reverb(0.3).reverb(0.1)
+    expect(effects(p)).toHaveLength(2)
+  })
+})
+
+describe('.delay()', () => {
+  it('appends delay effect with time', () => {
+    const fx = singleFx(part().delay(0.25), 'delay')
+    expect(fx.props).toMatchObject({ time: 0.25 })
+  })
+
+  it('includes feedback when provided', () => {
+    const fx = singleFx(part().delay(0.25, 0.4), 'delay')
+    expect(fx.props).toMatchObject({ time: 0.25, feedback: 0.4 })
+  })
+})
+
+describe('.chorus()', () => {
+  it('appends chorus effect', () => {
+    const fx = singleFx(part().chorus(0.6), 'chorus')
+    expect(fx.props).toMatchObject({ depth: 0.6 })
+  })
+
+  it('uses default depth when omitted', () => {
+    const fx = singleFx(part().chorus(), 'chorus')
+    expect(typeof fx.props.depth).toBe('number')
+  })
+})
+
+describe('.flange()', () => {
+  it('appends flanger effect', () => {
+    const fx = singleFx(part().flange(0.4), 'flanger')
+    expect(fx.props).toMatchObject({ depth: 0.4 })
+  })
+})
+
+describe('.bit()', () => {
+  it('appends bitcrusher effect', () => {
+    const fx = singleFx(part().bit(8), 'bitcrusher')
+    expect(fx.props).toMatchObject({ bits: 8 })
+  })
+})
+
+describe('.saturate()', () => {
+  it('appends saturation effect', () => {
+    const fx = singleFx(part().saturate(0.7), 'saturation')
+    expect(typeof fx.props.drive).toBe('number')
+  })
+})
+
+describe('.widen()', () => {
+  it('appends stereo-widener effect', () => {
+    const fx = singleFx(part().widen(0.8), 'stereo-widener')
+    expect(fx.props).toMatchObject({ width: 0.8 })
+  })
+})
+
+// ── SIMPLE_FX methods ─────────────────────────────────────────────────────────
+
+describe('.distortion()', () => {
+  it('appends distortion effect', () => {
+    const fx = singleFx(part().distortion(0.5), 'distortion')
+    expect(typeof fx.props.drive).toBe('number')
+  })
+
+  it('uses default amount when omitted', () => {
+    const fx = singleFx(part().distortion(), 'distortion')
+    expect(typeof fx.props.drive).toBe('number')
+  })
+
+  it('clamps drive to 0–1', () => {
+    const fx = singleFx(part().distortion(2), 'distortion')
+    expect(fx.props.drive as number).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('.phaser()', () => {
+  it('appends phaser effect', () => {
+    const fx = singleFx(part().phaser(0.5, 2), 'phaser')
+    expect(fx.props).toMatchObject({ depth: 0.5, rate: 2 })
+  })
+
+  it('uses defaults when no args given', () => {
+    const fx = singleFx(part().phaser(), 'phaser')
+    expect(typeof fx.props.depth).toBe('number')
+    expect(typeof fx.props.rate).toBe('number')
+  })
+})
+
+describe('.compressor()', () => {
+  it('appends compressor effect', () => {
+    const fx = singleFx(part().compressor(-20, 6), 'compressor')
+    expect(fx.props).toMatchObject({ threshold: -20, ratio: 6 })
+  })
+
+  it('uses defaults when no args given', () => {
+    const fx = singleFx(part().compressor(), 'compressor')
+    expect(typeof fx.props.threshold).toBe('number')
+    expect(typeof fx.props.ratio).toBe('number')
+  })
+})
+
+describe('.limiter()', () => {
+  it('appends limiter effect', () => {
+    const fx = singleFx(part().limiter(-2), 'limiter')
+    expect(fx.props).toMatchObject({ ceiling: -2 })
+  })
+
+  it('uses default ceiling when omitted', () => {
+    const fx = singleFx(part().limiter(), 'limiter')
+    expect(typeof fx.props.ceiling).toBe('number')
+  })
+})
+
+describe('.gate()', () => {
+  it('appends gate effect', () => {
+    const fx = singleFx(part().gate(-30, 8), 'gate')
+    expect(fx.props).toMatchObject({ threshold: -30, ratio: 8 })
+  })
+
+  it('uses defaults when no args given', () => {
+    const fx = singleFx(part().gate(), 'gate')
+    expect(typeof fx.props.threshold).toBe('number')
+    expect(typeof fx.props.ratio).toBe('number')
+  })
+})
+
+// ── Effects stack ordering ────────────────────────────────────────────────────
+
+describe('effects ordering', () => {
+  it('effects are appended in call order', () => {
+    const p = part().reverb(0.2).delay(0.25).distortion(0.3)
+    const fxList = effects(p)
+    expect(fxList).toHaveLength(3)
+    expect(fxList[0]?.effectType).toBe('reverb')
+    expect(fxList[1]?.effectType).toBe('delay')
+    expect(fxList[2]?.effectType).toBe('distortion')
+  })
+})
+
+// ── Tone ──────────────────────────────────────────────────────────────────────
+
+describe('.filter()', () => {
+  it('sets _filter with frequency', () => {
+    const p = part().filter(800)
+    expect(p._filter?.frequency).toBe(800)
+  })
+
+  it('sets _filter with frequency and Q', () => {
+    const p = part().filter(1200, 4)
+    expect(p._filter).toMatchObject({ frequency: 1200, Q: 4 })
+  })
+})
+
+describe('.eq()', () => {
+  it('sets _eq with low/mid/high', () => {
+    const p = part().eq(3, -2, 1)
+    expect(p._eq).toMatchObject({ lo: 3, mid: -2, hi: 1 })
+  })
+})
+
+// ── Space ─────────────────────────────────────────────────────────────────────
+
+describe('.pan()', () => {
+  it('sets _pan', () => {
+    expect(part().pan(-0.5)._pan).toBe(-0.5)
+  })
+
+  it('sets _pan to 0 (centre)', () => {
+    expect(part().pan(0)._pan).toBe(0)
+  })
+})
+
+// ── Amplitude / ADSR ─────────────────────────────────────────────────────────
+
+describe('.attack()', () => {
+  it('sets _adsr.attack', () => {
+    expect(part().attack(0.01)._adsr?.attack).toBe(0.01)
+  })
+
+  it('merges with existing adsr', () => {
+    const p = part().decay(0.2).attack(0.01)
+    expect(p._adsr?.attack).toBe(0.01)
+    expect(p._adsr?.decay).toBe(0.2)
+  })
+})
+
+describe('.decay()', () => {
+  it('sets _adsr.decay', () => {
+    expect(part().decay(0.3)._adsr?.decay).toBe(0.3)
+  })
+})
+
+describe('.sustain()', () => {
+  it('sets _adsr.sustain', () => {
+    expect(part().sustain(0.6)._adsr?.sustain).toBe(0.6)
+  })
+})
+
+describe('.release()', () => {
+  it('sets _adsr.release', () => {
+    expect(part().release(0.5)._adsr?.release).toBe(0.5)
+  })
+})
+
+// ── Pitch / notes ─────────────────────────────────────────────────────────────
+
+describe('.pitch()', () => {
+  it('sets _pitchOffset', () => {
+    expect(part().pitch(7)._pitchOffset).toBe(7)
+  })
+
+  it('negative semitones', () => {
+    expect(part().pitch(-12)._pitchOffset).toBe(-12)
+  })
+})
+
+describe('.octave()', () => {
+  it('sets _octave', () => {
+    expect(part().octave(1)._octave).toBe(1)
+  })
+})
+
+describe('.glide()', () => {
+  it('sets _glide', () => {
+    expect(part().glide(0.05)._glide).toBe(0.05)
+  })
+})
+
+describe('.dur()', () => {
+  it('sets _dur', () => {
+    expect(part().dur(2)._dur).toBe(2)
+  })
+})
+
+// ── Bar / scheduling ──────────────────────────────────────────────────────────
+
+describe('.fromBar()', () => {
+  it('sets _fromBar', () => {
+    expect(part().fromBar(4)._fromBar).toBe(4)
+  })
+})
+
+describe('.untilBar()', () => {
+  it('sets _untilBar', () => {
+    expect(part().untilBar(8)._untilBar).toBe(8)
+  })
+})
+
+describe('.fadeIn()', () => {
+  it('sets _fadeInBars', () => {
+    expect(part().fadeIn(2)._fadeInBars).toBe(2)
+  })
+})
+
+describe('.fadeOut()', () => {
+  it('sets _fadeOutBars', () => {
+    expect(part().fadeOut(4)._fadeOutBars).toBe(4)
+  })
+})
+
+// ── Routing ───────────────────────────────────────────────────────────────────
+
+describe('.mute()', () => {
+  it('sets _mute to true', () => {
+    expect(part().mute()._mute).toBe(true)
+  })
+})
+
+describe('.solo()', () => {
+  it('sets _solo to true', () => {
+    expect(part().solo()._solo).toBe(true)
+  })
+})
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
+
+describe('.name()', () => {
+  it('sets _name', () => {
+    expect(part().name('bass')._name).toBe('bass')
+  })
+})
+
+describe('.seed()', () => {
+  it('sets _seed', () => {
+    expect(part().seed(42)._seed).toBe(42)
+  })
+})
+
+// ── Visual ────────────────────────────────────────────────────────────────────
+
+describe('.color()', () => {
+  it('sets _visual.color', () => {
+    expect(part().color('#ff0000')._visual?.color).toBe('#ff0000')
+  })
+
+  it('merges with other visual fields', () => {
+    const p = part().glyph('★').color('#00ff00')
+    expect(p._visual?.glyph).toBe('★')
+    expect(p._visual?.color).toBe('#00ff00')
+  })
+})
+
+describe('.glyph()', () => {
+  it('sets _visual.glyph', () => {
+    expect(part().glyph('◆')._visual?.glyph).toBe('◆')
+  })
+})
+
+describe('.label()', () => {
+  it('sets _visual.label', () => {
+    expect(part().label('kick 808')._visual?.label).toBe('kick 808')
+  })
+})
+
+describe('.visual()', () => {
+  it('merges all visual fields at once', () => {
+    const p = part().visual({ color: '#ff0000', glyph: '◆', label: 'bass' })
+    expect(p._visual).toMatchObject({ color: '#ff0000', glyph: '◆', label: 'bass' })
+  })
+
+  it('partial override preserves existing fields', () => {
+    const p = part().color('#ff0000').visual({ label: 'kick' })
+    expect(p._visual?.color).toBe('#ff0000')
+    expect(p._visual?.label).toBe('kick')
+  })
+})
+
+// ── Model + open routing ──────────────────────────────────────────────────────
+
+describe('.model()', () => {
+  it('changes instrumentType to ${base}${variant}', () => {
+    expect(part().model('808').instrumentType).toBe('kick808')
+  })
+
+  it('sets _model', () => {
+    expect(part().model('808')._model).toBe('808')
+  })
+
+  it('also updates type alias', () => {
+    expect(part().model('909').type).toBe('kick909')
+  })
+
+  it('preserves _effects through model change', () => {
+    const p = part().reverb(0.2).model('808')
+    expect(effects(p)).toHaveLength(1)
+    expect(effects(p)[0]?.effectType).toBe('reverb')
+  })
+
+  it('_model survives further chain calls', () => {
+    expect(part().model('808').volume(0.9)._model).toBe('808')
+  })
+})
+
+describe('.open()', () => {
+  it('hihat808 → hihatopen808', () => {
+    expect(hihat().model('808').open().instrumentType).toBe('hihatopen808')
+  })
+
+  it('unknown type passes through unchanged', () => {
+    expect(part().open().instrumentType).toBe('kick')
+  })
+
+  it('preserves all prior chain state', () => {
+    const p = hihat().model('808').volume(0.6).pattern([1, 0, 1, 0]).open()
+    expect(p.instrumentType).toBe('hihatopen808')
+    expect(p._volume).toBe(0.6)
+    expect(p._pattern).toBeDefined()
+  })
+})
+
+describe('HiHat().model("808").open() ≡ HihatOpen808()', () => {
+  it('produces identical instrumentType', async () => {
+    const { HiHat }          = await import('../src/percussion.js')
+    const { HihatOpen808 }   = await import('../src/percussion.js')
+    expect(HiHat().model('808').open().instrumentType).toBe(HihatOpen808().instrumentType)
+  })
+
+  it('both have _model 808', async () => {
+    const { HiHat, HihatOpen808 } = await import('../src/percussion.js')
+    expect(HiHat().model('808').open()._model).toBe('808')
+    expect(HihatOpen808()._model).toBe('808')
+  })
+})

--- a/packages/dsl/tests/percussion.test.ts
+++ b/packages/dsl/tests/percussion.test.ts
@@ -145,8 +145,8 @@ describe('Kick808', () => {
     expect(isChainablePart(Kick808())).toBe(true)
   })
 
-  it('has instrumentType kick', () => {
-    expect(Kick808().instrumentType).toBe('kick')
+  it('has instrumentType kick808', () => {
+    expect(Kick808().instrumentType).toBe('kick808')
   })
 
   it('has _model 808', () => {
@@ -183,8 +183,8 @@ describe('Kick909', () => {
     expect(isChainablePart(Kick909())).toBe(true)
   })
 
-  it('has instrumentType kick', () => {
-    expect(Kick909().instrumentType).toBe('kick')
+  it('has instrumentType kick909', () => {
+    expect(Kick909().instrumentType).toBe('kick909')
   })
 
   it('has _model 909', () => {
@@ -212,8 +212,8 @@ describe('Hihat808', () => {
     expect(isChainablePart(Hihat808())).toBe(true)
   })
 
-  it('has instrumentType hihat', () => {
-    expect(Hihat808().instrumentType).toBe('hihat')
+  it('has instrumentType hihat808', () => {
+    expect(Hihat808().instrumentType).toBe('hihat808')
   })
 
   it('has _model 808', () => {
@@ -237,8 +237,8 @@ describe('Snare909', () => {
     expect(isChainablePart(Snare909())).toBe(true)
   })
 
-  it('has instrumentType snare', () => {
-    expect(Snare909().instrumentType).toBe('snare')
+  it('has instrumentType snare909', () => {
+    expect(Snare909().instrumentType).toBe('snare909')
   })
 
   it('has _model 909', () => {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -5,7 +5,9 @@
   "description": "Score Studio — DAW, live coding, and DJ set GUI",
   "main": "out/main/index.js",
   "scripts": {
+    "sync-monaco-types": "node scripts/sync-monaco-types.mjs",
     "dev": "electron-vite dev",
+    "prebuild": "node scripts/sync-monaco-types.mjs",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "pack": "electron-vite build && electron-builder --dir",

--- a/packages/gui/scripts/sync-monaco-types.mjs
+++ b/packages/gui/scripts/sync-monaco-types.mjs
@@ -1,0 +1,35 @@
+// scripts/sync-monaco-types.mjs
+//
+// Generates score-dsl-types.ts from score-dsl.d.ts so the Monaco string mirror
+// never drifts from the TypeScript declaration source.
+//
+// Run: node scripts/sync-monaco-types.mjs
+// Hooked into: "prebuild" in packages/gui/package.json
+//
+// Only touch point for Monaco declarations: edit score-dsl.d.ts.
+// This script handles the rest.
+
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname  = dirname(fileURLToPath(import.meta.url))
+const typesDir   = resolve(__dirname, '../src/renderer/types')
+const dtsPath    = resolve(typesDir, 'score-dsl.d.ts')
+const outputPath = resolve(typesDir, 'score-dsl-types.ts')
+
+const dts = readFileSync(dtsPath, 'utf8')
+
+const output = [
+  '// Generated from score-dsl.d.ts — run scripts/sync-monaco-types.mjs to regenerate.',
+  '// To add a declaration: edit score-dsl.d.ts, then run the script (or let prebuild do it).',
+  '',
+  '/** Hand-written Score DSL ambient declarations. Loaded into Monaco TypeScript service on editor mount. */',
+  `export const SCORE_DSL_TYPES: string = \``,
+  dts,
+  `\``,
+  '',
+].join('\n')
+
+writeFileSync(outputPath, output, 'utf8')
+console.log(`[sync-monaco-types] wrote ${outputPath}`)

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -9,7 +9,7 @@ import { MasterLevel }                      from '../shared/MasterLevel.js'
 import { MixerStrip }                       from '../shared/MixerStrip.js'
 import { DraggablePanel }                   from '../shared/DraggablePanel.js'
 import { CodeWaveform }                     from '../shared/CodeWaveform.js'
-import { getActiveLines, getStepBadges, getBlockBounds, getTrackLines } from '../shared/CodeHighlight.js'
+import { getActiveLines, getStepBadges, getBlockBounds, getTrackLines, getActiveStepHighlight } from '../shared/CodeHighlight.js'
 import { CodeEditorPanel }                                              from '../shared/CodeEditorPanel.js'
 import type { EditorDecoration, StepBadge, BlockHighlight }            from '../shared/CodeEditorPanel.js'
 import { ReferencePanel }                   from '../shared/ReferencePanel.js'
@@ -210,6 +210,13 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
         return bounds ? [bounds] : []
       })
   }, [engineState.playing, code, tracks, currentStep])
+
+  // Inline step highlight — flashes the euclidean arg or active pattern element
+  // for each hitting track. Only active during playback.
+  const inlineHighlights = useMemo(
+    () => engineState.playing ? getActiveStepHighlight(code, tracks, currentStep) : [],
+    [engineState.playing, code, tracks, currentStep],
+  )
 
   const [panels, setPanels] = useState<PanelVisibility>({
     punchcard:  true,
@@ -628,6 +635,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
                 stepBadges={stepBadges}
                 importsVisible={importsVisible}
                 blockHighlights={blockHighlights}
+                inlineHighlights={inlineHighlights}
               />
             </div>
           </div>

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -9,7 +9,7 @@ import { MasterLevel }                      from '../shared/MasterLevel.js'
 import { MixerStrip }                       from '../shared/MixerStrip.js'
 import { DraggablePanel }                   from '../shared/DraggablePanel.js'
 import { CodeWaveform }                     from '../shared/CodeWaveform.js'
-import { getActiveLines, getStepBadges, getBlockBounds, getTrackLines, getActiveStepHighlight } from '../shared/CodeHighlight.js'
+import { getStepBadges, getBlockBounds, getTrackLines, getActiveStepHighlight } from '../shared/CodeHighlight.js'
 import { CodeEditorPanel }                                              from '../shared/CodeEditorPanel.js'
 import type { EditorDecoration, StepBadge, BlockHighlight }            from '../shared/CodeEditorPanel.js'
 import { ReferencePanel }                   from '../shared/ReferencePanel.js'
@@ -177,17 +177,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   // Accumulate panel positions for debounced save (ref avoids extra re-renders)
   const layoutAccRef = useRef<PanelLayoutMap>({})
 
-  // Monaco beat-highlight decorations — active track lines while playing
-  const editorDecorations = useMemo((): ReadonlyArray<EditorDecoration> => {
-    if (!engineState.playing) return []
-    const activeLines = getActiveLines(code, tracks, currentStep)
-    return activeLines.map(zeroIdx => ({
-      startLine:   zeroIdx + 1,  // Monaco is 1-based
-      endLine:     zeroIdx + 1,
-      className:   'score-beat-active',
-      isWholeLine: true,
-    }))
-  }, [engineState.playing, code, tracks, currentStep])
+  const editorDecorations = useMemo((): ReadonlyArray<EditorDecoration> => [], [])
   // t219 — step badges: per-instrument line `STEP/TOTAL` pills during playback
   const stepBadges = useMemo((): ReadonlyArray<StepBadge> =>
     engineState.playing

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -19,7 +19,7 @@ import { EvalStatus }                       from '../status/index.js'
 import type { EvalStatusKind }             from '../status/EvalStatus.js'
 import { BarCounter }                       from '../status/index.js'
 import { PendingSwapBadge }                 from '../status/index.js'
-import { patchBpm, patchTrackPattern, patchTrackVolume, patchTrackNote, patchChainMethod, parseTrackChainParams, parseTrackModel, patchInstrumentModel, patchMute, parseMuteState, patchAddInstrument, uniqueVarName } from '../../lib/codePatcher.js'
+import { patchBpm, patchTrackPattern, insertTrackPattern, patchTrackVolume, patchTrackNote, patchChainMethod, parseTrackChainParams, parseTrackModel, patchInstrumentModel, patchMute, parseMuteState, patchAddInstrument, uniqueVarName } from '../../lib/codePatcher.js'
 import { InstrumentPanel } from '../shared/InstrumentPanel.js'
 import type { PianoRollNote }              from '../visualizer/PianoRoll.js'
 import type { PanelLayoutMap }            from '../../../main/ipc-types.js'
@@ -452,7 +452,18 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
       pat[stepIndex % len] = newVal
       return { ...t, pattern: pat }
     }))
-    setCode(prev => patchTrackPattern(prev, trackIndex, stepIndex, newVal))
+    setCode(prev => {
+      const patched = patchTrackPattern(prev, trackIndex, stepIndex, newVal)
+      // Fallback: euclidean shorthand (e.g. Kick808(4)) has no .pattern() to patch in-place.
+      // Build the full toggled pattern array and insert it explicitly.
+      if (patched === prev) {
+        // Drum patterns are always numeric (0|1); cast away the string union from PunchcardTrack.
+        const newPattern: number[] = track.pattern.map(v => (typeof v === 'number' ? v : 0))
+        newPattern[stepIndex % len] = newVal
+        return insertTrackPattern(prev, trackIndex, newPattern)
+      }
+      return patched
+    })
     if (evalDebounceRef.current !== null) clearTimeout(evalDebounceRef.current)
     evalDebounceRef.current = setTimeout(() => {
       setError(null)

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -211,8 +211,6 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
       })
   }, [engineState.playing, code, tracks, currentStep])
 
-  // Inline step highlight — flashes the euclidean arg or active pattern element
-  // for each hitting track. Only active during playback.
   const inlineHighlights = useMemo(
     () => engineState.playing ? getActiveStepHighlight(code, tracks, currentStep) : [],
     [engineState.playing, code, tracks, currentStep],
@@ -461,10 +459,7 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
     }))
     setCode(prev => {
       const patched = patchTrackPattern(prev, trackIndex, stepIndex, newVal)
-      // Fallback: euclidean shorthand (e.g. Kick808(4)) has no .pattern() to patch in-place.
-      // Build the full toggled pattern array and insert it explicitly.
       if (patched === prev) {
-        // Drum patterns are always numeric (0|1); cast away the string union from PunchcardTrack.
         const newPattern: number[] = track.pattern.map(v => (typeof v === 'number' ? v : 0))
         newPattern[stepIndex % len] = newVal
         return insertTrackPattern(prev, trackIndex, newPattern)

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -186,27 +186,29 @@ const injectDecorationCss = (): void => {
       background: rgba(74, 143, 255, 0.07) !important;
       border-left: 2px solid rgba(74, 143, 255, 0.4) !important;
     }
-    /* t330 — Block highlight fade animation (Strudl-style) */
+    /* Block highlight — subtle left border only while the track is active this step.
+       No background fill — avoids whole-line flash that obscures code readability.
+       Alternating -a/-b forces a class-name change each tick so deltaDecorations re-runs. */
     @keyframes score-block-fade {
-      0%   { background: rgba(74, 143, 255, 0.12); border-left-color: rgba(74, 143, 255, 0.55); }
-      100% { background: transparent;              border-left-color: transparent; }
+      0%   { border-left-color: rgba(74, 143, 255, 0.7); }
+      100% { border-left-color: rgba(74, 143, 255, 0.15); }
     }
-    /* Two alternating classes so deltaDecorations triggers a DOM class-name change
-       on consecutive ticks, which restarts the CSS animation each step. */
     .score-block-active-a,
     .score-block-active-b {
-      animation: score-block-fade 200ms ease-out forwards;
-      border-left: 2px solid rgba(74, 143, 255, 0.55);
+      animation: score-block-fade 250ms ease-out forwards;
+      border-left: 2px solid rgba(74, 143, 255, 0.7);
     }
-    /* Inline step highlight — flashes the euclidean arg or active pattern element.
-       Two alternating classes so the animation restarts on consecutive ticks. */
-    @keyframes score-inline-flash {
-      0%   { background: rgba(74, 143, 255, 0.55); color: #ffffff; border-radius: 2px; }
-      100% { background: transparent;              color: inherit; }
+    /* Inline step highlight — solid white underline + mild background on the
+       euclidean arg or active pattern element. High contrast, no flicker.
+       Alternating -a/-b so consecutive ticks restart the animation. */
+    @keyframes score-inline-active {
+      0%   { background: rgba(255, 255, 255, 0.18); border-bottom: 2px solid #ffffff; color: #ffffff; }
+      100% { background: transparent;               border-bottom: 2px solid rgba(255,255,255,0.2); color: inherit; }
     }
     .score-inline-active-a,
     .score-inline-active-b {
-      animation: score-inline-flash 180ms ease-out forwards;
+      animation: score-inline-active 300ms ease-out forwards;
+      border-radius: 2px;
     }
     /* Step badge — inline content widget gutter marker */
     .score-step-badge {
@@ -264,10 +266,7 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
   const inlineFlipRef        = useRef(false)
   const monacoRef            = useRef<Monaco | null>(null)
 
-  // Notify Monaco when the container resizes (e.g. console panel toggle pushes editor height).
-  // Without this, the editor's internal scroll area is never recalculated and content appears clipped.
-  // Pass explicit pixel dimensions from the ResizeObserver entry — avoids a layout() no-arg race
-  // where Monaco reads the DOM before the browser has finished the resize reflow.
+  // Pass explicit dimensions from ResizeObserver — avoids a layout() no-arg race before reflow.
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
@@ -281,7 +280,6 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     return () => { observer.disconnect() }
   }, [])
 
-  // Apply decorations whenever they change
   useEffect(() => {
     const ed     = editorRef.current
     const monaco = monacoRef.current
@@ -335,8 +333,6 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     const model = ed.getModel()
     if (!model) return
 
-    // Alternate CSS class name each tick so the animation always restarts,
-    // even when the same block stays active across consecutive steps.
     blockFlipRef.current = !blockFlipRef.current
     const className = blockFlipRef.current ? 'score-block-active-a' : 'score-block-active-b'
 
@@ -352,9 +348,6 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     blockHighlightsRef.current = ed.deltaDecorations(blockHighlightsRef.current, newBlocks)
   }, [blockHighlights])
 
-  // Inline step highlights — character-level flash on the euclidean arg or active
-  // pattern element (e.g. the `4` in `Kick808(4)`). Restarts animation each tick
-  // by alternating between -a and -b class names.
   useEffect(() => {
     const ed     = editorRef.current
     const monaco = monacoRef.current

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -11,6 +11,7 @@ import { useRef, useEffect, useCallback, memo } from 'react'
 import MonacoEditor, { type OnMount, type Monaco }  from '@monaco-editor/react'
 import type { editor as MonacoEditorNS }            from 'monaco-editor'
 import { SCORE_DSL_TYPES }                          from '../../types/score-dsl-types.js'
+import type { InlineHighlight }                     from './CodeHighlight.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -67,6 +68,12 @@ type Props = {
    * CSS keyframe animation. The parent recomputes this array on every step tick.
    */
   readonly blockHighlights?: ReadonlyArray<BlockHighlight>
+  /**
+   * Inline character-level highlights — targets the euclidean arg (`4` in
+   * `Kick808(4)`) or the active element in `.pattern([...])`. Updated on every
+   * engine step tick; only active (hitting) tracks produce a highlight.
+   */
+  readonly inlineHighlights?: ReadonlyArray<InlineHighlight>
 }
 
 // ── Score DSL Token Provider ───────────────────────────────────────────────────
@@ -191,6 +198,16 @@ const injectDecorationCss = (): void => {
       animation: score-block-fade 200ms ease-out forwards;
       border-left: 2px solid rgba(74, 143, 255, 0.55);
     }
+    /* Inline step highlight — flashes the euclidean arg or active pattern element.
+       Two alternating classes so the animation restarts on consecutive ticks. */
+    @keyframes score-inline-flash {
+      0%   { background: rgba(74, 143, 255, 0.55); color: #ffffff; border-radius: 2px; }
+      100% { background: transparent;              color: inherit; }
+    }
+    .score-inline-active-a,
+    .score-inline-active-b {
+      animation: score-inline-flash 180ms ease-out forwards;
+    }
     /* Step badge — inline content widget gutter marker */
     .score-step-badge {
       display: inline-block;
@@ -235,7 +252,7 @@ const injectDecorationCss = (): void => {
  * />
  * ```
  */
-const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights }: Props) => {
+const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights, inlineHighlights }: Props) => {
   const editorRef            = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
   const containerRef         = useRef<HTMLDivElement>(null)
   const decorationsRef       = useRef<string[]>([])
@@ -243,6 +260,8 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
   const blockHighlightsRef   = useRef<string[]>([])
   // t330 — flip between -a and -b on every tick so the CSS animation restarts
   const blockFlipRef         = useRef(false)
+  const inlineHighlightsRef  = useRef<string[]>([])
+  const inlineFlipRef        = useRef(false)
   const monacoRef            = useRef<Monaco | null>(null)
 
   // Notify Monaco when the container resizes (e.g. console panel toggle pushes editor height).
@@ -327,6 +346,31 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
 
     blockHighlightsRef.current = ed.deltaDecorations(blockHighlightsRef.current, newBlocks)
   }, [blockHighlights])
+
+  // Inline step highlights — character-level flash on the euclidean arg or active
+  // pattern element (e.g. the `4` in `Kick808(4)`). Restarts animation each tick
+  // by alternating between -a and -b class names.
+  useEffect(() => {
+    const ed     = editorRef.current
+    const monaco = monacoRef.current
+    if (!ed || !monaco) return
+
+    const model = ed.getModel()
+    if (!model) return
+
+    inlineFlipRef.current = !inlineFlipRef.current
+    const className = inlineFlipRef.current ? 'score-inline-active-a' : 'score-inline-active-b'
+
+    const newInline = (inlineHighlights ?? []).map(h => ({
+      range: new monaco.Range(h.line, h.startCol, h.line, h.endCol),
+      options: {
+        inlineClassName: className,
+        stickiness:      monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+      },
+    }))
+
+    inlineHighlightsRef.current = ed.deltaDecorations(inlineHighlightsRef.current, newInline)
+  }, [inlineHighlights])
 
   // t220 — fold / unfold the leading import block when importsVisible changes
   useEffect(() => {

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -190,13 +190,16 @@ const injectDecorationCss = (): void => {
        outlines are used. Classes kept so deltaDecorations calls don't error. */
     .score-block-active-a,
     .score-block-active-b {}
-    /* Inline step highlight — Strudl-style box outline around the active token.
-       No background, no animation. Constant solid outline while the step is active.
-       -a/-b alternation forces a class-name swap each tick so deltaDecorations fires. */
+    /* Inline step highlight — Strudl-style box around the active token.
+       outline is clipped by Monaco overflow:hidden line containers so we use
+       box-shadow instead (not clipped the same way). Subtle background tint
+       ensures visibility in screenshots. -a/-b swap forces deltaDecorations. */
     .score-inline-active-a,
     .score-inline-active-b {
-      outline: 1px solid rgba(255, 255, 255, 0.75);
+      background: rgba(255, 255, 255, 0.13);
+      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.85);
       border-radius: 2px;
+      padding: 1px 1px;
     }
     /* Step badge — inline content widget gutter marker */
     .score-step-badge {

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -191,15 +191,14 @@ const injectDecorationCss = (): void => {
     .score-block-active-a,
     .score-block-active-b {}
     /* Inline step highlight — Strudl-style box around the active token.
-       outline is clipped by Monaco overflow:hidden line containers so we use
-       box-shadow instead (not clipped the same way). Subtle background tint
-       ensures visibility in screenshots. -a/-b swap forces deltaDecorations. */
-    .score-inline-active-a,
-    .score-inline-active-b {
-      background: rgba(255, 255, 255, 0.13);
-      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.85);
+       Single stable class (no -a/-b flip) so there is no frame gap where
+       nothing is applied — that gap was causing the highlight to vanish in
+       screenshots. box-shadow used instead of outline (outline is clipped by
+       Monaco overflow:hidden line containers). */
+    .score-inline-active {
+      background: rgba(255, 255, 255, 0.18);
+      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.9);
       border-radius: 2px;
-      padding: 1px 1px;
     }
     /* Step badge — inline content widget gutter marker */
     .score-step-badge {
@@ -254,7 +253,6 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
   // t330 — flip between -a and -b on every tick so the CSS animation restarts
   const blockFlipRef         = useRef(false)
   const inlineHighlightsRef  = useRef<string[]>([])
-  const inlineFlipRef        = useRef(false)
   const monacoRef            = useRef<Monaco | null>(null)
 
   // Pass explicit dimensions from ResizeObserver — avoids a layout() no-arg race before reflow.
@@ -347,13 +345,10 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     const model = ed.getModel()
     if (!model) return
 
-    inlineFlipRef.current = !inlineFlipRef.current
-    const className = inlineFlipRef.current ? 'score-inline-active-a' : 'score-inline-active-b'
-
     const newInline = (inlineHighlights ?? []).map(h => ({
       range: new monaco.Range(h.line, h.startCol, h.line, h.endCol),
       options: {
-        inlineClassName: className,
+        inlineClassName: 'score-inline-active',
         stickiness:      monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
       },
     }))

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -186,28 +186,16 @@ const injectDecorationCss = (): void => {
       background: rgba(74, 143, 255, 0.07) !important;
       border-left: 2px solid rgba(74, 143, 255, 0.4) !important;
     }
-    /* Block highlight — subtle left border only while the track is active this step.
-       No background fill — avoids whole-line flash that obscures code readability.
-       Alternating -a/-b forces a class-name change each tick so deltaDecorations re-runs. */
-    @keyframes score-block-fade {
-      0%   { border-left-color: rgba(74, 143, 255, 0.7); }
-      100% { border-left-color: rgba(74, 143, 255, 0.15); }
-    }
+    /* Block highlight — no-op. Whole-line highlight is disabled; only inline token
+       outlines are used. Classes kept so deltaDecorations calls don't error. */
     .score-block-active-a,
-    .score-block-active-b {
-      animation: score-block-fade 250ms ease-out forwards;
-      border-left: 2px solid rgba(74, 143, 255, 0.7);
-    }
-    /* Inline step highlight — solid white underline + mild background on the
-       euclidean arg or active pattern element. High contrast, no flicker.
-       Alternating -a/-b so consecutive ticks restart the animation. */
-    @keyframes score-inline-active {
-      0%   { background: rgba(255, 255, 255, 0.18); border-bottom: 2px solid #ffffff; color: #ffffff; }
-      100% { background: transparent;               border-bottom: 2px solid rgba(255,255,255,0.2); color: inherit; }
-    }
+    .score-block-active-b {}
+    /* Inline step highlight — Strudl-style box outline around the active token.
+       No background, no animation. Constant solid outline while the step is active.
+       -a/-b alternation forces a class-name swap each tick so deltaDecorations fires. */
     .score-inline-active-a,
     .score-inline-active-b {
-      animation: score-inline-active 300ms ease-out forwards;
+      outline: 1px solid rgba(255, 255, 255, 0.75);
       border-radius: 2px;
     }
     /* Step badge — inline content widget gutter marker */

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -237,12 +237,25 @@ const injectDecorationCss = (): void => {
  */
 const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges, importsVisible = true, blockHighlights }: Props) => {
   const editorRef            = useRef<MonacoEditorNS.IStandaloneCodeEditor | null>(null)
+  const containerRef         = useRef<HTMLDivElement>(null)
   const decorationsRef       = useRef<string[]>([])
   const stepBadgesRef        = useRef<string[]>([])
   const blockHighlightsRef   = useRef<string[]>([])
   // t330 — flip between -a and -b on every tick so the CSS animation restarts
   const blockFlipRef         = useRef(false)
   const monacoRef            = useRef<Monaco | null>(null)
+
+  // Notify Monaco when the container resizes (e.g. console panel toggle pushes editor height).
+  // Without this, the editor's internal scroll area is never recalculated and content appears clipped.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => {
+      editorRef.current?.layout()
+    })
+    observer.observe(el)
+    return () => { observer.disconnect() }
+  }, [])
 
   // Apply decorations whenever they change
   useEffect(() => {
@@ -390,39 +403,41 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
   }, [onChange])
 
   return (
-    <MonacoEditor
-      height="100%"
-      language="typescript"
-      theme="score-dark"
-      value={value}
-      onChange={handleChange}
-      onMount={handleMount}
-      options={{
-        fontSize:              12.8,
-        fontFamily:            "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-        lineHeight:            1.65 * 12.8,
-        minimap:               { enabled: false },
-        scrollBeyondLastLine:  false,
-        wordWrap:              'on',
-        tabSize:               2,
-        insertSpaces:          true,
-        renderLineHighlight:   'line',
-        cursorBlinking:        'smooth',
-        cursorSmoothCaretAnimation: 'on',
-        padding:               { top: 12, bottom: 12 },
-        overviewRulerLanes:    1,
-        scrollbar: {
-          verticalScrollbarSize:   6,
-          horizontalScrollbarSize: 6,
-        },
-        // Folding enabled so import block can be collapsed via the Imports toggle (t220).
-        // The fold icon is hidden via CSS — folding: true is required for editor.fold() to work.
-        folding:               true,
-        showFoldingControls:   'never',
-        renderWhitespace:      'none',
-        guides:                { indentation: false },
-      }}
-    />
+    <div ref={containerRef} style={{ height: '100%' }}>
+      <MonacoEditor
+        height="100%"
+        language="typescript"
+        theme="score-dark"
+        value={value}
+        onChange={handleChange}
+        onMount={handleMount}
+        options={{
+          fontSize:              12.8,
+          fontFamily:            "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+          lineHeight:            1.65 * 12.8,
+          minimap:               { enabled: false },
+          scrollBeyondLastLine:  false,
+          wordWrap:              'on',
+          tabSize:               2,
+          insertSpaces:          true,
+          renderLineHighlight:   'line',
+          cursorBlinking:        'smooth',
+          cursorSmoothCaretAnimation: 'on',
+          padding:               { top: 12, bottom: 12 },
+          overviewRulerLanes:    1,
+          scrollbar: {
+            verticalScrollbarSize:   6,
+            horizontalScrollbarSize: 6,
+          },
+          // Folding enabled so import block can be collapsed via the Imports toggle (t220).
+          // The fold icon is hidden via CSS — folding: true is required for editor.fold() to work.
+          folding:               true,
+          showFoldingControls:   'never',
+          renderWhitespace:      'none',
+          guides:                { indentation: false },
+        }}
+      />
+    </div>
   )
 }
 

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -266,11 +266,16 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
 
   // Notify Monaco when the container resizes (e.g. console panel toggle pushes editor height).
   // Without this, the editor's internal scroll area is never recalculated and content appears clipped.
+  // Pass explicit pixel dimensions from the ResizeObserver entry — avoids a layout() no-arg race
+  // where Monaco reads the DOM before the browser has finished the resize reflow.
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
-    const observer = new ResizeObserver(() => {
-      editorRef.current?.layout()
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry || !editorRef.current) return
+      const { width, height } = entry.contentRect
+      editorRef.current.layout({ width: Math.floor(width), height: Math.floor(height) })
     })
     observer.observe(el)
     return () => { observer.disconnect() }

--- a/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeEditorPanel.tsx
@@ -348,8 +348,8 @@ const CodeEditorPanelInner = ({ value, onChange, onEval, decorations, stepBadges
     const newInline = (inlineHighlights ?? []).map(h => ({
       range: new monaco.Range(h.line, h.startCol, h.line, h.endCol),
       options: {
-        inlineClassName: 'score-inline-active',
-        stickiness:      monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+        className: 'score-inline-active',
+        stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
       },
     }))
 

--- a/packages/gui/src/renderer/components/shared/CodeHighlight.tsx
+++ b/packages/gui/src/renderer/components/shared/CodeHighlight.tsx
@@ -5,6 +5,18 @@ type TrackInfo = {
   readonly pattern: ReadonlyArray<number | string>
 }
 
+/**
+ * Character-level decoration range for a single inline beat highlight.
+ * Targets the euclidean arg (e.g. the `4` in `Kick808(4)`) or the active
+ * step element in an explicit `.pattern([...])` array.
+ * All positions are 1-based (Monaco convention).
+ */
+export type InlineHighlight = {
+  readonly line:     number
+  readonly startCol: number
+  readonly endCol:   number
+}
+
 type Props = {
   /** The full code string in the editor. */
   readonly code:        string
@@ -205,6 +217,140 @@ export const getStepBadges = (
     const total = track.pattern.length > 0 ? track.pattern.length : defaultStepCount
     return { line: lineIndex + 1, step: currentStep % total, total }
   }).filter((b): b is { line: number; step: number; total: number } => b !== null)
+}
+
+/**
+ * Matches the numeric euclidean arg in a drum shorthand call — e.g. the `4`
+ * in `Kick808(4)`. Only matches numeric args, not empty `()` or pitch strings.
+ */
+const EUCLIDEAN_ARG_RE = /(?:Kick(?:808|909)?|Snare(?:909)?|Hihat(?:808)?|HiHat(?:808)?|Sample)\s*\((\d+)\)/
+
+/**
+ * Returns character-level inline highlight ranges for the currently active
+ * step across all tracks — used to render a Strudl-style inline playhead in
+ * the Monaco editor.
+ *
+ * Strategy per track:
+ *  - If the track block contains `.pattern([...])` → find the element at
+ *    `currentStep % patternLength` and return its column range.
+ *  - Otherwise (euclidean shorthand, e.g. `Kick808(4)`) → return the column
+ *    range of the numeric arg inside the first `(N)` on the declaration line.
+ *
+ * Only tracks that are **active** at `currentStep` (i.e. their pattern value
+ * is truthy) produce a highlight — passive steps return nothing.
+ *
+ * @param code        - Full DSL code string from the editor.
+ * @param tracks      - Track descriptors from last successful eval.
+ * @param currentStep - Current zero-based sequencer step.
+ * @returns Array of column-level highlight ranges (1-based, Monaco convention).
+ *
+ * @example
+ * ```ts
+ * // const kick = Kick808(4).volume(0.8)   ← 4 hits, step 0 active
+ * getActiveStepHighlight(code, tracks, 0)
+ * // → [{ line: 3, startCol: 17, endCol: 18 }]  (highlights the `4`)
+ * ```
+ */
+export const getActiveStepHighlight = (
+  code:        string,
+  tracks:      ReadonlyArray<TrackInfo>,
+  currentStep: number,
+): ReadonlyArray<InlineHighlight> => {
+  if (tracks.length === 0) return []
+
+  const lines         = code.split('\n')
+  const trackLineList = getTrackLines(code, tracks)
+  const result: InlineHighlight[] = []
+
+  for (const { lineIndex, trackIndex } of trackLineList) {
+    const track = tracks[trackIndex]
+    if (!track) continue
+
+    const patLen     = Math.max(track.pattern.length, 1)
+    const activeStep = currentStep % patLen
+    const val        = track.pattern[activeStep]
+
+    // Only highlight the active (hitting) step
+    if (!val) continue
+
+    // ── Case 1: explicit .pattern([...]) ───────────────────────────────────
+    // Search from the declaration line through the track's chain block
+    const NEW_STATEMENT_RE = /^\s*(const|export|import|Song)\b/
+    let patternLineIdx = -1
+    let patternLine    = ''
+
+    for (let i = lineIndex; i < lines.length; i++) {
+      const ln = lines[i]
+      if (ln === undefined || ln.trim() === '') break
+      if (i > lineIndex && NEW_STATEMENT_RE.test(ln)) break
+      if (ln.includes('.pattern([')) {
+        patternLineIdx = i
+        patternLine    = ln
+        break
+      }
+    }
+
+    if (patternLineIdx !== -1) {
+      const patStart   = patternLine.indexOf('.pattern([')
+      const arrayStart = patStart + '.pattern(['.length
+      const arrayEnd   = patternLine.indexOf('])', arrayStart)
+      if (arrayStart !== -1 && arrayEnd !== -1) {
+        const arrayContent = patternLine.slice(arrayStart, arrayEnd)
+
+        // Tokenise by commas, tracking per-element char positions
+        const elements: Array<{ start: number; end: number }> = []
+        let tokenStart = 0
+        let inStr      = false
+
+        for (let i = 0; i < arrayContent.length; i++) {
+          const ch = arrayContent[i]
+          if (ch === "'" || ch === '"') inStr = !inStr
+          if (!inStr && ch === ',') {
+            elements.push({ start: tokenStart, end: i })
+            tokenStart = i + 1
+          }
+        }
+        elements.push({ start: tokenStart, end: arrayContent.length })
+
+        const el = elements[activeStep]
+        if (el) {
+          const raw      = arrayContent.slice(el.start, el.end)
+          const trimLeft  = raw.length - raw.trimStart().length
+          const trimRight = raw.length - raw.trimEnd().length
+          const absStart  = arrayStart + el.start + trimLeft
+          const absEnd    = arrayStart + el.end   - trimRight
+
+          result.push({
+            line:     patternLineIdx + 1,   // 1-based
+            startCol: absStart + 1,          // 1-based
+            endCol:   absEnd   + 1,
+          })
+          continue
+        }
+      }
+    }
+
+    // ── Case 2: euclidean shorthand ─────────────────────────────────────────
+    // Highlight the numeric arg — e.g. the `4` in `Kick808(4)`.
+    const declLine = lines[lineIndex]
+    if (!declLine) continue
+
+    const m = EUCLIDEAN_ARG_RE.exec(declLine)
+    if (!m) continue
+
+    // Locate the `(N)` within the full match to get exact column
+    const parenOpen  = declLine.indexOf('(', m.index)
+    const parenClose = declLine.indexOf(')', parenOpen)
+    if (parenOpen === -1 || parenClose <= parenOpen + 1) continue
+
+    result.push({
+      line:     lineIndex + 1,
+      startCol: parenOpen  + 2,    // skip `(`, 1-based
+      endCol:   parenClose + 1,    // 1-based, exclusive
+    })
+  }
+
+  return result
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────

--- a/packages/gui/src/renderer/components/status/EvalStatus.tsx
+++ b/packages/gui/src/renderer/components/status/EvalStatus.tsx
@@ -67,6 +67,9 @@ export const EvalStatus = ({ status, message, timestamp }: Props) => {
         {status === 'error'   && 'Error'}
         {status === 'pending' && 'Pending...'}
       </span>
+      {status === 'idle' && (
+        <span style={styles.hint}>Ctrl+Enter to run</span>
+      )}
       {status === 'ok' && timestamp !== undefined && (
         <span style={styles.time}>{relativeTime(timestamp)}</span>
       )}
@@ -126,5 +129,11 @@ const styles = {
     overflow:     'hidden',
     textOverflow: 'ellipsis',
     maxWidth:     '220px',
+  },
+  hint: {
+    display:    'block',
+    fontSize:   '0.62rem',
+    color:      '#444454',
+    marginTop:  '0.05rem',
   },
 } as const

--- a/packages/gui/src/renderer/lib/codePatcher.ts
+++ b/packages/gui/src/renderer/lib/codePatcher.ts
@@ -146,6 +146,56 @@ export const patchTrackPattern = (
 }
 
 /**
+ * Insert an explicit `.pattern([...])` into a track that uses euclidean shorthand
+ * (e.g. `Kick808(4)`) — which has no pattern array in the code to patch in-place.
+ *
+ * Inserts the pattern before `.volume()` if present, otherwise appends to the
+ * last non-empty line of the track's chain region.
+ *
+ * @param code       - Full DSL code string.
+ * @param trackIndex - Zero-based track index.
+ * @param pattern    - The full step pattern to insert (e.g. from engine track state).
+ * @returns Patched code string, or original if track region is not found.
+ *
+ * @example
+ * ```ts
+ * // const kick = Kick808(4).volume(0.8)
+ * insertTrackPattern(code, 0, [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0])
+ * // → const kick = Kick808(4).pattern([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]).volume(0.8)
+ * ```
+ */
+export const insertTrackPattern = (
+  code:       string,
+  trackIndex: number,
+  pattern:    ReadonlyArray<number>,
+): string => {
+  const region = trackSlice(code, trackIndex)
+  if (!region) return code
+  const { start, end } = region
+  const slice = code.slice(start, end)
+
+  const patternStr = `.pattern([${pattern.join(', ')}])`
+
+  // Insert before .volume() to keep volume last in the chain
+  const volMatch = /\.volume\(/.exec(slice)
+  if (volMatch) {
+    const newSlice = slice.slice(0, volMatch.index) + patternStr + slice.slice(volMatch.index)
+    return code.slice(0, start) + newSlice + code.slice(end)
+  }
+
+  // No .volume() — append to the last non-empty line of the track's chain region
+  const lines   = slice.split('\n')
+  const stopIdx = lines.findIndex(ln =>
+    ln.trim().startsWith('const ') || ln.trim().startsWith('export '))
+  const regionLines    = stopIdx === -1 ? lines : lines.slice(0, stopIdx)
+  const insertLineIdx  = regionLines.reduce((acc, ln, i) =>
+    ln.trim().length > 0 ? i : acc, 0)
+
+  const patched = lines.map((ln, i) => i === insertLineIdx ? ln + patternStr : ln)
+  return code.slice(0, start) + patched.join('\n') + code.slice(end)
+}
+
+/**
  * Replace the volume value for the given track.
  * Matches the first `volume: <number>` within the track's region.
  *

--- a/packages/gui/src/renderer/types/score-dsl-types.ts
+++ b/packages/gui/src/renderer/types/score-dsl-types.ts
@@ -62,6 +62,8 @@ declare interface ChainMethods<T> {
   fadeOutBars(bars?: number): T
   chokeGroup(id?: string): T
   seed(n?: number): T
+  model(variant?: string): T
+  open(): T
   dur(steps?: number): T
   visual(id?: string): T
   color(hex?: string): T

--- a/packages/gui/src/renderer/types/score-dsl-types.ts
+++ b/packages/gui/src/renderer/types/score-dsl-types.ts
@@ -1,4 +1,167 @@
-// Auto-generated from score-dsl.d.ts — do not edit directly.
+// Generated from score-dsl.d.ts — run scripts/sync-monaco-types.mjs to regenerate.
+// To add a declaration: edit score-dsl.d.ts, then run the script (or let prebuild do it).
 
 /** Hand-written Score DSL ambient declarations. Loaded into Monaco TypeScript service on editor mount. */
-export const SCORE_DSL_TYPES: string = "// ── @score/dsl — Hand-written type stub for Monaco TypeScript language service ──\n//\n// Purpose: Give Monaco enough type information to flag unknown Score symbols\n// without full IntelliSense (autocomplete, hover docs). That is Phase 13v.\n//\n// This file is loaded via monaco.languages.typescript.typescriptDefaults.addExtraLib\n// on editor mount. It declares the ambient shape of @score/dsl, @score/pattern,\n// and the math/theory helpers injected into the song eval sandbox.\n//\n// HARDWARE BOUNDARY — renderer process: types only, no runtime imports.\n\n// ── Shared descriptor types ────────────────────────────────────────────────────\n\n/** Opaque part descriptor returned by all instrument factories. */\ndeclare interface PartDescriptor {\n  readonly _instrumentType: string\n}\n\n/** Chain methods available on every instrument (partial — IntelliSense phase adds full set). */\ndeclare interface ChainMethods<T> {\n  volume(v: number): T\n  mute(): T\n  reverb(wet?: number, decay?: number): T\n  delay(wet?: number, time?: number, feedback?: number): T\n  filter(cutoff?: number, resonance?: number): T\n  distortion(amount?: number): T\n  chorus(depth?: number, rate?: number): T\n  flanger(depth?: number, rate?: number): T\n  phaser(depth?: number, rate?: number): T\n  compressor(threshold?: number, ratio?: number): T\n  limiter(ceiling?: number): T\n  eq(low?: number, mid?: number, high?: number): T\n  bitcrusher(bits?: number, mix?: number): T\n  stereoWidener(width?: number): T\n  gate(threshold?: number, ratio?: number): T\n  pan(value?: number): T\n  pitch(semitones?: number): T\n  octave(n?: number): T\n  scale(name?: string): T\n  glide(time?: number): T\n  decay(time?: number): T\n  attack(time?: number): T\n  release(time?: number): T\n  tune(semitones?: number): T\n  swing(amount?: number): T\n  humanize(amount?: number): T\n  degrade(probability?: number): T\n  stepProb(probability?: number): T\n  pattern(p: readonly (number | string)[]): T\n  notes(n: readonly string[]): T\n  every(n: number, fn: (p: readonly number[]) => readonly number[]): T\n  stretch(factor?: number): T\n  mask(m: readonly number[]): T\n  fromBar(bar?: number): T\n  untilBar(bar?: number): T\n  fadeInBars(bars?: number): T\n  fadeOutBars(bars?: number): T\n  chokeGroup(id?: string): T\n  seed(n?: number): T\n  dur(steps?: number): T\n  visual(id?: string): T\n  color(hex?: string): T\n  glyph(char?: string): T\n  label(text?: string): T\n}\n\n/** A ChainablePart is a PartDescriptor with chain methods. */\ndeclare type ChainablePart = PartDescriptor & ChainMethods<ChainablePart>\n\n// ── Song structure ─────────────────────────────────────────────────────────────\n\ndeclare interface SongDefinition {\n  readonly bpm:    number\n  readonly tracks: readonly PartDescriptor[]\n}\n\ndeclare function Song(props: { bpm: number; tracks: readonly PartDescriptor[]; seed?: number }): SongDefinition\ndeclare function Track(parts: readonly PartDescriptor[]): ChainablePart\n\n// ── Percussion ─────────────────────────────────────────────────────────────────\n\ndeclare function Kick(shorthand?: number): ChainablePart\ndeclare function Snare(shorthand?: number): ChainablePart\ndeclare function HiHat(shorthand?: number, openDecay?: number): ChainablePart\ndeclare function Kick808(shorthand?: number): ChainablePart\ndeclare function Kick909(shorthand?: number): ChainablePart\ndeclare function Snare909(shorthand?: number): ChainablePart\ndeclare function Hihat808(shorthand?: number, openDecay?: number): ChainablePart\n\n// ── Melodic instruments ────────────────────────────────────────────────────────\n\ndeclare function Synth(props?: { wave?: 'sine' | 'sawtooth' | 'square' | 'triangle'; volume?: number }): ChainablePart\ndeclare function Sample(props?: { src?: string; volume?: number }): ChainablePart\ndeclare function Theremin(props?: { volume?: number }): ChainablePart\ndeclare function Sax(props?: { volume?: number }): ChainablePart\ndeclare function Arp(props?: { notes?: readonly string[]; volume?: number }): ChainablePart\n\ndeclare function Pad(note?: string): ChainablePart\ndeclare function Pluck(note?: string): ChainablePart\ndeclare function Rhodes(note?: string): ChainablePart\ndeclare function Stab(note?: string): ChainablePart\ndeclare function Wurlitzer(note?: string): ChainablePart\ndeclare function Hammond(note?: string): ChainablePart\ndeclare function Clavinet(note?: string): ChainablePart\ndeclare function DX7Lead(note?: string): ChainablePart\ndeclare function WavetableSynth(note?: string): ChainablePart\ndeclare function SuperSaw(note?: string): ChainablePart\ndeclare function KarplusSynth(note?: string): ChainablePart\ndeclare function Guitar(note?: string): ChainablePart\ndeclare function AcousticGuitar(note?: string): ChainablePart\ndeclare function BassGuitar(note?: string): ChainablePart\ndeclare function Trumpet(note?: string): ChainablePart\ndeclare function Trombone(note?: string): ChainablePart\ndeclare function FrenchHorn(note?: string): ChainablePart\ndeclare function Flugelhorn(note?: string): ChainablePart\n\ndeclare function Bass303(note?: string): ChainablePart & {\n  cutoff(freq?: number): ChainablePart\n  resonance(q?: number): ChainablePart\n  accent(amount?: number): ChainablePart\n  slide(time?: number): ChainablePart\n  envDepth(depth?: number): ChainablePart\n}\n\ndeclare function SubSynth(note?: string): ChainablePart & {\n  cutoff(freq?: number): ChainablePart\n  resonance(q?: number): ChainablePart\n  wave(type?: 'sawtooth' | 'square'): ChainablePart\n}\n\ndeclare function FMSynth(note?: string): ChainablePart & {\n  modRatio(ratio?: number): ChainablePart\n  modIndex(index?: number): ChainablePart\n}\n\n// ── Pattern functions (injected into sandbox from @score/pattern) ──────────────\n\ndeclare function euclidean(steps: number, beats: number, offset?: number): readonly number[]\ndeclare function fast(factor: number, pattern: readonly number[]): readonly number[]\ndeclare function slow(factor: number, pattern: readonly number[]): readonly number[]\ndeclare function rev(pattern: readonly number[]): readonly number[]\ndeclare function every(n: number, fn: (p: readonly number[]) => readonly number[]): (p: readonly number[]) => readonly number[]\ndeclare function degrade(probability?: number): (p: readonly number[]) => readonly number[]\ndeclare function shift(offset: number, pattern: readonly number[]): readonly number[]\ndeclare function stack(...patterns: readonly (readonly number[])[]): readonly number[]\ndeclare function beat(n: number): readonly number[]\ndeclare function humanize(amount?: number): (p: readonly number[]) => readonly number[]\n\n// ── Theory functions (injected into sandbox from @score/dsl theory) ───────────\n\ndeclare function chord(root: string, type?: string): readonly string[]\ndeclare function scale(root: string, type?: string): readonly string[]\ndeclare function progression(chords: readonly string[]): readonly (readonly string[])[]\ndeclare const Scale: Record<string, string>\ndeclare const Progression: Record<string, readonly string[]>\n\n// ── Utility (injected into sandbox) ───────────────────────────────────────────\n\ndeclare function resolveFreq(note: string): number\n"
+export const SCORE_DSL_TYPES: string = `
+// ── @score/dsl — Hand-written type stub for Monaco TypeScript language service ──
+//
+// Purpose: Give Monaco enough type information to flag unknown Score symbols
+// without full IntelliSense (autocomplete, hover docs). That is Phase 13v.
+//
+// This file is loaded via monaco.languages.typescript.typescriptDefaults.addExtraLib
+// on editor mount. It declares the ambient shape of @score/dsl, @score/pattern,
+// and the math/theory helpers injected into the song eval sandbox.
+//
+// HARDWARE BOUNDARY — renderer process: types only, no runtime imports.
+
+// ── Shared descriptor types ────────────────────────────────────────────────────
+
+/** Opaque part descriptor returned by all instrument factories. */
+declare interface PartDescriptor {
+  readonly _instrumentType: string
+}
+
+/** Chain methods available on every instrument (partial — IntelliSense phase adds full set). */
+declare interface ChainMethods<T> {
+  volume(v: number): T
+  mute(): T
+  reverb(wet?: number, decay?: number): T
+  delay(wet?: number, time?: number, feedback?: number): T
+  filter(cutoff?: number, resonance?: number): T
+  distortion(amount?: number): T
+  chorus(depth?: number, rate?: number): T
+  flanger(depth?: number, rate?: number): T
+  phaser(depth?: number, rate?: number): T
+  compressor(threshold?: number, ratio?: number): T
+  limiter(ceiling?: number): T
+  eq(low?: number, mid?: number, high?: number): T
+  bitcrusher(bits?: number, mix?: number): T
+  stereoWidener(width?: number): T
+  gate(threshold?: number, ratio?: number): T
+  pan(value?: number): T
+  pitch(semitones?: number): T
+  octave(n?: number): T
+  scale(name?: string): T
+  glide(time?: number): T
+  decay(time?: number): T
+  attack(time?: number): T
+  release(time?: number): T
+  tune(semitones?: number): T
+  swing(amount?: number): T
+  humanize(amount?: number): T
+  degrade(probability?: number): T
+  stepProb(probability?: number): T
+  pattern(p: readonly (number | string)[]): T
+  notes(n: readonly string[]): T
+  every(n: number, fn: (p: readonly number[]) => readonly number[]): T
+  stretch(factor?: number): T
+  mask(m: readonly number[]): T
+  fromBar(bar?: number): T
+  untilBar(bar?: number): T
+  fadeInBars(bars?: number): T
+  fadeOutBars(bars?: number): T
+  chokeGroup(id?: string): T
+  seed(n?: number): T
+  dur(steps?: number): T
+  visual(id?: string): T
+  color(hex?: string): T
+  glyph(char?: string): T
+  label(text?: string): T
+}
+
+/** A ChainablePart is a PartDescriptor with chain methods. */
+declare type ChainablePart = PartDescriptor & ChainMethods<ChainablePart>
+
+// ── Song structure ─────────────────────────────────────────────────────────────
+
+declare interface SongDefinition {
+  readonly bpm:    number
+  readonly tracks: readonly PartDescriptor[]
+}
+
+declare function Song(props: { bpm: number; tracks: readonly PartDescriptor[]; seed?: number }): SongDefinition
+declare function Track(parts: readonly PartDescriptor[]): ChainablePart
+
+// ── Percussion ─────────────────────────────────────────────────────────────────
+
+declare function Kick(shorthand?: number): ChainablePart
+declare function Snare(shorthand?: number): ChainablePart
+declare function HiHat(shorthand?: number): ChainablePart
+declare function Kick808(shorthand?: number): ChainablePart
+declare function Kick909(shorthand?: number): ChainablePart
+declare function Snare909(shorthand?: number): ChainablePart
+declare function Hihat808(shorthand?: number): ChainablePart
+declare function HihatOpen808(shorthand?: number): ChainablePart
+
+// ── Melodic instruments ────────────────────────────────────────────────────────
+
+declare function Synth(props?: { wave?: 'sine' | 'sawtooth' | 'square' | 'triangle'; volume?: number }): ChainablePart
+declare function Sample(props?: { src?: string; volume?: number }): ChainablePart
+declare function Theremin(props?: { volume?: number }): ChainablePart
+declare function Sax(props?: { volume?: number }): ChainablePart
+declare function Arp(props?: { notes?: readonly string[]; volume?: number }): ChainablePart
+
+declare function Pad(note?: string): ChainablePart
+declare function Pluck(note?: string): ChainablePart
+declare function Rhodes(note?: string): ChainablePart
+declare function Stab(note?: string): ChainablePart
+declare function Wurlitzer(note?: string): ChainablePart
+declare function Hammond(note?: string): ChainablePart
+declare function Clavinet(note?: string): ChainablePart
+declare function DX7Lead(note?: string): ChainablePart
+declare function WavetableSynth(note?: string): ChainablePart
+declare function SuperSaw(note?: string): ChainablePart
+declare function KarplusSynth(note?: string): ChainablePart
+declare function Guitar(note?: string): ChainablePart
+declare function AcousticGuitar(note?: string): ChainablePart
+declare function BassGuitar(note?: string): ChainablePart
+declare function Trumpet(note?: string): ChainablePart
+declare function Trombone(note?: string): ChainablePart
+declare function FrenchHorn(note?: string): ChainablePart
+declare function Flugelhorn(note?: string): ChainablePart
+
+declare function Bass303(note?: string): ChainablePart & {
+  cutoff(freq?: number): ChainablePart
+  resonance(q?: number): ChainablePart
+  accent(amount?: number): ChainablePart
+  slide(time?: number): ChainablePart
+  envDepth(depth?: number): ChainablePart
+}
+
+declare function SubSynth(note?: string): ChainablePart & {
+  cutoff(freq?: number): ChainablePart
+  resonance(q?: number): ChainablePart
+  wave(type?: 'sawtooth' | 'square'): ChainablePart
+}
+
+declare function FMSynth(note?: string): ChainablePart & {
+  modRatio(ratio?: number): ChainablePart
+  modIndex(index?: number): ChainablePart
+}
+
+// ── Pattern functions (injected into sandbox from @score/pattern) ──────────────
+
+declare function euclidean(steps: number, beats: number, offset?: number): readonly number[]
+declare function fast(factor: number, pattern: readonly number[]): readonly number[]
+declare function slow(factor: number, pattern: readonly number[]): readonly number[]
+declare function rev(pattern: readonly number[]): readonly number[]
+declare function every(n: number, fn: (p: readonly number[]) => readonly number[]): (p: readonly number[]) => readonly number[]
+declare function degrade(probability?: number): (p: readonly number[]) => readonly number[]
+declare function shift(offset: number, pattern: readonly number[]): readonly number[]
+declare function stack(...patterns: readonly (readonly number[])[]): readonly number[]
+declare function beat(n: number): readonly number[]
+declare function humanize(amount?: number): (p: readonly number[]) => readonly number[]
+
+// ── Theory functions (injected into sandbox from @score/dsl theory) ───────────
+
+declare function chord(root: string, type?: string): readonly string[]
+declare function scale(root: string, type?: string): readonly string[]
+declare function progression(chords: readonly string[]): readonly (readonly string[])[]
+declare const Scale: Record<string, string>
+declare const Progression: Record<string, readonly string[]>
+
+// ── Utility (injected into sandbox) ───────────────────────────────────────────
+
+declare function resolveFreq(note: string): number
+
+`

--- a/packages/gui/src/renderer/types/score-dsl.d.ts
+++ b/packages/gui/src/renderer/types/score-dsl.d.ts
@@ -81,11 +81,12 @@ declare function Track(parts: readonly PartDescriptor[]): ChainablePart
 
 declare function Kick(shorthand?: number): ChainablePart
 declare function Snare(shorthand?: number): ChainablePart
-declare function HiHat(shorthand?: number, openDecay?: number): ChainablePart
+declare function HiHat(shorthand?: number): ChainablePart
 declare function Kick808(shorthand?: number): ChainablePart
 declare function Kick909(shorthand?: number): ChainablePart
 declare function Snare909(shorthand?: number): ChainablePart
-declare function Hihat808(shorthand?: number, openDecay?: number): ChainablePart
+declare function Hihat808(shorthand?: number): ChainablePart
+declare function HihatOpen808(shorthand?: number): ChainablePart
 
 // ── Melodic instruments ────────────────────────────────────────────────────────
 

--- a/packages/gui/src/renderer/types/score-dsl.d.ts
+++ b/packages/gui/src/renderer/types/score-dsl.d.ts
@@ -57,6 +57,8 @@ declare interface ChainMethods<T> {
   fadeOutBars(bars?: number): T
   chokeGroup(id?: string): T
   seed(n?: number): T
+  model(variant?: string): T
+  open(): T
   dur(steps?: number): T
   visual(id?: string): T
   color(hex?: string): T

--- a/packages/instruments/src/index.ts
+++ b/packages/instruments/src/index.ts
@@ -1,17 +1,23 @@
 // @score/instruments — instrument and effect registries
 //
-// INSTRUMENT_REGISTRY maps every instrumentType key to its component factory.
-// EFFECTS_REGISTRY maps every effectType key to its effect factory.
+// INSTRUMENT_REGISTRY maps every instrumentType key to its component factory,
+// dispatch model, volume routing, and (for percussion) default step pattern.
 //
-// The engine uses these registries (post PR2) to replace the 14-case instrument switch
-// and the hydrateEffect switch in engine.ts. For now they serve as the authoritative
-// type source: InstrumentDescriptor.instrumentType is derived from
-// keyof typeof INSTRUMENT_REGISTRY.
+// Adding a new instrument: add ONE entry here.
+// The engine derives PERCUSSION_INSTRUMENT_TYPES, MELODIC_VOICE_INSTRUMENT_TYPES,
+// and MELODIC_INSTRUMENT_TYPE_SET automatically — no separate Sets to maintain.
 //
 // Design rules:
 //   - Object.freeze — registries are immutable after creation
 //   - Zero let, zero classes, factory functions only
-//   - Every future instrument drops into an existing category file with no structural change
+//   - Every future instrument drops into an existing category with no structural change
+//
+// Dispatch model reference:
+//   A         — Percussion   (create-once, trigger per hit)
+//   B         — Generic Synth (persistent component, triggerNote per step)
+//   B-melodic — Melodic Voice (new voice per step: noteOn / noteOff)
+//   C         — Continuous   (boot once, setFrequency per step)
+//   D         — State machine (Arp: cycling note machine)
 //
 // Planned instruments (not yet built) are marked with PLANNED comments.
 // See docs/design/refactor-audit.md for the full file structure.
@@ -20,6 +26,7 @@ import {
   createKick808,
   createKick909,
   createHihat808,
+  createHihatOpen808,
   createSnare909,
   createSubtractiveSynth,
   createFMSynth,
@@ -74,71 +81,99 @@ export { createGenericHihat } from './drums/cymbal.js'
 export { createGenericSynth } from './synths/trigger.js'
 export { createArp }          from './melodic/sequenced.js'
 
+// ── Dispatch model + volume routing tags ──────────────────────────────────────
+
+/** Instrument dispatch model — determines how the engine triggers each type. */
+export type DispatchModel = 'A' | 'B' | 'B-melodic' | 'C' | 'D'
+
+/** Volume routing — determines whether chain `.volume()` maps to `gain` or `volume` in props. */
+export type VolumeRouting = 'percussion' | 'melodic'
+
+// ── Default percussion patterns ────────────────────────────────────────────────
+// Exported for engine use. Grouped here so they stay in sync with registry entries.
+
+export const DEFAULT_KICK_PATTERN  = [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0] as const
+export const DEFAULT_SNARE_PATTERN = [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0] as const
+export const DEFAULT_HIHAT_PATTERN = [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0] as const
+
 // ── INSTRUMENT_REGISTRY ───────────────────────────────────────────────────────
 //
-// Maps instrumentType → component factory. The engine (post PR2) calls:
-//   INSTRUMENT_REGISTRY[comp.instrumentType]?.(ctx, normalizedProps)
+// One entry = one instrument. The engine derives all classification sets from this.
 //
-// Factory signatures vary by instrument dispatch model:
-//   A — Percussion (create-once, trigger-repeatedly): (ctx, props) → PercussionComponent
-//   B — Melodic voice (create per note):              (ctx, props) → voice-like AudioComponent
-//   C — Continuous (boot once, setFrequency per step): (ctx, props) → continuous AudioComponent
-//   D — State machine:                                 (ctx, props) → ArpComponent
-//   E — Special (sample):                              requires decoded buffer, engine-managed
-//
-// 'sample' is omitted from the registry — it requires a pre-decoded BackendBuffer passed
-// at runtime by the engine; it cannot be constructed from props alone.
-// The engine continues to handle 'sample' via its existing createSamplePlayer path.
-//
-// PLANNED entries are commented out — they will be added when the instruments are built.
+// Factory signatures vary by dispatch model — the engine casts at call time.
+// 'sample' is omitted — it requires a pre-decoded buffer, engine-managed separately.
 
 export const INSTRUMENT_REGISTRY = Object.freeze({
-  // ── Drums — Model A ─────────────────────────────────────────────
-  'kick':      createGenericKick,       // generic sine sweep
-  'snare':     createGenericSnare,      // generic noise + sine
-  'hihat':     createGenericHihat,      // generic HPF noise
-  'kick808':   createKick808,           // pure sine pitch envelope
-  'kick909':   createKick909,           // kick808 + noise click
-  'hihat808':  createHihat808,          // 6 detuned sq oscs
-  'snare909':  createSnare909,          // 2 triangle oscs + noise HPF
+
+  // ── Drums — Model A ─────────────────────────────────────────────────────────
+  'kick':         { factory: createGenericKick,      dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_KICK_PATTERN  },
+  'snare':        { factory: createGenericSnare,     dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_SNARE_PATTERN },
+  'hihat':        { factory: createGenericHihat,     dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_HIHAT_PATTERN },
+  'kick808':      { factory: createKick808,           dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_KICK_PATTERN  },
+  'kick909':      { factory: createKick909,           dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_KICK_PATTERN  },
+  'hihat808':     { factory: createHihat808,          dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_HIHAT_PATTERN },
+  'hihatopen808': { factory: createHihatOpen808,      dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_HIHAT_PATTERN },
+  'snare909':     { factory: createSnare909,          dispatchModel: 'A' as DispatchModel, volumeRouting: 'percussion' as VolumeRouting, defaultPattern: DEFAULT_SNARE_PATTERN },
   // PLANNED: 'clap909', 'cowbell808', 'rimshot', 'kickHardstyle', 'kickHardcore'
 
-  // ── Synths — Model B ─────────────────────────────────────────────
-  'synth':     createGenericSynth,      // basic oscillator + ADSR (trigger per note)
-  'subsynth':  createSubtractiveSynth,  // osc → resonant filter → ADSR VCA, unison/detune
-  'pad':       createPad,               // subsynth with slow-attack defaults
-  'fmsynth':   createFMSynth,           // 2-op FM synthesis
-  'rhodes':    createRhodes,            // fmsynth with DX7 defaults
-  'pluck':     createPluck,             // Karplus-Strong, no noteOff
-  'bass-303':  createBass303,           // TB-303: MEG/VEG, cutoff/resonance, glide
+  // ── Synth — Model B ──────────────────────────────────────────────────────────
+  'synth':        { factory: createGenericSynth,     dispatchModel: 'B'         as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+
+  // ── Melodic voices — Model B-melodic ────────────────────────────────────────
+  'subsynth':     { factory: createSubtractiveSynth, dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'pad':          { factory: createPad,              dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'fmsynth':      { factory: createFMSynth,          dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'rhodes':       { factory: createRhodes,           dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'pluck':        { factory: createPluck,            dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'bass-303':     { factory: createBass303,          dispatchModel: 'B-melodic' as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
   // PLANNED: 'supersaw', 'reese', 'wobbleBass', 'granular', 'wavetable', 'organ'
 
-  // ── Melodic — Model C + D ─────────────────────────────────────────
-  'theremin':  Theremin,                // Model C — continuous, no steps
-  'sax':       Sax,                     // Model C — persistent voice + per-step trigger
-  'arp':       createArp,               // Model D — arpState cycling note machine
+  // ── Continuous + state machine — Model C, D ─────────────────────────────────
+  'theremin':     { factory: Theremin,               dispatchModel: 'C'         as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'sax':          { factory: Sax,                    dispatchModel: 'C'         as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
+  'arp':          { factory: createArp,              dispatchModel: 'D'         as DispatchModel, volumeRouting: 'melodic' as VolumeRouting },
   // PLANNED: 'flute', 'strings', 'choir'
-} as const)
+
+})
+
+// ── Derived classification sets ───────────────────────────────────────────────
+//
+// Engine imports these instead of maintaining manual Sets.
+// Adding a new instrument to INSTRUMENT_REGISTRY updates these automatically.
+
+/** All registered instrument type keys. */
+export type InstrumentType = keyof typeof INSTRUMENT_REGISTRY
+
+/** Model A percussion types — create-once, trigger per hit. */
+export const PERCUSSION_INSTRUMENT_TYPES: ReadonlySet<InstrumentType> = new Set(
+  (Object.entries(INSTRUMENT_REGISTRY) as [InstrumentType, { dispatchModel: DispatchModel }][])
+    .filter(([, e]) => e.dispatchModel === 'A')
+    .map(([k]) => k),
+)
+
+/** Model B-melodic types — new voice per step (noteOn / noteOff). */
+export const MELODIC_VOICE_INSTRUMENT_TYPES: ReadonlySet<InstrumentType> = new Set(
+  (Object.entries(INSTRUMENT_REGISTRY) as [InstrumentType, { dispatchModel: DispatchModel }][])
+    .filter(([, e]) => e.dispatchModel === 'B-melodic')
+    .map(([k]) => k),
+)
 
 /**
- * The set of all registered instrument type keys.
- * `InstrumentDescriptor.instrumentType` is derived from this type.
- *
- * @example
- * ```ts
- * const isKnownInstrument = (t: string): t is InstrumentType =>
- *   t in INSTRUMENT_REGISTRY
- * ```
+ * All melodic instrument type keys + 'sample'.
+ * Used to route `_volume` to `gain` (melodic) rather than `volume` (percussion).
+ * 'sample' is not in the registry (pre-decoded buffer path) but is melodic for volume routing.
  */
-export type InstrumentType = keyof typeof INSTRUMENT_REGISTRY
+export const MELODIC_INSTRUMENT_TYPE_SET: ReadonlySet<string> = new Set([
+  ...(Object.entries(INSTRUMENT_REGISTRY) as [string, { volumeRouting: VolumeRouting }][])
+    .filter(([, e]) => e.volumeRouting === 'melodic')
+    .map(([k]) => k),
+  'sample',
+])
 
 // ── EFFECTS_REGISTRY ──────────────────────────────────────────────────────────
 //
 // Maps effectType → effect factory from @score/effects.
-// The engine (post PR2) calls:
-//   EFFECTS_REGISTRY[desc.effectType]?.(ctx, desc.props)
-//
-// Replaces the hydrateEffect switch in engine.ts.
+// The engine calls: EFFECTS_REGISTRY[desc.effectType]?.(ctx, desc.props)
 
 export const EFFECTS_REGISTRY = Object.freeze({
   'delay':          createDelay,

--- a/packages/instruments/tests/registry.test.ts
+++ b/packages/instruments/tests/registry.test.ts
@@ -198,7 +198,7 @@ const mockCtx = {
 const EXPECTED_INSTRUMENT_TYPES: ReadonlyArray<InstrumentType> = [
   // Drums
   'kick', 'snare', 'hihat',
-  'kick808', 'kick909', 'hihat808', 'snare909',
+  'kick808', 'kick909', 'hihat808', 'hihatopen808', 'snare909',
   // Synths
   'synth', 'subsynth', 'pad', 'fmsynth', 'rhodes', 'pluck', 'bass-303',
   // Melodic
@@ -220,7 +220,7 @@ describe('INSTRUMENT_REGISTRY', () => {
   it.each(EXPECTED_INSTRUMENT_TYPES)(
     '%s factory is a function',
     (instrumentType) => {
-      expect(typeof INSTRUMENT_REGISTRY[instrumentType]).toBe('function')
+      expect(typeof INSTRUMENT_REGISTRY[instrumentType].factory).toBe('function')
     },
   )
 
@@ -229,10 +229,11 @@ describe('INSTRUMENT_REGISTRY', () => {
     ['snare',    {},                    ],
     ['hihat',    {},                    ],
     ['synth',    {},                    ],
-    ['kick808',  {},                    ],
-    ['kick909',  {},                    ],
-    ['hihat808', {},                    ],
-    ['snare909', {},                    ],
+    ['kick808',      {},                    ],
+    ['kick909',      {},                    ],
+    ['hihat808',     {},                    ],
+    ['hihatopen808', {},                    ],
+    ['snare909',     {},                    ],
     ['subsynth', {},                    ],
     ['fmsynth',  {},                    ],
     ['pad',      {},                    ],
@@ -245,10 +246,9 @@ describe('INSTRUMENT_REGISTRY', () => {
   ] as const)(
     '%s factory produces a valid AudioComponent (id, type, connect, disconnect, dispose)',
     (instrumentType, props) => {
-      const factory = INSTRUMENT_REGISTRY[instrumentType]
+      const { factory } = INSTRUMENT_REGISTRY[instrumentType]
       // Cast through unknown — mockCtx satisfies the methods used by each factory but
       // does not implement every BackendContext method (compressor, delay, etc.).
-       
       const component = (factory as unknown as (ctx: unknown, props: unknown) => unknown)(mockCtx, props)
 
       expect(component).toBeDefined()


### PR DESCRIPTION
## Summary

- **HihatOpen808**: adds the 808 open hi-hat as a first-class instrument type (`instrumentType: 'hihatopen808'`), wired through `@score/components` → registry → engine → DSL. Unlike `Hihat808().model('open')` (which would dispatch to the wrong factory), this creates its own registry entry with the correct 0.3s decay.
- **Registry scalability**: `INSTRUMENT_REGISTRY` entries now carry `dispatchModel`, `volumeRouting`, and `defaultPattern`. The engine derives its classification sets (`PERCUSSION_INSTRUMENT_TYPES`, `MELODIC_VOICE_INSTRUMENT_TYPES`, `MELODIC_INSTRUMENT_TYPE_SET`) automatically — no more parallel hardcoded Sets or `PERCUSSION_DEFAULT_PATTERNS` map to maintain. Adding a new instrument = one registry entry.
- **Effect chain methods**: `distortion`, `phaser`, `compressor`, `limiter`, `gate` were declared in Monaco types but never implemented. Added via a `SIMPLE_FX` data table in `chain.ts` — one line per effect.
- **Monaco codegen**: `score-dsl-types.ts` is now generated from `score-dsl.d.ts` via `scripts/sync-monaco-types.mjs`, hooked into `prebuild`. Single source of truth for Monaco declarations.

## Test plan

- [ ] `pnpm turbo typecheck` — 32/32 passing
- [ ] `HihatOpen808()` available in song editor (Monaco) without type error
- [ ] `HihatOpen808().pattern([...])` plays with open hat decay (~0.3s), not closed (~0.06s)
- [ ] `Kick().distortion(0.5)` no longer throws `TypeError: kick.distortion is not a function`
- [ ] `pnpm --filter=@score/gui sync-monaco-types` regenerates `score-dsl-types.ts` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)