### PR TITLE
feat(resilience): engine crash resilience + engine:error IPC overlay (t184, t133)

### DIFF
--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -88,7 +88,17 @@ const buildEffectsChain = (
   descriptors: ReadonlyArray<EffectDescriptor> | undefined,
 ): AudioComponent[] => {
   if (!descriptors || descriptors.length === 0) return []
-  return descriptors.map(d => hydrateEffect(ctx, d))
+  return descriptors.flatMap(d => {
+    try {
+      return [hydrateEffect(ctx, d)]
+    } catch (err) {
+      // Effect hydration failure — log and skip. One bad effect must not crash
+      // the whole song boot. The channel will have a gap in its effects chain
+      // but audio continues uninterrupted.
+      console.error(`[score-engine] effect '${d.effectType}' failed to hydrate — skipped`, err)
+      return []
+    }
+  })
 }
 
 // ── Type guard ────────────────────────────────────────────────────────────────

--- a/packages/cli/tests/engine-resilience.test.ts
+++ b/packages/cli/tests/engine-resilience.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { createScoreEngine } from '../src/engine.js'
+import { webAudioBackend } from '@score/core'
+import { Song, Track, Synth, Kick } from '@score/dsl'
+import { Reverb } from '@score/effects'
+
+// Verify engine crash resilience (t184):
+// - A bad effect that throws during buildEffectsChain is skipped, not propagated.
+// - A Song boot failure keeps the previous engine alive (boot() try-first pattern).
+
+// Redirect createContext to offline mode so node-web-audio-api does not try
+// to open ALSA/JACK device drivers (unavailable on GitHub Actions runners).
+const _realCreateContext = webAudioBackend.createContext.bind(webAudioBackend)
+beforeAll(() => {
+  vi.spyOn(webAudioBackend, 'createContext').mockImplementation(
+    () => _realCreateContext({ offline: { length: 44100 } }),
+  )
+})
+afterAll(() => { vi.restoreAllMocks() })
+
+describe('engine — crash resilience', () => {
+  it('bad effect factory: engine boots when createReverb throws — effect skipped, no crash', async () => {
+    // Simulate an effect factory that throws (e.g. missing AudioContext API).
+    // The engine should skip the bad effect and boot successfully.
+    const effectsMod = await import('@score/effects')
+    const spy = vi.spyOn(effectsMod, 'createReverb').mockImplementationOnce(() => {
+      throw new Error('simulated reverb factory failure')
+    })
+
+    const song = Song({
+      bpm: 120,
+      tracks: [
+        Track(Synth({
+          wave: 'sawtooth',
+          frequency: 130.81,
+          pattern: [1, 0, 1, 0],
+          gain: 0.5,
+          effects: [Reverb({ decay: 1.5, mix: 0.2 })],
+        })),
+      ],
+    })
+
+    // Engine must resolve (not reject) even though reverb creation throws.
+    await expect(createScoreEngine(song)).resolves.toBeDefined()
+    spy.mockRestore()
+  })
+
+  it('engine boots from a clean song after a previous bad-effect boot', async () => {
+    // Verify the engine remains bootable after a resilience-skip event.
+    const song = Song({
+      bpm: 128,
+      tracks: [Track(Kick())],
+    })
+    await expect(createScoreEngine(song)).resolves.toBeDefined()
+  })
+})

--- a/packages/core/src/errors/ScoreError.ts
+++ b/packages/core/src/errors/ScoreError.ts
@@ -18,3 +18,15 @@ export const ScoreError = (
   error.context = context
   return error
 }
+
+/**
+ * Lightweight ScoreError factory for internal engine errors that do not have
+ * a user-facing context (received / fix / docs). Use when an error is not caused
+ * by song author input — e.g. effect hydration failure, unexpected engine throw.
+ *
+ * @param message - Human-readable error description.
+ * @param cause   - Optional underlying error that caused this one.
+ * @returns An `Error` with `name: 'ScoreError'` and optional `cause`.
+ */
+export const createScoreError = (message: string, cause?: unknown): Error =>
+  Object.assign(new Error(message), { name: 'ScoreError', cause })

--- a/packages/gui/src/main/index.ts
+++ b/packages/gui/src/main/index.ts
@@ -3,7 +3,7 @@ import path                                          from 'node:path'
 import { readFileSync, writeFileSync }               from 'node:fs'
 import vm                                            from 'node:vm'
 import { createScoreEngine, isPartDescriptor, partToInstrumentDescriptor } from '@score/cli/engine'
-import type { PatchProps }                           from '@score/cli/engine'
+import type { PatchProps, ScoreEngine }              from '@score/cli/engine'
 import {
   Kick, Snare, HiHat, Synth, Sample, Theremin, Sax, Arp,
   Kick808, Kick909, Snare909, Hihat808, SubSynth, FMSynth,
@@ -13,7 +13,6 @@ import {
   Track, Song, resolveFreq,
 }                                                    from '@score/dsl'
 import type { SongDefinition, InstrumentDescriptor } from '@score/dsl'
-import type { ScoreEngine }                          from '@score/cli/engine'
 import {
   Delay, Reverb, Filter, Compressor, EQ, Distortion, Limiter,
   BitCrusher, Chorus, Phaser, Flanger, StereoWidener, Gate,
@@ -212,8 +211,19 @@ const panicStop = (): void => {
 }
 
 const boot = async (song: SongDefinition, barOffset = 0): Promise<void> => {
+  // t184 — Try to boot the new engine BEFORE tearing down the current one.
+  // If createScoreEngine throws, the previous engine keeps running uninterrupted.
+  let engine: ScoreEngine
+  try {
+    engine = await createScoreEngine(song)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    const stack   = err instanceof Error ? err.stack : undefined
+    console.error('[score-studio] engine boot failed — keeping previous engine running', err)
+    send('engine:error', { message, ...(stack !== undefined ? { stack } : {}) })
+    return
+  }
   teardown()
-  const engine = await createScoreEngine(song)
   slotRef.value = { engine, playing: false, bpm: song.bpm, bars: barOffset }
   // Per-step IPC — fires every sequencer step carrying the full temporal coordinate.
   // bar and beat are derived from the engine state; time (audioContext.currentTime)
@@ -320,13 +330,14 @@ const writeLayout = (layout: PanelLayoutMap): void => {
 
 process.on('uncaughtException', (err: Error) => {
   console.error('[score-studio] uncaughtException', err)
-  send('error:report', { message: `Uncaught: ${err.message}` })
+  send('engine:error', { message: `Uncaught: ${err.message}`, ...(err.stack !== undefined ? { stack: err.stack } : {}) })
 })
 
 process.on('unhandledRejection', (reason: unknown) => {
   const message = reason instanceof Error ? reason.message : String(reason)
+  const stack   = reason instanceof Error ? reason.stack : undefined
   console.error('[score-studio] unhandledRejection', reason)
-  send('error:report', { message: `Unhandled rejection: ${message}` })
+  send('engine:error', { message: `Unhandled: ${message}`, ...(stack !== undefined ? { stack } : {}) })
 })
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────────

--- a/packages/gui/src/main/ipc-types.ts
+++ b/packages/gui/src/main/ipc-types.ts
@@ -88,4 +88,11 @@ export type MainToRenderer = {
    * Renderer shows a brief transient flash to confirm the stop landed.
    */
   'engine:panic':    undefined
+  /**
+   * Fires when the engine throws unexpectedly — effect hydration failure,
+   * uncaught main-process exception, or a new Song boot that failed while a
+   * previous engine was running. The previous engine is kept alive on boot
+   * failure so playback is not interrupted.
+   */
+  'engine:error':    { message: string; stack?: string }
 }

--- a/packages/gui/src/renderer/components/LiveCode/index.tsx
+++ b/packages/gui/src/renderer/components/LiveCode/index.tsx
@@ -133,6 +133,8 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
   const [fftBins,     setFftBins]     = useState<readonly number[]>([])
   const [logEntries,  setLogEntries]  = useState<ReadonlyArray<LogEntry>>([])
   const [pianoNotes,  setPianoNotes]  = useState<ReadonlyArray<PianoRollNote>>([])
+  // t184/t133 — engine:error history (last 5 unexpected errors, separate from song eval errors)
+  const [engineErrors, setEngineErrors] = useState<readonly string[]>([])
   // t220 — import visibility toggle (stub: fold/unfold in Monaco; auto-inject deferred for DSL chain API)
   const [importsVisible, setImportsVisible] = useState(false)
   // Instrument panel — which track is currently selected (null = none)
@@ -243,6 +245,16 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
       setEvalStatus('error')
       addLog('error', message)
       if (fix) addLog('info', `💡 ${fix}`)
+    })
+    return unsub
+  }, [addLog])
+
+  useEffect(() => {
+    const unsub = window.scoreBridge.on('engine:error', ({ message }) => {
+      // Keep last 5 unexpected engine errors — distinct from song eval errors.
+      // Previous engine stays running; this overlay is purely informational.
+      setEngineErrors(prev => [...prev.slice(-4), message])
+      addLog('error', `[engine] ${message}`)
     })
     return unsub
   }, [addLog])
@@ -630,6 +642,24 @@ export const LiveCode = ({ hardware, onHome }: Props) => {
             </div>
           )}
 
+          {engineErrors.length > 0 && (
+            <div style={styles.engineErrorOverlay} role="alert" aria-live="assertive">
+              <div style={styles.engineErrorHeader}>
+                <span>Engine error</span>
+                <button
+                  style={styles.engineErrorDismiss}
+                  onClick={() => { setEngineErrors([]) }}
+                  aria-label="Dismiss engine errors"
+                >
+                  ✕
+                </button>
+              </div>
+              {engineErrors.map((msg, i) => (
+                <div key={i} style={styles.engineErrorEntry}>{msg}</div>
+              ))}
+            </div>
+          )}
+
           {/* Monaco editor + waveform overlay stacked */}
           {/* z-index 0: CodeWaveform (canvas behind)  1: Monaco editor */}
           <div style={styles.editorArea}>
@@ -948,6 +978,7 @@ const styles = {
     flexDirection: 'column' as const,
     background:    '#0d0d10',
     overflow:      'hidden',
+    position:      'relative' as const,
   },
   splitter: {
     width:          '6px',
@@ -965,6 +996,43 @@ const styles = {
     borderBottom: '1px solid #5a2a2a',
     flexShrink:   0,
     fontFamily:   "'JetBrains Mono', 'Fira Code', monospace",
+  },
+  engineErrorOverlay: {
+    position:     'absolute' as const,
+    top:          '0.5rem',
+    right:        '0.5rem',
+    zIndex:       100,
+    background:   '#2a1a0a',
+    border:       '1px solid #7a3a1a',
+    borderRadius: '4px',
+    padding:      '0.5rem 0.75rem',
+    maxWidth:     '380px',
+    fontFamily:   "'JetBrains Mono', 'Fira Code', monospace",
+    fontSize:     '0.7rem',
+    color:        '#ffaa55',
+    boxShadow:    '0 2px 8px rgba(0,0,0,0.6)',
+  },
+  engineErrorHeader: {
+    display:        'flex',
+    justifyContent: 'space-between',
+    alignItems:     'center',
+    marginBottom:   '0.3rem',
+    fontWeight:     700 as const,
+    color:          '#ffcc88',
+  },
+  engineErrorDismiss: {
+    background:  'none',
+    border:      'none',
+    color:       '#ffaa55',
+    cursor:      'pointer',
+    fontSize:    '0.8rem',
+    padding:     '0 0.2rem',
+    lineHeight:  1,
+  },
+  engineErrorEntry: {
+    marginTop:  '0.2rem',
+    lineHeight: 1.4,
+    wordBreak:  'break-word' as const,
   },
   // Container for waveform + textarea stacked absolutely
   editorArea: {

--- a/packages/gui/tests/LiveCode.test.tsx
+++ b/packages/gui/tests/LiveCode.test.tsx
@@ -201,3 +201,36 @@ describe('LiveCode — resizable editor/canvas split (t152)', () => {
     fireEvent.mouseUp(window)
   })
 })
+
+// ── t184/t133: engine:error overlay ───────────────────────────────────────────
+
+describe('LiveCode — engine:error overlay (t184/t133)', () => {
+  it('shows overlay when engine:error fires', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    act(() => { emitBridgeEvent('engine:error', { message: 'effect hydration failed' }) })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    // Use exact string — addLog also renders "[engine] effect hydration failed" so regex would match twice
+    expect(screen.getByText('effect hydration failed')).toBeInTheDocument()
+  })
+
+  it('dismiss button removes the overlay', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    act(() => { emitBridgeEvent('engine:error', { message: 'engine crashed' }) })
+    const dismiss = screen.getByLabelText('Dismiss engine errors')
+    act(() => { fireEvent.click(dismiss) })
+    // addLog keeps "[engine] engine crashed" in the console panel — query for the exact overlay text only
+    expect(screen.queryByText('engine crashed')).not.toBeInTheDocument()
+  })
+
+  it('keeps last 5 errors — older entries are dropped on overflow', () => {
+    render(<LiveCode hardware="pc-only" onHome={vi.fn()} />)
+    act(() => {
+      for (let i = 1; i <= 6; i++) {
+        emitBridgeEvent('engine:error', { message: `error ${String(i)}` })
+      }
+    })
+    // addLog keeps "[engine] error 1" in console — query for exact overlay entry text only
+    expect(screen.queryByText('error 1')).not.toBeInTheDocument()
+    expect(screen.getByText('error 6')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Engine crash resilience: catches and surfaces engine errors via IPC overlay
- Adds `engine:error` IPC channel with error overlay in LiveCode renderer component
- Tests for engine resilience in CLI and GUI

## Test plan

- [ ] Engine error overlay renders on crash
- [ ] `engine:error` IPC fires correctly from main process
- [ ] `engine-resilience.test.ts` passes
- [ ] `LiveCode.test.tsx` passes
- [ ] No regressions in existing GUI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)