### PR TITLE
fix(gui): explicit jest-dom type augmentation for Electron v39 compatibility

### DIFF
--- a/packages/gui/tests/vitest-jest-dom.d.ts
+++ b/packages/gui/tests/vitest-jest-dom.d.ts
@@ -1,0 +1,25 @@
+// ── @testing-library/jest-dom type augmentation ────────────────────────────────
+//
+// Explicitly augments Vitest's Assertion interface with jest-dom matchers
+// (toBeInTheDocument, toHaveTextContent, toHaveStyle, toHaveAttribute, etc.).
+//
+// Why this file exists:
+//   The import in setup.ts ('import @testing-library/jest-dom/vitest') provides
+//   the runtime matchers but its module augmentation can be silently dropped
+//   by tsc when Electron v39+ types are present — the Electron type surface is
+//   large enough to cause ambiguity in Vitest's Assertion interface resolution.
+//
+//   This file lives directly in tests/ which is in tsconfig.json "include", so
+//   tsc always processes it unconditionally, regardless of Electron version.
+//
+// @see packages/gui/tests/setup.ts — runtime registration of the matchers
+// @see https://github.com/testing-library/jest-dom#with-vitest
+
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers'
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
+  interface Assertion<T = any> extends TestingLibraryMatchers<T, void> {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends TestingLibraryMatchers<any, void> {}
+}


### PR DESCRIPTION
## Summary

- Adds `tests/vitest-jest-dom.d.ts` — explicit Vitest `Assertion` interface augmentation with `@testing-library/jest-dom` matchers
- Fixes CI typecheck failure introduced when Electron v39.8.5 types are present

## Root cause

Electron v39.8.5 type surface causes tsc to silently drop the `@vitest/expect.Assertion` augmentation from `@testing-library/jest-dom/vitest` (which is imported via `setup.ts`). The result is TS2339 errors on `toBeInTheDocument`, `toHaveTextContent`, `toHaveStyle`, etc. across all GUI test files.

The issue is specific to Electron v39.8.5 — v39.8.4 and v35.x are unaffected.

## Fix

Add `tests/vitest-jest-dom.d.ts` in the `tests/` directory (which is in `tsconfig.json` `include`). tsc processes files in `include` unconditionally, so this augmentation is always applied regardless of Electron version.

The `setup.ts` import (`import '@testing-library/jest-dom/vitest'`) is retained for runtime matcher registration.

## Test plan

- [x] `pnpm -F @score/gui typecheck` — passes locally
- [x] Pre-commit hook (`pnpm typecheck`) — passes
- [ ] CI on this PR — should pass typecheck with Electron v39.8.5

This unblocks merging Dependabot PR #142 (electron 35.7.5 → 39.8.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)