### PR TITLE
chore: remove AI training prohibition clause from Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,17 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ────────────────────────────────────────────────────────────────────────────
-AI TRAINING PROHIBITION
-────────────────────────────────────────────────────────────────────────────
-
-Notwithstanding the permissions granted by the Apache License above, use of
-this Software, its source code, documentation, or any portion thereof as
-training data, fine-tuning data, evaluation data, or any other input to
-machine learning models, large language models, AI systems, or automated code
-generation tools is explicitly prohibited without prior written permission
-from the copyright holder.
-
-────────────────────────────────────────────────────────────────────────────
 THESIS AND RESEARCH ATTRIBUTION
 ────────────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. To
 
 ## License
 
-Apache License 2.0. Use freely — personal, commercial, open source. AI training use prohibited. See [LICENSE](./LICENSE). Author: Bree Yard.
+Apache License 2.0. Use freely — personal, commercial, open source. See [LICENSE](./LICENSE). Author: Bree Yard.


### PR DESCRIPTION
## Summary

- Removes the non-standard AI training prohibition clause from LICENSE
- Updates README to drop the matching "AI training use prohibited" line
- Leaves the standard Apache 2.0 text and thesis attribution block intact

## Why

The AI training clause is a field-of-endeavor restriction, which violates the OSI open source definition. With it present, GitHub shows the license as "Other" instead of "Apache-2.0". Removing it makes the license OSI-compliant and properly detected.

## Test plan
- [ ] Verify GitHub shows "Apache-2.0" label on the repo after merge
- [ ] LICENSE contains only Apache 2.0 + thesis attribution block

🤖 Generated with [Claude Code](https://claude.com/claude-code)